### PR TITLE
fix: resolve pre-existing CI pipeline failures

### DIFF
--- a/packages/api/tests/test_policy.py
+++ b/packages/api/tests/test_policy.py
@@ -82,7 +82,7 @@ class TestDefaultPolicyProvider:
         self, mock_settings: MagicMock, mock_db: MagicMock
     ) -> None:
         """Should block tiers not in allowlist."""
-        mock_settings.parsed_allowed_tiers = ["starter", "standard"]
+        mock_settings.parsed_allowed_tiers = ["starter", "pro"]
 
         with patch("runtm_api.core.config.get_settings", return_value=mock_settings):
             provider = DefaultPolicyProvider()
@@ -91,17 +91,17 @@ class TestDefaultPolicyProvider:
         assert result.allowed is False
         assert "performance" in result.reason
         assert "starter" in result.reason
-        assert "standard" in result.reason
+        assert "pro" in result.reason
 
     def test_tier_allowlist_allows_valid_tier(
         self, mock_settings: MagicMock, mock_db: MagicMock
     ) -> None:
         """Should allow tiers in allowlist."""
-        mock_settings.parsed_allowed_tiers = ["starter", "standard"]
+        mock_settings.parsed_allowed_tiers = ["starter", "pro"]
 
         with patch("runtm_api.core.config.get_settings", return_value=mock_settings):
             provider = DefaultPolicyProvider()
-            result = provider.check_deploy("tenant_1", mock_db, requested_tier="standard")
+            result = provider.check_deploy("tenant_1", mock_db, requested_tier="pro")
 
         assert result.allowed is True
 

--- a/packages/shared/runtm_shared/storage/__init__.py
+++ b/packages/shared/runtm_shared/storage/__init__.py
@@ -54,9 +54,7 @@ def get_artifact_store(backend: str = "local", **kwargs) -> ArtifactStore:
 
     registered = ", ".join(sorted(_backend_registry)) if _backend_registry else ""
     available = f"local, {registered}" if registered else "local"
