### PR TITLE
feat: add S3/Tigris artifact storage backend

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - REDIS_URL=redis://redis:6379
       - API_SECRET=${RUNTM_API_SECRET:?Set RUNTM_API_SECRET environment variable}
       - ARTIFACT_STORAGE_PATH=/artifacts
+      - ARTIFACT_STORAGE_BACKEND=local
       - AUTH_MODE=single_tenant
       - DEBUG=true
       # FLY_API_TOKEN and FLY_ORG are loaded from .env via env_file above
@@ -46,6 +47,7 @@ services:
       - API_SECRET=${RUNTM_API_SECRET:?Set RUNTM_API_SECRET environment variable}
       - FLY_ORG=${FLY_ORG:-personal}
       - ARTIFACT_STORAGE_PATH=/artifacts
+      - ARTIFACT_STORAGE_BACKEND=local
       - USE_REMOTE_BUILDER=true
       - DEBUG=true
       # ALLOW_LOCAL_BUILDS is intentionally NOT set - forbidden in production

--- a/infra/local.env.example
+++ b/infra/local.env.example
@@ -24,6 +24,14 @@ FLY_ORG=personal
 
 # Storage
 ARTIFACT_STORAGE_PATH=/artifacts
+# Storage backend: "local" (dev, shared Docker volume) or "s3" (production, Tigris)
+ARTIFACT_STORAGE_BACKEND=local
+# S3/Tigris settings (only needed when ARTIFACT_STORAGE_BACKEND=s3)
+# Fly.io auto-injects these when you run `fly storage create`:
+# BUCKET_NAME=runtm-artifacts
+# AWS_ENDPOINT_URL_S3=https://fly.storage.tigris.dev
+# AWS_ACCESS_KEY_ID=tid_...
+# AWS_SECRET_ACCESS_KEY=tsec_...
 
 # Auth mode (single_tenant or multi_tenant)
 AUTH_MODE=single_tenant

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -74,5 +74,8 @@ pytest
 | `REDIS_URL` | Redis connection string | Required |
 | `RUNTM_API_SECRET` | API authentication secret (what server validates against) | Required |
 | `ARTIFACT_STORAGE_PATH` | Local artifact storage path | `/artifacts` |
+| `ARTIFACT_STORAGE_BACKEND` | Storage backend: `local` or `s3` | `local` |
+| `BUCKET_NAME` | S3/Tigris bucket name (when backend=s3) | - |
+| `AWS_ENDPOINT_URL_S3` | S3 endpoint URL (e.g. `https://fly.storage.tigris.dev`) | - |
 | `AUTH_MODE` | Auth mode: `single_tenant` or `multi_tenant` | `single_tenant` |
 

--- a/packages/api/runtm_api/core/config.py
+++ b/packages/api/runtm_api/core/config.py
@@ -68,6 +68,13 @@ class Settings(BaseSettings):
 
     # Storage
     artifact_storage_path: str = "/artifacts"
+    artifact_storage_backend: str = "local"  # "local" (dev) or "s3" (production/Tigris)
+
+    # S3 / Tigris configuration (only used when artifact_storage_backend = "s3")
+    # Fly.io auto-injects these when you run `fly storage create`
+    s3_bucket: str = Field(default="", validation_alias="BUCKET_NAME")
+    s3_endpoint_url: str = Field(default="", validation_alias="AWS_ENDPOINT_URL_S3")
+    s3_region: str = "auto"
 
     # Server
     host: str = "0.0.0.0"

--- a/packages/api/runtm_api/routes/deployments.py
+++ b/packages/api/runtm_api/routes/deployments.py
@@ -784,13 +784,22 @@ async def create_deployment(
         # Use deployment_id generated earlier (before reservation)
         artifact_key = generate_artifact_key(deployment_id)
 
-        # Store artifact
-        import os
+        # Store artifact via configured backend (local disk or S3/Tigris)
+        # Runs in a thread to avoid blocking the async event loop during
+        # network I/O (boto3 is synchronous; local file writes are fast
+        # but S3 uploads can take seconds).
+        import asyncio
 
-        artifact_path = os.path.join(settings.artifact_storage_path, artifact_key)
-        os.makedirs(os.path.dirname(artifact_path), exist_ok=True)
-        with open(artifact_path, "wb") as f:
-            f.write(artifact_content)
+        from runtm_worker.storage import get_artifact_store
+
+        store = get_artifact_store(
+            backend=settings.artifact_storage_backend,
+            storage_path=settings.artifact_storage_path,
+            s3_bucket=settings.s3_bucket,
+            s3_endpoint_url=settings.s3_endpoint_url or None,
+            s3_region=settings.s3_region,
+        )
+        await asyncio.to_thread(store.put, artifact_key, artifact_content)
 
         # Create deployment record with tenant isolation
         deployment = Deployment(

--- a/packages/shared/runtm_shared/storage/base.py
+++ b/packages/shared/runtm_shared/storage/base.py
@@ -9,11 +9,11 @@ class ArtifactStore(ABC):
     """Abstract interface for artifact storage.
 
     Implementations:
-        - LocalFileStore: Local filesystem (dev)
-        - S3Store: AWS S3 / GCS (future)
+        - LocalFileStore: Local filesystem (dev, shared Docker volume)
+        - S3FileStore: S3-compatible storage (production, Tigris/AWS S3/R2)
 
     Usage:
-        store = LocalFileStore("/artifacts")
+        store = get_artifact_store(backend="local", storage_path="/artifacts")
         uri = store.put("artifacts/dep_abc123/artifact.zip", data)
         data = store.get("artifacts/dep_abc123/artifact.zip")
     """

--- a/packages/worker/README.md
+++ b/packages/worker/README.md
@@ -49,6 +49,9 @@ pytest
 | `REDIS_URL` | Redis connection string | Required |
 | `FLY_API_TOKEN` | Fly.io API token | Required |
 | `ARTIFACT_STORAGE_PATH` | Local artifact storage path | `/artifacts` |
+| `ARTIFACT_STORAGE_BACKEND` | Storage backend: `local` or `s3` | `local` |
+| `BUCKET_NAME` | S3/Tigris bucket name (when backend=s3) | - |
+| `AWS_ENDPOINT_URL_S3` | S3 endpoint URL (e.g. `https://fly.storage.tigris.dev`) | - |
 | `USE_REMOTE_BUILDER` | Use Fly's remote builder (faster) | `true` |
 
 ## Providers

--- a/packages/worker/pyproject.toml
+++ b/packages/worker/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "rq>=1.15,<2.0",
     "httpx>=0.24,<1.0",
     "docker>=6.0,<8.0",
+    "boto3>=1.28,<2.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/worker/runtm_worker/jobs/deploy.py
+++ b/packages/worker/runtm_worker/jobs/deploy.py
@@ -28,7 +28,7 @@ from runtm_shared.urls import construct_deployment_url, get_subdomain_for_app
 from runtm_worker.builder import DockerBuilder
 from runtm_worker.logs import LogCapture
 from runtm_worker.providers import FlyProvider
-from runtm_worker.storage import LocalFileStore
+from runtm_shared.storage.base import ArtifactStore
 
 
 class DeployJob:
@@ -70,7 +70,7 @@ class DeployJob:
     def __init__(
         self,
         db: Session,
-        storage_path: str,
+        storage: ArtifactStore,
         fly_api_token: str | None = None,
         redeploy_from: str | None = None,
         use_remote_builder: bool = True,
@@ -82,7 +82,7 @@ class DeployJob:
 
         Args:
             db: Database session
-            storage_path: Path to artifact storage
+            storage: Artifact store (LocalFileStore for dev, S3FileStore for prod)
             fly_api_token: Fly.io API token
             redeploy_from: Previous deployment ID for redeployments
             use_remote_builder: Use Fly's remote builder (faster, recommended)
@@ -91,7 +91,7 @@ class DeployJob:
             allow_local_builds: Explicit override for local builds (dev only)
         """
         self.db = db
-        self.storage = LocalFileStore(storage_path)
+        self.storage = storage
         self.fly_api_token = fly_api_token or os.environ.get("FLY_API_TOKEN")
         self.redeploy_from = redeploy_from
         self.use_remote_builder = use_remote_builder
@@ -835,6 +835,7 @@ def process_deployment(
     """
     from runtm_api.core.config import get_settings
     from runtm_api.db import create_session
+    from runtm_worker.storage import get_artifact_store
 
     settings = get_settings()
     db = create_session()
@@ -843,10 +844,18 @@ def process_deployment(
     if use_remote_builder is None:
         use_remote_builder = settings.use_remote_builder
 
+    storage = get_artifact_store(
+        backend=settings.artifact_storage_backend,
+        storage_path=settings.artifact_storage_path,
+        s3_bucket=settings.s3_bucket,
+        s3_endpoint_url=settings.s3_endpoint_url or None,
+        s3_region=settings.s3_region,
+    )
+
     try:
         job = DeployJob(
             db=db,
-            storage_path=settings.artifact_storage_path,
+            storage=storage,
             redeploy_from=redeploy_from,
             use_remote_builder=use_remote_builder,
             secrets=secrets,

--- a/packages/worker/runtm_worker/storage/__init__.py
+++ b/packages/worker/runtm_worker/storage/__init__.py
@@ -1,5 +1,53 @@
 """Storage implementations."""
 
+from __future__ import annotations
+
+from runtm_shared.storage.base import ArtifactStore
 from runtm_worker.storage.local import LocalFileStore
 
-__all__ = ["LocalFileStore"]
+
+def get_artifact_store(
+    backend: str = "local",
+    storage_path: str = "/artifacts",
+    s3_bucket: str = "",
+    s3_endpoint_url: str | None = None,
+    s3_region: str = "auto",
+) -> ArtifactStore:
+    """Factory that returns the right ArtifactStore for the environment.
+
+    Args:
+        backend: "local" (dev, shared Docker volume) or "s3" (production, Tigris)
+        storage_path: Filesystem path for local backend
+        s3_bucket: Bucket name for S3 backend
+        s3_endpoint_url: Endpoint URL (e.g. https://fly.storage.tigris.dev)
+        s3_region: AWS region (default "auto" for Tigris)
+
+    Returns:
+        Configured ArtifactStore instance
+
+    Raises:
+        ValueError: If backend is unknown or required config is missing
+    """
+    if backend == "local":
+        return LocalFileStore(storage_path)
+
+    if backend == "s3":
+        if not s3_bucket:
+            raise ValueError(
+                "S3_BUCKET is required when ARTIFACT_STORAGE_BACKEND=s3. "
+                "Run `fly storage create` to provision a Tigris bucket."
+            )
+        from runtm_worker.storage.s3 import S3FileStore
+
+        return S3FileStore(
+            bucket=s3_bucket,
+            endpoint_url=s3_endpoint_url,
+            region=s3_region,
+        )
+
+    raise ValueError(
+        f"Unknown storage backend: '{backend}'. Use 'local' or 's3'."
+    )
+
+
+__all__ = ["LocalFileStore", "get_artifact_store"]

--- a/packages/worker/runtm_worker/storage/s3.py
+++ b/packages/worker/runtm_worker/storage/s3.py
@@ -1,0 +1,90 @@
+"""S3-compatible artifact storage implementation (Tigris / AWS S3 / R2)."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import boto3
+
+from runtm_shared.errors import ArtifactNotFoundError, StorageReadError, StorageWriteError
+from runtm_shared.storage.base import ArtifactStore
+
+
+class S3FileStore(ArtifactStore):
+    """S3-compatible implementation of ArtifactStore.
+
+    Works with any S3-compatible service (Tigris, AWS S3, Cloudflare R2).
+    Fly.io's Tigris is the primary target — set endpoint_url to
+    https://fly.storage.tigris.dev and use Fly-issued credentials.
+
+    Usage:
+        store = S3FileStore(bucket="runtm-artifacts")
+        store.put("artifacts/dep_abc123/artifact.zip", data)
+        data = store.get("artifacts/dep_abc123/artifact.zip")
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        endpoint_url: str | None = None,
+        region: str = "auto",
+    ):
+        self.bucket = bucket
+        self._client = boto3.client(
+            "s3",
+            endpoint_url=endpoint_url,
+            region_name=region,
+        )
+
+    def put(self, key: str, data: bytes) -> str:
+        try:
+            self._client.put_object(Bucket=self.bucket, Key=key, Body=data)
+            return self.get_uri(key)
+        except Exception as e:
+            raise StorageWriteError(key, str(e)) from e
+
+    def get(self, key: str) -> bytes:
+        try:
+            response = self._client.get_object(Bucket=self.bucket, Key=key)
+            return response["Body"].read()
+        except self._client.exceptions.NoSuchKey as e:
+            raise ArtifactNotFoundError(key) from e
+        except Exception as e:
+            raise StorageReadError(key, str(e)) from e
+
+    def delete(self, key: str) -> None:
+        try:
+            self._client.delete_object(Bucket=self.bucket, Key=key)
+        except Exception as e:
+            raise StorageWriteError(key, str(e)) from e
+
+    def exists(self, key: str) -> bool:
+        try:
+            self._client.head_object(Bucket=self.bucket, Key=key)
+            return True
+        except self._client.exceptions.ClientError:
+            return False
+
+    def get_uri(self, key: str) -> str:
+        return f"s3://{self.bucket}/{key}"
+
+    def get_size(self, key: str) -> int | None:
+        try:
+            response = self._client.head_object(Bucket=self.bucket, Key=key)
+            return response["ContentLength"]
+        except self._client.exceptions.ClientError:
+            return None
+
+    def get_path(self, key: str) -> Path:
+        """Download artifact to a temp file and return the local path.
+
+        The Docker builder requires a filesystem path to extract the zip.
+        For S3-backed storage we download on demand.
+        """
+        data = self.get(key)
+        tmp_dir = Path(tempfile.mkdtemp(prefix="runtm-artifact-"))
+        filename = key.rsplit("/", 1)[-1] if "/" in key else key
+        dest = tmp_dir / filename
+        dest.write_bytes(data)
+        return dest

--- a/packages/worker/tests/test_storage.py
+++ b/packages/worker/tests/test_storage.py
@@ -1,0 +1,263 @@
+"""Tests for artifact storage implementations and factory."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from runtm_shared.errors import ArtifactNotFoundError, StorageReadError, StorageWriteError
+from runtm_worker.storage.local import LocalFileStore
+
+
+class TestLocalFileStore:
+    """Tests for LocalFileStore (baseline — must keep working after refactor)."""
+
+    def setup_method(self) -> None:
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = LocalFileStore(self.tmpdir)
+
+    def test_put_and_get(self) -> None:
+        data = b"hello artifact"
+        self.store.put("dep_abc/artifact.zip", data)
+        assert self.store.get("dep_abc/artifact.zip") == data
+
+    def test_exists_true(self) -> None:
+        self.store.put("dep_abc/artifact.zip", b"data")
+        assert self.store.exists("dep_abc/artifact.zip") is True
+
+    def test_exists_false(self) -> None:
+        assert self.store.exists("nonexistent/artifact.zip") is False
+
+    def test_get_missing_raises(self) -> None:
+        with pytest.raises(ArtifactNotFoundError):
+            self.store.get("nonexistent/artifact.zip")
+
+    def test_delete(self) -> None:
+        self.store.put("dep_abc/artifact.zip", b"data")
+        self.store.delete("dep_abc/artifact.zip")
+        assert self.store.exists("dep_abc/artifact.zip") is False
+
+    def test_get_uri(self) -> None:
+        uri = self.store.get_uri("dep_abc/artifact.zip")
+        assert uri.startswith("file://")
+
+    def test_get_path(self) -> None:
+        self.store.put("dep_abc/artifact.zip", b"data")
+        path = self.store.get_path("dep_abc/artifact.zip")
+        assert isinstance(path, Path)
+        assert path.exists()
+
+    def test_get_size(self) -> None:
+        self.store.put("dep_abc/artifact.zip", b"12345")
+        assert self.store.get_size("dep_abc/artifact.zip") == 5
+
+    def test_get_size_missing(self) -> None:
+        assert self.store.get_size("nonexistent") is None
+
+    def test_path_traversal_blocked(self) -> None:
+        with pytest.raises(StorageWriteError):
+            self.store.put("../../etc/passwd", b"evil")
+
+
+class TestS3FileStore:
+    """Tests for S3FileStore using mocked boto3."""
+
+    def _make_store(self):
+        from runtm_worker.storage.s3 import S3FileStore
+
+        return S3FileStore(
+            bucket="test-bucket",
+            endpoint_url="https://fly.storage.tigris.dev",
+            region="auto",
+        )
+
+    @patch("runtm_worker.storage.s3.boto3")
+    def test_put(self, mock_boto3: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+
+        store = self._make_store()
+        uri = store.put("artifacts/dep_abc/artifact.zip", b"hello")
+
+        mock_client.put_object.assert_called_once_with(
+            Bucket="test-bucket",
+            Key="artifacts/dep_abc/artifact.zip",
+            Body=b"hello",
+        )
+        assert "s3://" in uri
+
+    @patch("runtm_worker.storage.s3.boto3")
+    def test_get(self, mock_boto3: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_body = MagicMock()
+        mock_body.read.return_value = b"artifact-data"
+        mock_client.get_object.return_value = {"Body": mock_body}
+
+        store = self._make_store()
+        data = store.get("artifacts/dep_abc/artifact.zip")
+
+        mock_client.get_object.assert_called_once_with(
+            Bucket="test-bucket",
+            Key="artifacts/dep_abc/artifact.zip",
+        )
+        assert data == b"artifact-data"
+
+    @patch("runtm_worker.storage.s3.boto3")
+    def test_get_missing_raises_artifact_not_found(self, mock_boto3: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+
+        error_response = {"Error": {"Code": "NoSuchKey", "Message": "Not found"}}
+        mock_client.get_object.side_effect = mock_client.exceptions.NoSuchKey(
+            error_response, "GetObject"
+        )
+        mock_client.exceptions.NoSuchKey = type(
+            "NoSuchKey", (Exception,), {}
+        )
+        mock_client.get_object.side_effect = mock_client.exceptions.NoSuchKey(
+            "Not found"
+        )
+
+        store = self._make_store()
+        with pytest.raises(ArtifactNotFoundError):
+            store.get("nonexistent/artifact.zip")
+
+    @patch("runtm_worker.storage.s3.boto3")
+    def test_delete(self, mock_boto3: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+
+        store = self._make_store()
+        store.delete("artifacts/dep_abc/artifact.zip")
+
+        mock_client.delete_object.assert_called_once_with(
+            Bucket="test-bucket",
+            Key="artifacts/dep_abc/artifact.zip",
+        )
+
+    @patch("runtm_worker.storage.s3.boto3")
+    def test_exists_true(self, mock_boto3: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.head_object.return_value = {"ContentLength": 100}
+
+        store = self._make_store()
+        assert store.exists("artifacts/dep_abc/artifact.zip") is True
+
+    @patch("runtm_worker.storage.s3.boto3")
+    def test_exists_false(self, mock_boto3: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.exceptions.ClientError = type("ClientError", (Exception,), {})
+        mock_client.head_object.side_effect = mock_client.exceptions.ClientError("Not found")
+
+        store = self._make_store()
+        assert store.exists("nonexistent/artifact.zip") is False
+
+    @patch("runtm_worker.storage.s3.boto3")
+    def test_get_uri(self, mock_boto3: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+
+        store = self._make_store()
+        uri = store.get_uri("artifacts/dep_abc/artifact.zip")
+        assert uri == "s3://test-bucket/artifacts/dep_abc/artifact.zip"
+
+    @patch("runtm_worker.storage.s3.boto3")
+    def test_get_size(self, mock_boto3: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.head_object.return_value = {"ContentLength": 42}
+
+        store = self._make_store()
+        assert store.get_size("artifacts/dep_abc/artifact.zip") == 42
+
+    @patch("runtm_worker.storage.s3.boto3")
+    def test_get_size_missing(self, mock_boto3: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.exceptions.ClientError = type("ClientError", (Exception,), {})
+        mock_client.head_object.side_effect = mock_client.exceptions.ClientError("Not found")
+
+        store = self._make_store()
+        assert store.get_size("nonexistent") is None
+
+    @patch("runtm_worker.storage.s3.boto3")
+    def test_get_path_downloads_to_temp(self, mock_boto3: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_body = MagicMock()
+        mock_body.read.return_value = b"zip-contents"
+        mock_client.get_object.return_value = {"Body": mock_body}
+
+        store = self._make_store()
+        path = store.get_path("artifacts/dep_abc/artifact.zip")
+
+        assert isinstance(path, Path)
+        assert path.exists()
+        assert path.read_bytes() == b"zip-contents"
+
+    @patch("runtm_worker.storage.s3.boto3")
+    def test_put_write_error(self, mock_boto3: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.put_object.side_effect = Exception("Network error")
+
+        store = self._make_store()
+        with pytest.raises(StorageWriteError):
+            store.put("key", b"data")
+
+    @patch("runtm_worker.storage.s3.boto3")
+    def test_get_read_error(self, mock_boto3: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.get_object.side_effect = Exception("Network error")
+        mock_client.exceptions.NoSuchKey = type("NoSuchKey", (Exception,), {})
+
+        store = self._make_store()
+        with pytest.raises(StorageReadError):
+            store.get("key")
+
+
+class TestGetArtifactStore:
+    """Tests for the factory function."""
+
+    def test_default_returns_local(self) -> None:
+        from runtm_worker.storage import get_artifact_store
+
+        store = get_artifact_store(
+            backend="local",
+            storage_path="/tmp/test-artifacts",
+        )
+        assert isinstance(store, LocalFileStore)
+
+    @patch("runtm_worker.storage.s3.boto3")
+    def test_s3_backend(self, mock_boto3: MagicMock) -> None:
+        from runtm_worker.storage import get_artifact_store
+        from runtm_worker.storage.s3 import S3FileStore
+
+        mock_boto3.client.return_value = MagicMock()
+
+        store = get_artifact_store(
+            backend="s3",
+            s3_bucket="my-bucket",
+            s3_endpoint_url="https://fly.storage.tigris.dev",
+            s3_region="auto",
+        )
+        assert isinstance(store, S3FileStore)
+
+    def test_invalid_backend_raises(self) -> None:
+        from runtm_worker.storage import get_artifact_store
+
+        with pytest.raises(ValueError, match="Unknown storage backend"):
+            get_artifact_store(backend="azure-blob")
+
+    def test_s3_missing_bucket_raises(self) -> None:
+        from runtm_worker.storage import get_artifact_store
+
+        with pytest.raises(ValueError, match="S3_BUCKET"):
+            get_artifact_store(backend="s3", s3_bucket="")


### PR DESCRIPTION
## Summary

- **Add S3FileStore** — a new `ArtifactStore` implementation backed by boto3, compatible with Tigris, AWS S3, and Cloudflare R2
- **Add `get_artifact_store()` factory** — selects the right storage backend (`local` or `s3`) based on the `ARTIFACT_STORAGE_BACKEND` env var
- **Refactor DeployJob** to accept an `ArtifactStore` instead of a raw filesystem path, and update the API deployment route to store artifacts through the abstraction
- **Add configuration** for S3/Tigris credentials (`BUCKET_NAME`, `AWS_ENDPOINT_URL_S3`, etc.) in Settings, docker-compose, env examples, and README docs
- **Add comprehensive tests** for LocalFileStore, S3FileStore, and the factory function

## Motivation

On Fly.io, the web and worker process groups run on separate machines with independent filesystems. Previously the Cloud Backend worked around this with a fragile HTTP-based artifact download between machines. This PR adds proper pluggable object storage so both sides read/write from the same bucket, eliminating the cross-machine coupling entirely.

## Test plan

- [ ] `pytest packages/worker/tests/test_storage.py` — all storage tests pass (local + mocked S3)
- [ ] Dev environment with `ARTIFACT_STORAGE_BACKEND=local` works unchanged
- [ ] Verify S3FileStore connects to a real Tigris bucket when credentials are provided

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how deployment artifacts are written/read by introducing a pluggable storage backend (local vs S3) used by both API and worker; misconfiguration or S3 errors could break deployments. Adds new boto3 dependency and async-to-thread upload behavior that may affect performance/failure modes.
> 
> **Overview**
> Adds configurable artifact storage via `ARTIFACT_STORAGE_BACKEND` with a new S3/Tigris implementation (`S3FileStore`) and a `get_artifact_store()` factory to select `local` vs `s3`.
> 
> Refactors artifact handling so the API’s deployment upload path stores artifacts through the backend (using `asyncio.to_thread`), and the worker’s `DeployJob` now receives an `ArtifactStore` instance rather than a filesystem path.
> 
> Introduces S3-related settings (`BUCKET_NAME`, `AWS_ENDPOINT_URL_S3`, region) across config, docker-compose, env examples, and READMEs; adds `boto3` to worker dependencies and adds unit tests covering local storage, S3 storage (mocked), and the factory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73ca54ab3ebaaaf451bb3b5cf455b45c5602fc72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->