-    raise ValueError(
-        f"Unknown storage backend: '{backend}'. Available: {available}."
-    )
+    raise ValueError(f"Unknown storage backend: '{backend}'. Available: {available}.")
 
 
 __all__ = [

--- a/packages/shared/tests/test_storage.py
+++ b/packages/shared/tests/test_storage.py
@@ -15,15 +15,14 @@ from pathlib import Path
 
 import pytest
 
-from runtm_shared.errors import ArtifactNotFoundError, StorageReadError, StorageWriteError
+from runtm_shared.errors import ArtifactNotFoundError, StorageWriteError
 from runtm_shared.storage import (
     ArtifactStore,
     LocalFileStore,
+    _backend_registry,
     get_artifact_store,
     register_backend,
 )
-from runtm_shared.storage import _backend_registry
-
 
 # ---------------------------------------------------------------------------
 # Fixture: clean registry between tests
@@ -116,7 +115,7 @@ class TestGetArtifactStore:
             get_artifact_store(backend="azure-blob")
 
     def test_unknown_backend_message_lists_available(self) -> None:
-        register_backend("mock", lambda **kw: None)  # type: ignore[arg-type]
+        register_backend("mock", lambda **_kw: None)  # type: ignore[arg-type]
         with pytest.raises(ValueError, match="mock"):
             get_artifact_store(backend="nope")
 
@@ -164,21 +163,39 @@ class TestRegisterBackend:
         """Registering the same name twice replaces the factory."""
 
         class StoreA(ArtifactStore):
-            def put(self, key, data): return ""
-            def get(self, key): return b""
-            def delete(self, key): pass
-            def exists(self, key): return False
-            def get_uri(self, key): return ""
+            def put(self, key, data):
+                return ""
+
+            def get(self, key):
+                return b""
+
+            def delete(self, key):
+                pass
+
+            def exists(self, key):
+                return False
+
+            def get_uri(self, key):
+                return ""
 
         class StoreB(ArtifactStore):
-            def put(self, key, data): return ""
-            def get(self, key): return b""
-            def delete(self, key): pass
-            def exists(self, key): return False
-            def get_uri(self, key): return ""
+            def put(self, key, data):
+                return ""
 
-        register_backend("x", lambda **kw: StoreA())
-        register_backend("x", lambda **kw: StoreB())
+            def get(self, key):
+                return b""
+
+            def delete(self, key):
+                pass
+
+            def exists(self, key):
+                return False
+
+            def get_uri(self, key):
+                return ""
+
+        register_backend("x", lambda **_kw: StoreA())
+        register_backend("x", lambda **_kw: StoreB())
 
         store = get_artifact_store(backend="x")
         assert isinstance(store, StoreB)
@@ -188,11 +205,20 @@ class TestRegisterBackend:
         received = {}
 
         class Dummy(ArtifactStore):
-            def put(self, key, data): return ""
-            def get(self, key): return b""
-            def delete(self, key): pass
-            def exists(self, key): return False
-            def get_uri(self, key): return ""
+            def put(self, key, data):
+                return ""
+
+            def get(self, key):
+                return b""
+
+            def delete(self, key):
+                pass
+
+            def exists(self, key):
+                return False
+
+            def get_uri(self, key):
+                return ""
 
         def factory(**kwargs):
             received.update(kwargs)

--- a/packages/worker/runtm_worker/jobs/deploy.py
+++ b/packages/worker/runtm_worker/jobs/deploy.py
@@ -16,6 +16,7 @@ from runtm_shared.errors import (
     DeployTimeoutError,
     HealthCheckError,
 )
+from runtm_shared.storage.base import ArtifactStore
 from runtm_shared.types import (
     DeploymentState,
     Limits,
@@ -28,7 +29,6 @@ from runtm_shared.urls import construct_deployment_url, get_subdomain_for_app
 from runtm_worker.builder import DockerBuilder
 from runtm_worker.logs import LogCapture
 from runtm_worker.providers import FlyProvider
-from runtm_shared.storage.base import ArtifactStore
 
 
 class DeployJob:


### PR DESCRIPTION
## Summary

Fixes all pre-existing CI failures that currently break `main` and block all open PRs (#6, #7, #8).

**What this PR fixes (5 of 7 CI jobs):**

- **Lint** -- Ruff I001 (unsorted imports in `test_storage.py` and `deploy.py`), F401 (unused `StorageReadError` import), ARG005 (unused lambda args), and format violations
- **Test API Package** -- `test_tier_allowlist_allows_valid_tier` used the deprecated `standard` tier (removed from `VALID_TIER_NAMES`), replaced with valid `pro` tier
- **Test Shared Package** -- already passing
- **Test Template** -- already passing
- **Build Docker Images** -- already passing

## Action required from @Gustrigos

**The remaining 2 failures (Test CLI Package, Type Check)** are caused by a missing dependency in `.github/workflows/ci.yml`. The CLI's `pyproject.toml` declares `runtm-agents>=0.1.0` as a dev dependency, but the CI workflow never installs `packages/agents` before `packages/cli`.

**The fix** (could not be pushed via fork due to GitHub's `workflow` OAuth scope restriction):

In `.github/workflows/ci.yml`, add two lines in **both** the `typecheck` and `test-cli` jobs:

```yaml
# typecheck job (line ~47):
pip install -e packages/shared[dev]
pip install -e packages/api[dev]
pip install -e packages/worker[dev]
pip install -e packages/agents[dev]    # <-- ADD THIS
pip install -e packages/sandbox[dev]   # <-- ADD THIS
pip install -e packages/cli[dev]

# test-cli job (line ~147):
pip install -e packages/shared[dev]
pip install -e packages/agents[dev]    # <-- ADD THIS
pip install -e packages/sandbox[dev]   # <-- ADD THIS
pip install -e packages/cli[dev]
```

Once this PR is merged and the `ci.yml` change is applied (either by amending this PR with push access, or as a follow-up commit to `main`), **all 7 CI jobs will pass** and PRs #6, #7, #8 will unblock.

## Test plan

- [x] `ruff check .` passes locally (0 errors)
- [x] `ruff format --check .` passes locally (0 reformats)
- [ ] CI Lint job passes after merge
- [ ] CI Test API Package passes after merge
- [ ] CI Test CLI + Type Check pass after `ci.yml` fix is applied
