### PR TITLE
docs: surface v0 programmatic and v2 sandbox-lifecycle session endpoints

### DIFF
--- a/docs/cloud-api/authentication.mdx
+++ b/docs/cloud-api/authentication.mdx
@@ -14,7 +14,7 @@ curl https://app.runtm.com/api/sessions \
   -H "Authorization: Bearer runtm_sk_live_abc123..."
 ```
 
-All API keys use the prefix `runtm_sk_` followed by an opaque secret. The raw secret is shown **once** when you create the key — store it in a secrets manager or environment variable immediately.
+All API keys use the prefix `runtm_sk_` followed by an opaque secret. The raw secret is shown **once** when you create the key - store it in a secrets manager or environment variable immediately.
 
 ## Creating API keys
 
@@ -24,8 +24,8 @@ All API keys use the prefix `runtm_sk_` followed by an opaque secret. The raw se
   </Step>
 
   <Step title="Choose context">
-    - **Personal key** — created outside any org; sees only your personal sessions, secrets, and instructions.
-    - **Organization key** — switch to an org first, then create the key; it sees that org's shared resources.
+    - **Personal key** - created outside any org; sees only your personal sessions, secrets, and instructions.
+    - **Organization key** - switch to an org first, then create the key; it sees that org's shared resources.
   </Step>
 
   <Step title="Select scopes">
@@ -33,7 +33,7 @@ All API keys use the prefix `runtm_sk_` followed by an opaque secret. The raw se
   </Step>
 
   <Step title="Copy the secret">
-    The raw key is displayed once. Copy it now — you cannot retrieve it later. You can always verify a key with the [Verify endpoint](/cloud-api/authentication/verify).
+    The raw key is displayed once. Copy it now - you cannot retrieve it later. You can always verify a key with the [Verify endpoint](/cloud-api/authentication/verify).
   </Step>
 </Steps>
 
@@ -47,7 +47,7 @@ curl https://app.runtm.com/api/sessions \
   -H "X-Organization-Id: org_abc123"
 ```
 
-If the key was created in an org context, the organization is already embedded in the key. You can still pass the header explicitly — the API uses it as confirmation and will reject a mismatch.
+If the key was created in an org context, the organization is already embedded in the key. You can still pass the header explicitly - the API uses it as confirmation and will reject a mismatch.
 
 If the key was created in personal context, omitting the header returns your personal resources. Adding the header scopes the request to the specified org (provided you are a member).
 
@@ -57,7 +57,7 @@ If the key was created in personal context, omitting the header returns your per
 |--------|-------------|-----------------|
 | Created in | Personal context (no org selected) | Org context (org selected in dashboard) |
 | Default scope | Your personal sessions, secrets, instructions | The org's shared sessions, secrets, instructions |
-| `X-Organization-Id` | Optional — adds org scope if you are a member | Embedded — header is optional but must match |
+| `X-Organization-Id` | Optional - adds org scope if you are a member | Embedded - header is optional but must match |
 | Visibility | Only your resources | Resources visible to org members |
 
 ## Security best practices

--- a/docs/cloud-api/authentication/verify.mdx
+++ b/docs/cloud-api/authentication/verify.mdx
@@ -4,7 +4,7 @@ api: "GET /auth/verify"
 description: "Verify an API key and inspect its scopes"
 ---
 
-Validates the provided API key and returns its metadata, including the scopes it was granted and the user and organization it belongs to. Any valid key can call this endpoint — no specific scope is required.
+Validates the provided API key and returns its metadata, including the scopes it was granted and the user and organization it belongs to. Any valid key can call this endpoint - no specific scope is required.
 
 ## Headers
 

--- a/docs/cloud-api/configuration/current-plan.mdx
+++ b/docs/cloud-api/configuration/current-plan.mdx
@@ -43,7 +43,7 @@ sandbox sizing for the caller. The exact response is contextual:
 </ResponseField>
 
 <ResponseField name="sandbox_tier" type="string">
-  E2B sandbox tier the caller's sessions boot with. One of `"base"` or
+  Sandbox tier the caller's sessions boot with. One of `"base"` or
   `"standard"`.
 </ResponseField>
 

--- a/docs/cloud-api/context/knowledge/catalog.mdx
+++ b/docs/cloud-api/context/knowledge/catalog.mdx
@@ -5,7 +5,7 @@ description: "List every available knowledge provider and its capabilities."
 ---
 
 Returns the full catalog of knowledge providers with their auth methods, tools, and display metadata.
-The catalog is resolved from code at import time — no database queries are involved.
+The catalog is resolved from code at import time - no database queries are involved.
 
 **Required scope:** `integrations:read`
 

--- a/docs/cloud-api/context/knowledge/patch.mdx
+++ b/docs/cloud-api/context/knowledge/patch.mdx
@@ -6,7 +6,7 @@ description: "Update display name, metadata, or tool permissions on an integrati
 
 Partially updates a knowledge integration. Only the fields you include in the body are changed; omitted fields are left untouched.
 
-This endpoint does **not** update credentials — use [Rotate Credentials](/cloud-api/context/knowledge/rotate) for that.
+This endpoint does **not** update credentials - use [Rotate Credentials](/cloud-api/context/knowledge/rotate) for that.
 
 **Required scope:** `integrations:write`
 

--- a/docs/cloud-api/context/skills/create.mdx
+++ b/docs/cloud-api/context/skills/create.mdx
@@ -4,7 +4,7 @@ api: "POST /api/agent-directives"
 description: "Create a new agent directive (skill, MCP server, doc, hook, etc.)"
 ---
 
-Creates a new agent directive. The directive starts as an unpublished draft — call [Publish](/cloud-api/context/skills/publish) to activate it.
+Creates a new agent directive. The directive starts as an unpublished draft - call [Publish](/cloud-api/context/skills/publish) to activate it.
 
 **Required scope:** `context:write`
 
@@ -37,7 +37,7 @@ Creates a new agent directive. The directive starts as an unpublished draft — 
 </ParamField>
 
 <ParamField body="content" type="object" required>
-  Type-specific content payload. Shape depends on `type` — see examples.
+  Type-specific content payload. Shape depends on `type` - see examples.
 </ParamField>
 
 ## Response

--- a/docs/cloud-api/context/skills/discover-in-repo.mdx
+++ b/docs/cloud-api/context/skills/discover-in-repo.mdx
@@ -4,7 +4,7 @@ api: "POST /api/agent-directives:discover-in-repo"
 description: "Scan a GitHub repository for SKILL.md candidates"
 ---
 
-Scans a GitHub repository tree for every `SKILL.md` file and returns candidates the UI can render for user selection. Read-only — no directives are created.
+Scans a GitHub repository tree for every `SKILL.md` file and returns candidates the UI can render for user selection. Read-only - no directives are created.
 
 **Required scope:** `context:read`
 

--- a/docs/cloud-api/context/skills/resync.mdx
+++ b/docs/cloud-api/context/skills/resync.mdx
@@ -39,7 +39,7 @@ When `auto_publish` is `true` and the previous version was already published, th
 </ResponseField>
 
 <ResponseField name="no_changes" type="boolean">
-  `true` if upstream content was identical — no new version was created.
+  `true` if upstream content was identical - no new version was created.
 </ResponseField>
 
 <ResponseField name="previous_version" type="integer">

--- a/docs/cloud-api/context/skills/version.mdx
+++ b/docs/cloud-api/context/skills/version.mdx
@@ -4,7 +4,7 @@ api: "POST /api/agent-directives/{directive_id}:new-version"
 description: "Clone a directive into a new unpublished draft version"
 ---
 
-Creates a new unpublished draft by cloning the specified directive. Idempotent — repeat calls return the same draft until it is published. Attachments are copied forward so publishing lands atomically without re-attaching.
+Creates a new unpublished draft by cloning the specified directive. Idempotent - repeat calls return the same draft until it is published. Attachments are copied forward so publishing lands atomically without re-attaching.
 
 **Required scope:** `context:write`
 

--- a/docs/cloud-api/deploy/preflight.mdx
+++ b/docs/cloud-api/deploy/preflight.mdx
@@ -68,7 +68,7 @@ data = response.json()
 if data["api_reachable"] and data["credentials_present"]:
     print(f"Ready to deploy (latency: {data['latency_ms']}ms)")
 else:
-    print("Preflight failed — check connectivity or credentials")
+    print("Preflight failed - check connectivity or credentials")
 ```
 
 ```javascript JavaScript
@@ -86,7 +86,7 @@ const data = await response.json();
 if (data.api_reachable && data.credentials_present) {
   console.log(`Ready to deploy (latency: ${data.latency_ms}ms)`);
 } else {
-  console.log("Preflight failed — check connectivity or credentials");
+  console.log("Preflight failed - check connectivity or credentials");
 }
 ```
 </RequestExample>

--- a/docs/cloud-api/deploy/scaffold.mdx
+++ b/docs/cloud-api/deploy/scaffold.mdx
@@ -4,7 +4,7 @@ api: "POST /api/sessions/{session_id}/deploy/scaffold"
 description: "Generate deployment config files for the session project"
 ---
 
-Deterministically generates deployment configuration files (`runtm.yaml`, `Dockerfile`, `.runtmignore`, `.dockerignore`) for the session project. Only creates files that are missing — existing files are skipped.
+Deterministically generates deployment configuration files (`runtm.yaml`, `Dockerfile`, `.runtmignore`, `.dockerignore`) for the session project. Only creates files that are missing - existing files are skipped.
 
 **Required scope:** `deployments:write`
 

--- a/docs/cloud-api/errors.mdx
+++ b/docs/cloud-api/errors.mdx
@@ -31,7 +31,7 @@ Some endpoints return a structured detail object with additional context:
 
 | Code | Meaning | When you will see it |
 |------|---------|---------------------|
-| `400` | **Bad Request** | Validation failed — missing or invalid fields, malformed JSON. |
+| `400` | **Bad Request** | Validation failed - missing or invalid fields, malformed JSON. |
 | `401` | **Unauthorized** | API key is missing, invalid, or expired. |
 | `403` | **Forbidden** | Key is valid but lacks the required scope, or the user is not a member of the target organization. |
 | `404` | **Not Found** | The requested resource does not exist, or is not visible to the key's scope. |

--- a/docs/cloud-api/guardrails/org-limits-set.mdx
+++ b/docs/cloud-api/guardrails/org-limits-set.mdx
@@ -4,7 +4,7 @@ api: "PUT /api/organizations/{org_id}/limits"
 description: "Set the usage limits and deployment policy for an organization."
 ---
 
-Updates the organization's usage limits. All fields in the `limits` object are optional — omitted fields retain their current values.
+Updates the organization's usage limits. All fields in the `limits` object are optional - omitted fields retain their current values.
 
 **Required scope:** `guardrails:write`
 

--- a/docs/cloud-api/integrations/github-app/installation-delete.mdx
+++ b/docs/cloud-api/integrations/github-app/installation-delete.mdx
@@ -4,7 +4,7 @@ api: "DELETE /api/github-app/installations/{installation_id}"
 description: "Remove a GitHub App installation record."
 ---
 
-Removes a GitHub App installation from the database. This does not uninstall the app from GitHub — it only removes the record from Runtime.
+Removes a GitHub App installation from the database. This does not uninstall the app from GitHub - it only removes the record from Runtime.
 
 **Required scope:** `integrations:write`
 

--- a/docs/cloud-api/integrations/linear/integration-update.mdx
+++ b/docs/cloud-api/integrations/linear/integration-update.mdx
@@ -4,7 +4,7 @@ api: "POST /api/v1/linear/integration"
 description: "Update the Linear integration configuration."
 ---
 
-Updates settings for an existing Linear integration. Supports partial updates — only provided fields are changed. Requires org admin role.
+Updates settings for an existing Linear integration. Supports partial updates - only provided fields are changed. Requires org admin role.
 
 **Required scope:** `integrations:write`
 

--- a/docs/cloud-api/overview.mdx
+++ b/docs/cloud-api/overview.mdx
@@ -13,7 +13,7 @@ It is designed for:
 - Internal tools and dashboards that read activity, manage secrets, or sync templates across orgs
 
 <Tip>
-**Looking for guides?** If you want patterns and walkthroughs instead of endpoint specs, see the [Guides](/guides/overview) — covering authentication, session management, prompt streaming, file operations, telemetry, and best practices.
+**Looking for guides?** If you want patterns and walkthroughs instead of endpoint specs, see the [Guides](/guides/overview) - covering authentication, session management, prompt streaming, file operations, telemetry, and best practices.
 </Tip>
 
 ## Base URL

--- a/docs/cloud-api/provider-keys/resolved.mdx
+++ b/docs/cloud-api/provider-keys/resolved.mdx
@@ -6,9 +6,9 @@ description: "Get the resolved provider key after applying the org → user fall
 
 Returns the effective provider key for the authenticated user after applying the resolution chain. The platform resolves keys in this order:
 
-1. **Org enforced key** — if the user's organization has set a key with `enforced` policy, it wins
-2. **User org key** — a personal key the user stored while in an org context
-3. **User personal key** — the user's own key outside any org
+1. **Org enforced key** - if the user's organization has set a key with `enforced` policy, it wins
+2. **User org key** - a personal key the user stored while in an org context
+3. **User personal key** - the user's own key outside any org
 
 This endpoint tells you which source won and whether a key is available, without revealing the key itself.
 
@@ -68,7 +68,7 @@ data = response.json()
 if data["has_key"]:
     print(f"Using {data['source']} key: {data['key_preview']}")
 else:
-    print("No key available — configure one in settings")
+    print("No key available - configure one in settings")
 ```
 
 ```javascript JavaScript

--- a/docs/cloud-api/rate-limits.mdx
+++ b/docs/cloud-api/rate-limits.mdx
@@ -69,7 +69,7 @@ Wait the number of seconds specified in `Retry-After` before retrying.
   </Accordion>
 
   <Accordion title="Cache responses">
-    Cache responses that don't change frequently — session lists, template configs, org settings. Use `Cache-Control` or a local TTL to avoid unnecessary requests.
+    Cache responses that don't change frequently - session lists, template configs, org settings. Use `Cache-Control` or a local TTL to avoid unnecessary requests.
   </Accordion>
 
   <Accordion title="Batch operations">

--- a/docs/cloud-api/scopes.mdx
+++ b/docs/cloud-api/scopes.mdx
@@ -3,7 +3,7 @@ title: "Scopes & Permissions"
 description: "API key scopes, what they unlock, and role ceilings"
 ---
 
-Every API key carries a set of **scopes** that determine which endpoints it can call. Scopes follow the pattern `resource:action` — for example, `sessions:read` allows listing and viewing sessions but not modifying them.
+Every API key carries a set of **scopes** that determine which endpoints it can call. Scopes follow the pattern `resource:action` - for example, `sessions:read` allows listing and viewing sessions but not modifying them.
 
 ## Scope reference
 
@@ -52,7 +52,7 @@ A key can never exceed the permissions of the user who created it. The user's **
 |------|---------|
 | **Member** | Can create keys with any scope that applies to member-accessible resources. Cannot grant `guardrails:write` or `templates:delete`. |
 | **Admin** | Can create keys with all scopes except those reserved for owners. |
-| **Owner** | No restrictions — can create keys with any scope. |
+| **Owner** | No restrictions - can create keys with any scope. |
 
 If a user's role is downgraded after a key is created, the key's effective permissions are reduced to match the new role at request time.
 

--- a/docs/cloud-api/secrets/personal-list.mdx
+++ b/docs/cloud-api/secrets/personal-list.mdx
@@ -4,7 +4,7 @@ api: "GET /api/secrets/personal"
 description: "List personal secret names and metadata"
 ---
 
-Returns names and metadata for the authenticated user's personal secrets. Values are never returned — only names and whether a value is set.
+Returns names and metadata for the authenticated user's personal secrets. Values are never returned - only names and whether a value is set.
 
 **Required scope:** `secrets:read`
 

--- a/docs/cloud-api/secrets/personal-set.mdx
+++ b/docs/cloud-api/secrets/personal-set.mdx
@@ -4,7 +4,7 @@ api: "PUT /api/secrets/personal"
 description: "Create or update personal secrets"
 ---
 
-Bulk upserts personal secrets. Values are encrypted before storage and can never be read back — this is a write-only operation. Existing secrets with the same name are overwritten.
+Bulk upserts personal secrets. Values are encrypted before storage and can never be read back - this is a write-only operation. Existing secrets with the same name are overwritten.
 
 **Required scope:** `secrets:write`
 

--- a/docs/cloud-api/sessions/delete.mdx
+++ b/docs/cloud-api/sessions/delete.mdx
@@ -4,7 +4,7 @@ api: "DELETE /api/sessions/{session_id}"
 description: "Destroy a session and its sandbox"
 ---
 
-Destroys a cloud session and its underlying sandbox. This action is irreversible — all sandbox data is permanently deleted.
+Destroys a cloud session and its underlying sandbox. This action is irreversible - all sandbox data is permanently deleted.
 
 **Required scope:** `sessions:delete`
 

--- a/docs/cloud-api/sessions/detected-env-vars.mdx
+++ b/docs/cloud-api/sessions/detected-env-vars.mdx
@@ -58,7 +58,7 @@ response = requests.get(
 
 for v in response.json()["detected_vars"]:
     status = "set" if v["has_value"] else "missing"
-    print(f"{v['key']} ({v['source']}) — {status}")
+    print(f"{v['key']} ({v['source']}) - {status}")
 ```
 
 ```javascript JavaScript
@@ -72,7 +72,7 @@ const response = await fetch(
 const { detected_vars } = await response.json();
 detected_vars.forEach((v) => {
   const status = v.has_value ? "set" : "missing";
-  console.log(`${v.key} (${v.source}) — ${status}`);
+  console.log(`${v.key} (${v.source}) - ${status}`);
 });
 ```
 </RequestExample>

--- a/docs/cloud-api/sessions/env-vars.mdx
+++ b/docs/cloud-api/sessions/env-vars.mdx
@@ -5,7 +5,7 @@ description: "Get, set, and delete env vars scoped to a single session"
 
 Manage environment variables that are scoped to one session. Variables set
 here are encrypted at rest, injected into terminal commands and dev servers
-via E2B's process-level env injection, and survive pause/resume.
+via process-level env injection, and survive pause/resume.
 
 For variables shared across many sessions, use
 [Personal Secrets](/cloud-api/secrets/personal-list) and

--- a/docs/cloud-api/sessions/get.mdx
+++ b/docs/cloud-api/sessions/get.mdx
@@ -85,7 +85,7 @@ response = requests.get(
 )
 
 session = response.json()
-print(f"{session['name']} — {session['state']}")
+print(f"{session['name']} - {session['state']}")
 ```
 
 ```javascript JavaScript
@@ -97,7 +97,7 @@ const response = await fetch(
 );
 
 const session = await response.json();
-console.log(`${session.name} — ${session.state}`);
+console.log(`${session.name} - ${session.state}`);
 ```
 </RequestExample>
 

--- a/docs/cloud-api/sessions/heartbeat.mdx
+++ b/docs/cloud-api/sessions/heartbeat.mdx
@@ -1,8 +1,12 @@
 ---
-title: "Heartbeat"
+title: "Heartbeat (legacy)"
 api: "POST /api/sessions/{session_id}/heartbeat"
-description: "Keep a session alive and reset the auto-pause timer"
+description: "Legacy keepalive endpoint — prefer the v2 refresh endpoint"
 ---
+
+<Warning>
+  **Deprecated.** This endpoint relies on a side-effect-based keepalive. New integrations should use [`POST /api/v2/sessions/{id}/refresh`](/cloud-api/sessions/v2-refresh), which extends the sandbox TTL explicitly via E2B's REST API.
+</Warning>
 
 Sends a heartbeat to keep the session alive. Resets the auto-pause timer so the session won't be automatically paused due to inactivity.
 

--- a/docs/cloud-api/sessions/heartbeat.mdx
+++ b/docs/cloud-api/sessions/heartbeat.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Heartbeat (legacy)"
 api: "POST /api/sessions/{session_id}/heartbeat"
-description: "Legacy keepalive endpoint — prefer the v2 refresh endpoint"
+description: "Legacy keepalive endpoint - prefer the v2 refresh endpoint"
 ---
 
 <Warning>
-  **Deprecated.** This endpoint relies on a side-effect-based keepalive. New integrations should use [`POST /api/v2/sessions/{id}/refresh`](/cloud-api/sessions/v2-refresh), which extends the sandbox TTL explicitly via E2B's REST API.
+  **Deprecated.** This endpoint relies on a side-effect-based keepalive. New integrations should use [`POST /api/v2/sessions/{id}/refresh`](/cloud-api/sessions/v2-refresh), which extends the sandbox TTL explicitly via the sandbox provider's REST API.
 </Warning>
 
 Sends a heartbeat to keep the session alive. Resets the auto-pause timer so the session won't be automatically paused due to inactivity.

--- a/docs/cloud-api/sessions/launch.mdx
+++ b/docs/cloud-api/sessions/launch.mdx
@@ -4,7 +4,7 @@ api: "POST /api/v0/sessions/launch"
 description: "Create a session and fire a prompt in one call"
 ---
 
-Creates a new cloud session, configures lifecycle policy, and fires the prompt as a background task. Returns immediately with the session ID — poll [`GET /api/v0/sessions/{id}`](/cloud-api/sessions/v0-get) for status via the `last_prompt` field.
+Creates a new cloud session, configures lifecycle policy, and fires the prompt as a background task. Returns immediately with the session ID - poll [`GET /api/v0/sessions/{id}`](/cloud-api/sessions/v0-get) for status via the `last_prompt` field.
 
 This is the core "fire and forget" endpoint for programmatic agent workflows. It's the recommended entry point for Slack triggers, Linear automations, GitHub Actions, MCP servers, and any other webhook-driven integration.
 

--- a/docs/cloud-api/sessions/launch.mdx
+++ b/docs/cloud-api/sessions/launch.mdx
@@ -1,14 +1,18 @@
 ---
-title: "Launch Agent"
+title: "Launch Agent (v0)"
 api: "POST /api/v0/sessions/launch"
 description: "Create a session and fire a prompt in one call"
 ---
 
-Creates a new cloud session, configures lifecycle policy, and fires the prompt as a background task. Returns immediately with the session ID — poll `GET /api/v0/sessions/{id}` for status via the `last_prompt` field.
+Creates a new cloud session, configures lifecycle policy, and fires the prompt as a background task. Returns immediately with the session ID — poll [`GET /api/v0/sessions/{id}`](/cloud-api/sessions/v0-get) for status via the `last_prompt` field.
 
-This is the core "fire and forget" endpoint for programmatic agent workflows.
+This is the core "fire and forget" endpoint for programmatic agent workflows. It's the recommended entry point for Slack triggers, Linear automations, GitHub Actions, MCP servers, and any other webhook-driven integration.
 
 **Required scopes:** `sessions:write` **and** `sessions:prompt`
+
+<Tip>
+  Need to follow up after launch? Use [`POST /api/v0/sessions/{id}/prompt`](/cloud-api/sessions/v0-prompt) to send another prompt (SSE stream), [`POST /api/v0/sessions/{id}/git`](/cloud-api/sessions/v0-git) to commit/push/open a PR, and [`DELETE /api/v0/sessions/{id}`](/cloud-api/sessions/v0-delete) to clean up.
+</Tip>
 
 ## Headers
 

--- a/docs/cloud-api/sessions/list.mdx
+++ b/docs/cloud-api/sessions/list.mdx
@@ -79,7 +79,7 @@ response = requests.get(
 
 data = response.json()
 for s in data["sessions"]:
-    print(f"{s['id']} — {s['name']} ({s['state']})")
+    print(f"{s['id']} - {s['name']} ({s['state']})")
 ```
 
 ```javascript JavaScript
@@ -97,7 +97,7 @@ const response = await fetch(
 
 const data = await response.json();
 data.sessions.forEach((s) =>
-  console.log(`${s.id} — ${s.name} (${s.state})`)
+  console.log(`${s.id} - ${s.name} (${s.state})`)
 );
 ```
 </RequestExample>

--- a/docs/cloud-api/sessions/start.mdx
+++ b/docs/cloud-api/sessions/start.mdx
@@ -1,8 +1,12 @@
 ---
-title: "Start Session"
+title: "Start Session (legacy)"
 api: "POST /api/sessions/{session_id}/start"
-description: "Cold-start a session that hasn't been started yet"
+description: "Legacy cold-start endpoint — prefer the v2 sandbox lifecycle endpoint"
 ---
+
+<Warning>
+  **Deprecated.** This endpoint conflates sandbox lifecycle with dev-server orchestration. New integrations should use [`POST /api/v2/sessions/{id}/start`](/cloud-api/sessions/v2-start), which only handles sandbox lifecycle, plus [`POST /api/v2/sessions/{id}/connect`](/cloud-api/sessions/v2-connect) when you need a preview URL for a specific port.
+</Warning>
 
 Cold-starts a session that was created but hasn't been started. Provisions the sandbox and transitions the session to `active`.
 

--- a/docs/cloud-api/sessions/start.mdx
+++ b/docs/cloud-api/sessions/start.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Start Session (legacy)"
 api: "POST /api/sessions/{session_id}/start"
-description: "Legacy cold-start endpoint — prefer the v2 sandbox lifecycle endpoint"
+description: "Legacy cold-start endpoint - prefer the v2 sandbox lifecycle endpoint"
 ---
 
 <Warning>

--- a/docs/cloud-api/sessions/v0-create.mdx
+++ b/docs/cloud-api/sessions/v0-create.mdx
@@ -1,0 +1,125 @@
+---
+title: "Create Session (v0)"
+api: "POST /api/v0/sessions"
+description: "Create a sandbox without sending a prompt"
+---
+
+Creates a new cloud session backed by an E2B sandbox. The session starts in `creating` state and transitions to `running` once the sandbox is provisioned.
+
+Use this when you need to set up a sandbox up-front and decide what prompt to send later. If you want to fire a prompt at the same time you create the session, use [`POST /api/v0/sessions/launch`](/cloud-api/sessions/launch) instead.
+
+**Required scope:** `sessions:write`
+
+## Headers
+
+<ParamField header="Authorization" type="string" required>
+  Bearer token. Example: `Bearer runtm_xxx`
+</ParamField>
+
+## Body
+
+<ParamField body="agent" type="string" default="claude-code">
+  Coding agent: `claude-code`, `codex`, `opencode`, `github-copilot`, `cursor-cli`, `devin-cli`, `gemini-cli`.
+</ParamField>
+
+<ParamField body="template" type="string">
+  Project template to scaffold: `web-app`, `backend-service`, `static-site`.
+</ParamField>
+
+<ParamField body="mode" type="string" default="autopilot">
+  Session mode: `autopilot` (auto-approve actions) or `interactive`.
+</ParamField>
+
+<ParamField body="github_repo" type="object">
+  GitHub repo metadata for tier selection. Shape: `{ "full_name": "owner/repo", "size_kb": 1024, "requires_docker": false, "has_docker_compose": false, "is_monorepo": false }`.
+</ParamField>
+
+<ParamField body="source" type="string" default="api">
+  Origin of the session, surfaced in telemetry. Defaults to `api` for programmatic callers.
+</ParamField>
+
+<ParamField body="on_complete" type="string">
+  Lifecycle action when prompts complete: `pause` (default), `destroy`, or `keep_alive`.
+</ParamField>
+
+<ParamField body="ttl_minutes" type="integer">
+  Maximum session lifetime in minutes (1–1440). Acts as a safety net for background agents.
+</ParamField>
+
+## Response
+
+Returns `201` with the created session.
+
+<ResponseField name="id" type="string">Session ID — use this for subsequent prompt/git/destroy calls.</ResponseField>
+<ResponseField name="state" type="string">Initial state (typically `creating`).</ResponseField>
+<ResponseField name="agent" type="string">Coding agent assigned to the session.</ResponseField>
+<ResponseField name="template" type="string | null">Template used.</ResponseField>
+<ResponseField name="created_at" type="string">ISO 8601 creation timestamp.</ResponseField>
+<ResponseField name="expires_at" type="string | null">TTL expiry, if `ttl_minutes` was set.</ResponseField>
+
+<RequestExample>
+```bash cURL
+curl -X POST "https://app.runtm.com/api/v0/sessions" \
+  -H "Authorization: Bearer runtm_xxx" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent": "claude-code",
+    "template": "backend-service",
+    "on_complete": "pause",
+    "ttl_minutes": 60
+  }'
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://app.runtm.com/api/v0/sessions",
+    headers={"Authorization": "Bearer runtm_xxx"},
+    json={
+        "agent": "claude-code",
+        "template": "backend-service",
+        "on_complete": "pause",
+        "ttl_minutes": 60,
+    },
+)
+
+session = response.json()
+print(f"Created: {session['id']} (state={session['state']})")
+```
+
+```javascript JavaScript
+const response = await fetch(
+  "https://app.runtm.com/api/v0/sessions",
+  {
+    method: "POST",
+    headers: {
+      "Authorization": "Bearer runtm_xxx",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      agent: "claude-code",
+      template: "backend-service",
+      on_complete: "pause",
+      ttl_minutes: 60,
+    }),
+  }
+);
+
+const session = await response.json();
+console.log(`Created: ${session.id} (state=${session.state})`);
+```
+</RequestExample>
+
+<ResponseExample>
+```json 201
+{
+  "id": "86e11104-cdbb-42c9-bdc3-5212024ddb7b",
+  "state": "creating",
+  "agent": "claude-code",
+  "template": "backend-service",
+  "created_at": "2026-05-09T21:00:00Z",
+  "expires_at": "2026-05-09T22:00:00Z"
+}
+```
+</ResponseExample>

--- a/docs/cloud-api/sessions/v0-create.mdx
+++ b/docs/cloud-api/sessions/v0-create.mdx
@@ -4,7 +4,7 @@ api: "POST /api/v0/sessions"
 description: "Create a sandbox without sending a prompt"
 ---
 
-Creates a new cloud session backed by an E2B sandbox. The session starts in `creating` state and transitions to `running` once the sandbox is provisioned.
+Creates a new cloud session backed by a sandbox. The session starts in `creating` state and transitions to `running` once the sandbox is provisioned.
 
 Use this when you need to set up a sandbox up-front and decide what prompt to send later. If you want to fire a prompt at the same time you create the session, use [`POST /api/v0/sessions/launch`](/cloud-api/sessions/launch) instead.
 
@@ -50,7 +50,7 @@ Use this when you need to set up a sandbox up-front and decide what prompt to se
 
 Returns `201` with the created session.
 
-<ResponseField name="id" type="string">Session ID — use this for subsequent prompt/git/destroy calls.</ResponseField>
+<ResponseField name="id" type="string">Session ID - use this for subsequent prompt/git/destroy calls.</ResponseField>
 <ResponseField name="state" type="string">Initial state (typically `creating`).</ResponseField>
 <ResponseField name="agent" type="string">Coding agent assigned to the session.</ResponseField>
 <ResponseField name="template" type="string | null">Template used.</ResponseField>

--- a/docs/cloud-api/sessions/v0-delete.mdx
+++ b/docs/cloud-api/sessions/v0-delete.mdx
@@ -1,0 +1,79 @@
+---
+title: "Destroy Session (v0)"
+api: "DELETE /api/v0/sessions/{session_id}"
+description: "Permanently destroy a session and clean up its sandbox"
+---
+
+Permanently destroys a session and tears down the underlying E2B sandbox. This is irreversible — files inside the sandbox are lost unless they were committed and pushed.
+
+For a reversible "stop" that preserves the sandbox state, use [`POST /api/sessions/{id}/pause`](/cloud-api/sessions/pause) instead.
+
+**Required scope:** `sessions:delete`
+
+## Path Parameters
+
+<ParamField path="session_id" type="string" required>
+  The session ID to destroy.
+</ParamField>
+
+## Headers
+
+<ParamField header="Authorization" type="string" required>
+  Bearer token. Example: `Bearer runtm_xxx`
+</ParamField>
+
+## Response
+
+`200 OK`.
+
+<ResponseField name="id" type="string">The destroyed session ID.</ResponseField>
+<ResponseField name="destroyed_at" type="string">ISO 8601 timestamp when destruction completed.</ResponseField>
+<ResponseField name="message" type="string">Confirmation message.</ResponseField>
+
+## Errors
+
+| Status | Meaning |
+|---|---|
+| `403` | API key does not own this session |
+| `404` | Session not found or already destroyed |
+| `500` | Sandbox teardown failed — retry once; if it persists the session may already be in a terminal state |
+
+<RequestExample>
+```bash cURL
+curl -X DELETE "https://app.runtm.com/api/v0/sessions/86e11104-..." \
+  -H "Authorization: Bearer runtm_xxx"
+```
+
+```python Python
+import requests
+
+response = requests.delete(
+    "https://app.runtm.com/api/v0/sessions/86e11104-...",
+    headers={"Authorization": "Bearer runtm_xxx"},
+)
+
+print(response.json()["message"])
+```
+
+```javascript JavaScript
+const response = await fetch(
+  "https://app.runtm.com/api/v0/sessions/86e11104-...",
+  {
+    method: "DELETE",
+    headers: { "Authorization": "Bearer runtm_xxx" },
+  }
+);
+
+console.log((await response.json()).message);
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200
+{
+  "id": "86e11104-cdbb-42c9-bdc3-5212024ddb7b",
+  "destroyed_at": "2026-05-09T22:00:00Z",
+  "message": "Session destroyed successfully"
+}
+```
+</ResponseExample>

--- a/docs/cloud-api/sessions/v0-delete.mdx
+++ b/docs/cloud-api/sessions/v0-delete.mdx
@@ -4,7 +4,7 @@ api: "DELETE /api/v0/sessions/{session_id}"
 description: "Permanently destroy a session and clean up its sandbox"
 ---
 
-Permanently destroys a session and tears down the underlying E2B sandbox. This is irreversible — files inside the sandbox are lost unless they were committed and pushed.
+Permanently destroys a session and tears down the underlying sandbox. This is irreversible. Files inside the sandbox are lost unless they were committed and pushed.
 
 For a reversible "stop" that preserves the sandbox state, use [`POST /api/sessions/{id}/pause`](/cloud-api/sessions/pause) instead.
 
@@ -36,7 +36,7 @@ For a reversible "stop" that preserves the sandbox state, use [`POST /api/sessio
 |---|---|
 | `403` | API key does not own this session |
 | `404` | Session not found or already destroyed |
-| `500` | Sandbox teardown failed — retry once; if it persists the session may already be in a terminal state |
+| `500` | Sandbox teardown failed - retry once; if it persists the session may already be in a terminal state |
 
 <RequestExample>
 ```bash cURL

--- a/docs/cloud-api/sessions/v0-get.mdx
+++ b/docs/cloud-api/sessions/v0-get.mdx
@@ -1,0 +1,149 @@
+---
+title: "Get Session Status (v0)"
+api: "GET /api/v0/sessions/{session_id}"
+description: "Polling-friendly status endpoint for background agents"
+---
+
+Returns the current state of a session along with `last_prompt` (the polling status of the most recent prompt), `prompt_history`, and `lifecycle` policy. This is the endpoint to poll after [`POST /api/v0/sessions/launch`](/cloud-api/sessions/launch) or after sending a prompt via [`POST /api/v0/sessions/{id}/prompt`](/cloud-api/sessions/v0-prompt).
+
+The response shape is intentionally different from [`GET /api/sessions/{id}`](/cloud-api/sessions/get) — v0 includes the polling fields needed for fire-and-forget agent workflows.
+
+**Required scope:** `sessions:read`
+
+## Path Parameters
+
+<ParamField path="session_id" type="string" required>
+  The session ID returned by `launch` or `create`.
+</ParamField>
+
+## Headers
+
+<ParamField header="Authorization" type="string" required>
+  Bearer token. Example: `Bearer runtm_xxx`
+</ParamField>
+
+## Response
+
+<ResponseField name="id" type="string">Session ID.</ResponseField>
+<ResponseField name="state" type="string">Sandbox state: `creating`, `running`, `paused`, `error`.</ResponseField>
+<ResponseField name="agent" type="string">Coding agent (e.g. `claude-code`).</ResponseField>
+<ResponseField name="template" type="string | null">Template the session was scaffolded from.</ResponseField>
+<ResponseField name="created_at" type="string">ISO 8601 creation timestamp.</ResponseField>
+<ResponseField name="expires_at" type="string | null">TTL expiry. `null` for `keep_alive` sessions.</ResponseField>
+<ResponseField name="total_cost_usd" type="number">Aggregate cost across all prompts.</ResponseField>
+<ResponseField name="prompt_count" type="integer">Number of prompts run in this session.</ResponseField>
+<ResponseField name="name" type="string | null">Display name.</ResponseField>
+<ResponseField name="github_repo" type="string | null">GitHub `owner/repo` link.</ResponseField>
+
+<ResponseField name="last_prompt" type="object | null">
+  Status of the most recent prompt — the primary polling field.
+
+  - **`status`** — `idle`, `running`, `completed`, `error`, `timed_out`
+  - **`prompt_preview`** — first 200 chars of the prompt
+  - **`model`** — model used (e.g. `sonnet`)
+  - **`started_at`** / **`completed_at`** — ISO 8601 timestamps
+  - **`cost_usd`** — cost in USD for this prompt
+  - **`summary`** — first 500 chars of the agent's final response
+  - **`error`** — error string if `status` is `error` or `timed_out`
+  - **`plan_mode`** — whether plan mode was enabled
+</ResponseField>
+
+<ResponseField name="prompt_history" type="array">
+  Ordered list of all prompts run in this session, each with the same shape as `last_prompt`.
+</ResponseField>
+
+<ResponseField name="lifecycle" type="object | null">
+  Lifecycle policy applied at launch:
+
+  - **`on_complete`** — `pause`, `destroy`, or `keep_alive`
+  - **`ttl_minutes`** — TTL in minutes
+  - **`ttl_expires_at`** — ISO 8601 expiry timestamp
+</ResponseField>
+
+## Polling pattern
+
+```python
+import requests, time
+
+session_id = "86e11104-..."
+while True:
+    status = requests.get(
+        f"https://app.runtm.com/api/v0/sessions/{session_id}",
+        headers={"Authorization": "Bearer runtm_xxx"},
+    ).json()
+
+    last = status.get("last_prompt") or {}
+    if last.get("status") in ("completed", "error", "timed_out"):
+        print(f"Done: {last['status']} (${last.get('cost_usd', 0):.4f})")
+        print(last.get("summary"))
+        break
+
+    time.sleep(5)
+```
+
+For high-volume agents, use [webhooks](/guides/webhooks-and-triggers) instead of polling.
+
+<RequestExample>
+```bash cURL
+curl "https://app.runtm.com/api/v0/sessions/86e11104-cdbb-42c9-bdc3-5212024ddb7b" \
+  -H "Authorization: Bearer runtm_xxx"
+```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://app.runtm.com/api/v0/sessions/86e11104-cdbb-42c9-bdc3-5212024ddb7b",
+    headers={"Authorization": "Bearer runtm_xxx"},
+)
+
+session = response.json()
+print(f"State: {session['state']}")
+print(f"Last prompt: {(session.get('last_prompt') or {}).get('status', 'idle')}")
+```
+
+```javascript JavaScript
+const response = await fetch(
+  "https://app.runtm.com/api/v0/sessions/86e11104-cdbb-42c9-bdc3-5212024ddb7b",
+  { headers: { "Authorization": "Bearer runtm_xxx" } }
+);
+
+const session = await response.json();
+console.log(`State: ${session.state}`);
+console.log(`Last prompt: ${(session.last_prompt || {}).status || "idle"}`);
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200
+{
+  "id": "86e11104-cdbb-42c9-bdc3-5212024ddb7b",
+  "state": "running",
+  "agent": "claude-code",
+  "template": "backend-service",
+  "created_at": "2026-05-09T21:00:00Z",
+  "expires_at": "2026-05-09T22:00:00Z",
+  "total_cost_usd": 0.23,
+  "prompt_count": 1,
+  "name": "Refactor billing service",
+  "github_repo": "acme/billing",
+  "last_prompt": {
+    "status": "completed",
+    "prompt_preview": "Build a REST API with FastAPI that manages TODO items",
+    "model": "sonnet",
+    "started_at": "2026-05-09T21:00:30Z",
+    "completed_at": "2026-05-09T21:04:12Z",
+    "cost_usd": 0.23,
+    "summary": "Created FastAPI app at /home/user/main.py with CRUD endpoints…",
+    "error": null,
+    "plan_mode": false
+  },
+  "prompt_history": [],
+  "lifecycle": {
+    "on_complete": "pause",
+    "ttl_minutes": 60,
+    "ttl_expires_at": "2026-05-09T22:00:00Z"
+  }
+}
+```
+</ResponseExample>

--- a/docs/cloud-api/sessions/v0-get.mdx
+++ b/docs/cloud-api/sessions/v0-get.mdx
@@ -6,7 +6,7 @@ description: "Polling-friendly status endpoint for background agents"
 
 Returns the current state of a session along with `last_prompt` (the polling status of the most recent prompt), `prompt_history`, and `lifecycle` policy. This is the endpoint to poll after [`POST /api/v0/sessions/launch`](/cloud-api/sessions/launch) or after sending a prompt via [`POST /api/v0/sessions/{id}/prompt`](/cloud-api/sessions/v0-prompt).
 
-The response shape is intentionally different from [`GET /api/sessions/{id}`](/cloud-api/sessions/get) — v0 includes the polling fields needed for fire-and-forget agent workflows.
+The response shape is intentionally different from [`GET /api/sessions/{id}`](/cloud-api/sessions/get) - v0 includes the polling fields needed for fire-and-forget agent workflows.
 
 **Required scope:** `sessions:read`
 
@@ -36,16 +36,16 @@ The response shape is intentionally different from [`GET /api/sessions/{id}`](/c
 <ResponseField name="github_repo" type="string | null">GitHub `owner/repo` link.</ResponseField>
 
 <ResponseField name="last_prompt" type="object | null">
-  Status of the most recent prompt — the primary polling field.
+  Status of the most recent prompt - the primary polling field.
 
-  - **`status`** — `idle`, `running`, `completed`, `error`, `timed_out`
-  - **`prompt_preview`** — first 200 chars of the prompt
-  - **`model`** — model used (e.g. `sonnet`)
-  - **`started_at`** / **`completed_at`** — ISO 8601 timestamps
-  - **`cost_usd`** — cost in USD for this prompt
-  - **`summary`** — first 500 chars of the agent's final response
-  - **`error`** — error string if `status` is `error` or `timed_out`
-  - **`plan_mode`** — whether plan mode was enabled
+  - **`status`** - `idle`, `running`, `completed`, `error`, `timed_out`
+  - **`prompt_preview`** - first 200 chars of the prompt
+  - **`model`** - model used (e.g. `sonnet`)
+  - **`started_at`** / **`completed_at`** - ISO 8601 timestamps
+  - **`cost_usd`** - cost in USD for this prompt
+  - **`summary`** - first 500 chars of the agent's final response
+  - **`error`** - error string if `status` is `error` or `timed_out`
+  - **`plan_mode`** - whether plan mode was enabled
 </ResponseField>
 
 <ResponseField name="prompt_history" type="array">
@@ -55,9 +55,9 @@ The response shape is intentionally different from [`GET /api/sessions/{id}`](/c
 <ResponseField name="lifecycle" type="object | null">
   Lifecycle policy applied at launch:
 
-  - **`on_complete`** — `pause`, `destroy`, or `keep_alive`
-  - **`ttl_minutes`** — TTL in minutes
-  - **`ttl_expires_at`** — ISO 8601 expiry timestamp
+  - **`on_complete`** - `pause`, `destroy`, or `keep_alive`
+  - **`ttl_minutes`** - TTL in minutes
+  - **`ttl_expires_at`** - ISO 8601 expiry timestamp
 </ResponseField>
 
 ## Polling pattern

--- a/docs/cloud-api/sessions/v0-git.mdx
+++ b/docs/cloud-api/sessions/v0-git.mdx
@@ -1,0 +1,135 @@
+---
+title: "Git Operation (v0)"
+api: "POST /api/v0/sessions/{session_id}/git"
+description: "Run a git operation inside the sandbox (commit, push, create PR, etc.)"
+---
+
+Executes a git operation inside the sandbox's workspace — typically used by background agents to push their work and open a pull request after completing a task.
+
+The session must be in `running` state.
+
+**Required scope:** `sessions:write`
+
+## Path Parameters
+
+<ParamField path="session_id" type="string" required>
+  The session ID.
+</ParamField>
+
+## Headers
+
+<ParamField header="Authorization" type="string" required>
+  Bearer token. Example: `Bearer runtm_xxx`
+</ParamField>
+
+## Body
+
+<ParamField body="operation" type="string" required>
+  One of: `status`, `commit`, `push`, `pull`, `sync`, `create_branch`, `switch_branch`, `list_branches`, `create_pr`, `create_branch_and_pr`, `init_repo`.
+</ParamField>
+
+<ParamField body="working_dir" type="string" default="/home/user">
+  Directory containing the git repository inside the sandbox.
+</ParamField>
+
+<ParamField body="message" type="string">
+  Commit message — required when `operation` is `commit`.
+</ParamField>
+
+<ParamField body="branch" type="string">
+  Branch name — for `create_branch` / `switch_branch`.
+</ParamField>
+
+<ParamField body="branch_search" type="string">
+  Search filter for `list_branches`.
+</ParamField>
+
+<ParamField body="pr_title" type="string">
+  Pull request title — required for `create_pr` and `create_branch_and_pr`.
+</ParamField>
+
+<ParamField body="pr_body" type="string">
+  Pull request body.
+</ParamField>
+
+<ParamField body="pr_base" type="string">
+  Base branch for the PR. Defaults to the repository's default branch.
+</ParamField>
+
+<ParamField body="branch_session_id" type="string">
+  Session ID to derive the branch name from when using `create_branch_and_pr`.
+</ParamField>
+
+## Response
+
+<ResponseField name="success" type="boolean">Whether the operation succeeded.</ResponseField>
+<ResponseField name="operation" type="string">The operation that was attempted.</ResponseField>
+<ResponseField name="output" type="string | null">Stdout/stderr from git.</ResponseField>
+<ResponseField name="error" type="string | null">Error message if `success` is false.</ResponseField>
+
+Status-specific fields populated when relevant:
+
+<ResponseField name="is_git_repo" type="boolean">For `status`: whether `working_dir` is a git repo.</ResponseField>
+<ResponseField name="current_branch" type="string">Current branch name.</ResponseField>
+<ResponseField name="default_branch" type="string">Repo's default branch.</ResponseField>
+<ResponseField name="has_changes" type="boolean">Whether there are uncommitted changes.</ResponseField>
+<ResponseField name="ahead" type="integer">Commits ahead of upstream.</ResponseField>
+<ResponseField name="behind" type="integer">Commits behind upstream.</ResponseField>
+<ResponseField name="repo_full_name" type="string">GitHub `owner/repo` (after `init_repo` or when remote is set).</ResponseField>
+<ResponseField name="repo_url" type="string">HTTPS URL of the GitHub repo.</ResponseField>
+<ResponseField name="pr_url" type="string">URL of the created PR (after `create_pr` / `create_branch_and_pr`).</ResponseField>
+<ResponseField name="pr_number" type="integer">PR number.</ResponseField>
+<ResponseField name="created_branch" type="string">Branch that was created (for `create_branch_and_pr`).</ResponseField>
+<ResponseField name="branches" type="array">List of branch names (for `list_branches`).</ResponseField>
+
+<RequestExample>
+```bash cURL Create branch and PR
+curl -X POST "https://app.runtm.com/api/v0/sessions/86e11104-.../git" \
+  -H "Authorization: Bearer runtm_xxx" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "create_branch_and_pr",
+    "working_dir": "/home/user/project",
+    "pr_title": "Add /health endpoint",
+    "pr_body": "Adds a simple health check endpoint that returns 200."
+  }'
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://app.runtm.com/api/v0/sessions/86e11104-.../git",
+    headers={"Authorization": "Bearer runtm_xxx"},
+    json={
+        "operation": "create_branch_and_pr",
+        "working_dir": "/home/user/project",
+        "pr_title": "Add /health endpoint",
+        "pr_body": "Adds a simple health check endpoint.",
+    },
+)
+
+result = response.json()
+if result["success"]:
+    print(f"PR opened: {result['pr_url']}")
+else:
+    print(f"Failed: {result['error']}")
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200
+{
+  "success": true,
+  "operation": "create_branch_and_pr",
+  "output": "Created branch agent/86e11104 and pushed",
+  "current_branch": "agent/86e11104",
+  "default_branch": "main",
+  "repo_full_name": "acme/billing",
+  "repo_url": "https://github.com/acme/billing",
+  "created_branch": "agent/86e11104",
+  "pr_url": "https://github.com/acme/billing/pull/42",
+  "pr_number": 42
+}
+```
+</ResponseExample>

--- a/docs/cloud-api/sessions/v0-git.mdx
+++ b/docs/cloud-api/sessions/v0-git.mdx
@@ -4,7 +4,7 @@ api: "POST /api/v0/sessions/{session_id}/git"
 description: "Run a git operation inside the sandbox (commit, push, create PR, etc.)"
 ---
 
-Executes a git operation inside the sandbox's workspace — typically used by background agents to push their work and open a pull request after completing a task.
+Executes a git operation inside the sandbox's workspace - typically used by background agents to push their work and open a pull request after completing a task.
 
 The session must be in `running` state.
 
@@ -33,11 +33,11 @@ The session must be in `running` state.
 </ParamField>
 
 <ParamField body="message" type="string">
-  Commit message — required when `operation` is `commit`.
+  Commit message - required when `operation` is `commit`.
 </ParamField>
 
 <ParamField body="branch" type="string">
-  Branch name — for `create_branch` / `switch_branch`.
+  Branch name - for `create_branch` / `switch_branch`.
 </ParamField>
 
 <ParamField body="branch_search" type="string">
@@ -45,7 +45,7 @@ The session must be in `running` state.
 </ParamField>
 
 <ParamField body="pr_title" type="string">
-  Pull request title — required for `create_pr` and `create_branch_and_pr`.
+  Pull request title - required for `create_pr` and `create_branch_and_pr`.
 </ParamField>
 
 <ParamField body="pr_body" type="string">

--- a/docs/cloud-api/sessions/v0-list.mdx
+++ b/docs/cloud-api/sessions/v0-list.mdx
@@ -1,0 +1,113 @@
+---
+title: "List Sessions (v0)"
+api: "GET /api/v0/sessions"
+description: "List sessions owned by the authenticated API key with poll-friendly fields"
+---
+
+Returns a paginated list of sessions for the authenticated API key. The v0 list response includes `total_cost_usd`, `expires_at`, and a `source` field optimized for programmatic agent dashboards.
+
+For the dashboard-style list (different shape, includes `last_activity_at`, `prompt_count`, etc.), use [`GET /api/sessions`](/cloud-api/sessions/list).
+
+**Required scope:** `sessions:read`
+
+## Query Parameters
+
+<ParamField query="limit" type="integer" default="20">
+  Number of results to return (1–100).
+</ParamField>
+
+<ParamField query="offset" type="integer" default="0">
+  Number of results to skip for pagination.
+</ParamField>
+
+<ParamField query="state" type="string">
+  Filter by session state: `creating`, `running`, `paused`, `error`. When omitted, destroyed/destroying sessions are excluded.
+</ParamField>
+
+## Headers
+
+<ParamField header="Authorization" type="string" required>
+  Bearer token. Example: `Bearer runtm_xxx`
+</ParamField>
+
+## Response
+
+<ResponseField name="sessions" type="array">
+  Array of compact session objects (see fields below).
+</ResponseField>
+
+<ResponseField name="total" type="integer">
+  Total number of matching sessions for the authenticated key.
+</ResponseField>
+
+<ResponseField name="has_more" type="boolean">
+  Whether more results exist beyond `offset + limit`.
+</ResponseField>
+
+### Session item fields
+
+<ResponseField name="id" type="string">Session ID.</ResponseField>
+<ResponseField name="state" type="string">Current state: `creating`, `running`, `paused`, `error`.</ResponseField>
+<ResponseField name="agent" type="string">Coding agent (e.g. `claude-code`).</ResponseField>
+<ResponseField name="template" type="string | null">Template the session was scaffolded from.</ResponseField>
+<ResponseField name="name" type="string | null">Display name.</ResponseField>
+<ResponseField name="created_at" type="string">ISO 8601 creation timestamp.</ResponseField>
+<ResponseField name="expires_at" type="string | null">ISO 8601 TTL expiry. `null` for `keep_alive` sessions.</ResponseField>
+<ResponseField name="total_cost_usd" type="number">Aggregate cost across all prompts in this session.</ResponseField>
+<ResponseField name="github_repo" type="string | null">GitHub `owner/repo` if the session is linked to a repo.</ResponseField>
+<ResponseField name="source" type="string | null">How the session was created (`api`, `agents`, `slack`, `linear`, `web_ui`).</ResponseField>
+
+<RequestExample>
+```bash cURL
+curl "https://app.runtm.com/api/v0/sessions?limit=10&state=running" \
+  -H "Authorization: Bearer runtm_xxx"
+```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://app.runtm.com/api/v0/sessions",
+    headers={"Authorization": "Bearer runtm_xxx"},
+    params={"limit": 10, "state": "running"},
+)
+
+for s in response.json()["sessions"]:
+    print(f"{s['id']} {s['state']} ${s['total_cost_usd']:.4f}")
+```
+
+```javascript JavaScript
+const params = new URLSearchParams({ limit: "10", state: "running" });
+
+const response = await fetch(
+  `https://app.runtm.com/api/v0/sessions?${params}`,
+  { headers: { "Authorization": "Bearer runtm_xxx" } }
+);
+
+const { sessions } = await response.json();
+sessions.forEach((s) => console.log(`${s.id} ${s.state} $${s.total_cost_usd}`));
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200
+{
+  "sessions": [
+    {
+      "id": "86e11104-cdbb-42c9-bdc3-5212024ddb7b",
+      "state": "running",
+      "agent": "claude-code",
+      "template": "backend-service",
+      "name": "Refactor billing service",
+      "created_at": "2026-05-09T21:00:00Z",
+      "expires_at": "2026-05-09T22:00:00Z",
+      "total_cost_usd": 0.23,
+      "github_repo": "acme/billing",
+      "source": "api"
+    }
+  ],
+  "total": 1,
+  "has_more": false
+}
+```
+</ResponseExample>

--- a/docs/cloud-api/sessions/v0-prompt.mdx
+++ b/docs/cloud-api/sessions/v0-prompt.mdx
@@ -8,7 +8,7 @@ Sends a prompt to a session that is already in `running` state. The response is 
 
 Use this when you want to stream output in real time. If you'd rather kick off the prompt as a background task and poll for completion, [`POST /api/v0/sessions/launch`](/cloud-api/sessions/launch) and then poll [`GET /api/v0/sessions/{id}`](/cloud-api/sessions/v0-get) is the better pattern.
 
-The session must be in `running` state — call [`POST /api/v0/sessions`](/cloud-api/sessions/v0-create) first if you haven't already.
+The session must be in `running` state - call [`POST /api/v0/sessions`](/cloud-api/sessions/v0-create) first if you haven't already.
 
 **Required scope:** `sessions:prompt`
 
@@ -39,7 +39,7 @@ The session must be in `running` state — call [`POST /api/v0/sessions`](/cloud
 </ParamField>
 
 <ParamField body="plan_mode" type="boolean" default={false}>
-  Run in plan mode (read-only — agent analyzes without making changes).
+  Run in plan mode (read-only - agent analyzes without making changes).
 </ParamField>
 
 <ParamField body="continue_session" type="string">
@@ -72,7 +72,7 @@ Common `event_type` values:
 | `tool_use` | Tool invocation (file edit, bash command, etc.) |
 | `tool_result` | Tool output |
 | `result` | Final result with `cost_usd` metadata |
-| `error` | Fatal error — stream terminates |
+| `error` | Fatal error - stream terminates |
 | `done` | Stream complete (always last event) |
 
 ## Example

--- a/docs/cloud-api/sessions/v0-prompt.mdx
+++ b/docs/cloud-api/sessions/v0-prompt.mdx
@@ -1,0 +1,148 @@
+---
+title: "Send Prompt (v0)"
+api: "POST /api/v0/sessions/{session_id}/prompt"
+description: "Send a follow-up prompt to a running session and stream the response over SSE"
+---
+
+Sends a prompt to a session that is already in `running` state. The response is a Server-Sent Events (SSE) stream of the agent's output (tool calls, plan, intermediate results) terminated by a `done` event.
+
+Use this when you want to stream output in real time. If you'd rather kick off the prompt as a background task and poll for completion, [`POST /api/v0/sessions/launch`](/cloud-api/sessions/launch) and then poll [`GET /api/v0/sessions/{id}`](/cloud-api/sessions/v0-get) is the better pattern.
+
+The session must be in `running` state — call [`POST /api/v0/sessions`](/cloud-api/sessions/v0-create) first if you haven't already.
+
+**Required scope:** `sessions:prompt`
+
+## Path Parameters
+
+<ParamField path="session_id" type="string" required>
+  The session ID.
+</ParamField>
+
+## Headers
+
+<ParamField header="Authorization" type="string" required>
+  Bearer token. Example: `Bearer runtm_xxx`
+</ParamField>
+
+<ParamField header="Accept" type="string">
+  `text/event-stream` (recommended for SSE clients).
+</ParamField>
+
+## Body
+
+<ParamField body="prompt" type="string" required>
+  The prompt to send (0–100,000 characters).
+</ParamField>
+
+<ParamField body="model" type="string">
+  Model override: `sonnet`, `opus`, `haiku`, `opusplan`. Defaults to `sonnet`.
+</ParamField>
+
+<ParamField body="plan_mode" type="boolean" default={false}>
+  Run in plan mode (read-only — agent analyzes without making changes).
+</ParamField>
+
+<ParamField body="continue_session" type="string">
+  Claude Code session ID for conversation continuity.
+</ParamField>
+
+<ParamField body="new_session" type="boolean" default={false}>
+  Force a new agent session instead of resuming the previous one.
+</ParamField>
+
+<ParamField body="attachments" type="array">
+  Up to 5 base64-encoded files included as content blocks. Each entry: `{ "filename": "diagram.png", "media_type": "image/png", "data": "<base64>" }`.
+</ParamField>
+
+## Response
+
+`200 text/event-stream`. Each event has the shape:
+
+```
+event: <event_type>
+data: <json>
+
+```
+
+Common `event_type` values:
+
+| Event | Meaning |
+|---|---|
+| `assistant_message` | Streaming text from the agent |
+| `tool_use` | Tool invocation (file edit, bash command, etc.) |
+| `tool_result` | Tool output |
+| `result` | Final result with `cost_usd` metadata |
+| `error` | Fatal error — stream terminates |
+| `done` | Stream complete (always last event) |
+
+## Example
+
+<RequestExample>
+```bash cURL
+curl -N -X POST "https://app.runtm.com/api/v0/sessions/86e11104-.../prompt" \
+  -H "Authorization: Bearer runtm_xxx" \
+  -H "Accept: text/event-stream" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Add a /health endpoint that returns 200"}'
+```
+
+```python Python
+import requests
+
+with requests.post(
+    "https://app.runtm.com/api/v0/sessions/86e11104-.../prompt",
+    headers={
+        "Authorization": "Bearer runtm_xxx",
+        "Accept": "text/event-stream",
+    },
+    json={"prompt": "Add a /health endpoint that returns 200"},
+    stream=True,
+) as response:
+    for line in response.iter_lines():
+        if line:
+            print(line.decode())
+```
+
+```javascript JavaScript
+const response = await fetch(
+  "https://app.runtm.com/api/v0/sessions/86e11104-.../prompt",
+  {
+    method: "POST",
+    headers: {
+      "Authorization": "Bearer runtm_xxx",
+      "Accept": "text/event-stream",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ prompt: "Add a /health endpoint that returns 200" }),
+  }
+);
+
+const reader = response.body.getReader();
+const decoder = new TextDecoder();
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  process.stdout.write(decoder.decode(value));
+}
+```
+</RequestExample>
+
+<ResponseExample>
+```text 200
+event: assistant_message
+data: {"type":"assistant_message","content":"I'll add a /health endpoint…"}
+
+event: tool_use
+data: {"type":"tool_use","name":"Edit","input":{"file":"main.py"}}
+
+event: tool_result
+data: {"type":"tool_result","content":"File updated"}
+
+event: result
+data: {"type":"result","content":"Added /health endpoint","metadata":{"cost_usd":0.018}}
+
+event: done
+data: {"type":"done","message":"Stream complete"}
+
+```
+</ResponseExample>

--- a/docs/cloud-api/sessions/v2-connect.mdx
+++ b/docs/cloud-api/sessions/v2-connect.mdx
@@ -8,8 +8,8 @@ Returns a preview URL backed by a running service on the sandbox at the requeste
 
 The endpoint is idempotent and self-healing:
 
-- Reconciles the DB state with E2B (handles raw-URL auto-resume).
-- Resumes the sandbox if E2B reports it as paused.
+- Reconciles the DB state with the sandbox provider (handles raw-URL auto-resume).
+- Resumes the sandbox if the provider reports it as paused.
 - Starts or verifies the dev server (no-ops if already responding).
 - Persists `session.preview_url` and cached project metadata so Slack/agent callbacks can reuse the verified URL.
 

--- a/docs/cloud-api/sessions/v2-connect.mdx
+++ b/docs/cloud-api/sessions/v2-connect.mdx
@@ -90,7 +90,7 @@ console.log(`Preview at ${preview_url} (port ${port})`);
 <ResponseExample>
 ```json 200
 {
-  "preview_url": "https://3000-sb-xyz.e2b.app",
+  "preview_url": "https://3000-sb-xyz.dev.runtm.com",
   "port": 3000
 }
 ```

--- a/docs/cloud-api/sessions/v2-connect.mdx
+++ b/docs/cloud-api/sessions/v2-connect.mdx
@@ -1,0 +1,97 @@
+---
+title: "Get Preview URL for a Service (v2)"
+api: "POST /api/v2/sessions/{session_id}/connect"
+description: "Resolve a preview URL for a specific port on the sandbox"
+---
+
+Returns a preview URL backed by a running service on the sandbox at the requested port. This powers multi-port preview tabs in the workspace UI.
+
+The endpoint is idempotent and self-healing:
+
+- Reconciles the DB state with E2B (handles raw-URL auto-resume).
+- Resumes the sandbox if E2B reports it as paused.
+- Starts or verifies the dev server (no-ops if already responding).
+- Persists `session.preview_url` and cached project metadata so Slack/agent callbacks can reuse the verified URL.
+
+The list of available named services is exposed on the session's [`services` field](/cloud-api/sessions/v2-start) (e.g. `{ "frontend": 3000, "postgres": 5432 }`).
+
+**Required scope:** `sessions:write`
+
+## Path Parameters
+
+<ParamField path="session_id" type="string" required>
+  The session ID.
+</ParamField>
+
+## Query Parameters
+
+<ParamField query="port" type="integer" required>
+  The port number to expose. Must match a port the sandbox process is actually listening on.
+</ParamField>
+
+## Headers
+
+<ParamField header="Authorization" type="string" required>
+  Bearer token. Example: `Bearer runtm_xxx`
+</ParamField>
+
+<ParamField header="X-Organization-Id" type="string">
+  Required when the session belongs to an organization.
+</ParamField>
+
+## Response
+
+<ResponseField name="preview_url" type="string">
+  Public preview URL pointing at the sandbox port.
+</ResponseField>
+
+<ResponseField name="port" type="integer">
+  The port that was resolved.
+</ResponseField>
+
+## Errors
+
+| Status | Meaning |
+|---|---|
+| `404` | Session not found |
+| `410` | Sandbox has expired or is in an invalid state |
+| `502` | Could not resolve preview (port not listening, dev-server failed to start within 120s) |
+
+<RequestExample>
+```bash cURL
+curl -X POST "https://app.runtm.com/api/v2/sessions/86e11104-.../connect?port=3000" \
+  -H "Authorization: Bearer runtm_xxx"
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://app.runtm.com/api/v2/sessions/86e11104-.../connect",
+    headers={"Authorization": "Bearer runtm_xxx"},
+    params={"port": 3000},
+)
+
+data = response.json()
+print(f"Preview at {data['preview_url']}")
+```
+
+```javascript JavaScript
+const response = await fetch(
+  "https://app.runtm.com/api/v2/sessions/86e11104-.../connect?port=3000",
+  { method: "POST", headers: { "Authorization": "Bearer runtm_xxx" } }
+);
+
+const { preview_url, port } = await response.json();
+console.log(`Preview at ${preview_url} (port ${port})`);
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200
+{
+  "preview_url": "https://3000-sb-xyz.e2b.app",
+  "port": 3000
+}
+```
+</ResponseExample>

--- a/docs/cloud-api/sessions/v2-patch.mdx
+++ b/docs/cloud-api/sessions/v2-patch.mdx
@@ -1,0 +1,123 @@
+---
+title: "Update Session Tabs (v2)"
+api: "PATCH /api/v2/sessions/{session_id}"
+description: "Partial update for a session — currently supports the agent tab list"
+---
+
+Partial update for a session. Currently the only supported field is `tabs` — the ordered list of agent chat tabs that appears in the workspace.
+
+The `tabs` list is a **full replacement**: include every tab you want to keep, in the desired order. Each entry must have a UUID `id` and a non-empty `name`.
+
+**Required scope:** `sessions:write`
+
+## Path Parameters
+
+<ParamField path="session_id" type="string" required>
+  The session ID.
+</ParamField>
+
+## Headers
+
+<ParamField header="Authorization" type="string" required>
+  Bearer token. Example: `Bearer runtm_xxx`
+</ParamField>
+
+<ParamField header="X-Organization-Id" type="string">
+  Required when the session belongs to an organization.
+</ParamField>
+
+## Body
+
+<ParamField body="tabs" type="array" required>
+  Ordered list of tab objects. Full replacement — anything omitted is dropped.
+
+  Each entry:
+
+  - **`id`** (string, required) — UUID v4
+  - **`name`** (string, required) — non-empty display name
+</ParamField>
+
+## Validation rules
+
+- At least one tab must remain (empty list returns `400`).
+- Every `id` must be a valid UUID.
+- No duplicate `id`s.
+- Every `name` must be non-empty.
+
+## Response
+
+Returns the persisted tabs list.
+
+<ResponseField name="tabs" type="array">
+  The tabs after the update, in order.
+</ResponseField>
+
+## Errors
+
+| Status | Meaning |
+|---|---|
+| `400` | Empty list, invalid UUID, blank name, or duplicate id |
+| `404` | Session not found |
+
+<RequestExample>
+```bash cURL Rename a tab
+curl -X PATCH "https://app.runtm.com/api/v2/sessions/86e11104-..." \
+  -H "Authorization: Bearer runtm_xxx" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tabs": [
+      { "id": "86e11104-cdbb-42c9-bdc3-5212024ddb7b", "name": "Backend" },
+      { "id": "9f1a3b22-1cdf-4f8e-ae06-9e4ad7a2cd11", "name": "Frontend" }
+    ]
+  }'
+```
+
+```python Python
+import requests
+
+response = requests.patch(
+    "https://app.runtm.com/api/v2/sessions/86e11104-...",
+    headers={"Authorization": "Bearer runtm_xxx"},
+    json={
+        "tabs": [
+            {"id": "86e11104-cdbb-42c9-bdc3-5212024ddb7b", "name": "Backend"},
+            {"id": "9f1a3b22-1cdf-4f8e-ae06-9e4ad7a2cd11", "name": "Frontend"},
+        ]
+    },
+)
+
+print(response.json()["tabs"])
+```
+
+```javascript JavaScript
+const response = await fetch(
+  "https://app.runtm.com/api/v2/sessions/86e11104-...",
+  {
+    method: "PATCH",
+    headers: {
+      "Authorization": "Bearer runtm_xxx",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      tabs: [
+        { id: "86e11104-cdbb-42c9-bdc3-5212024ddb7b", name: "Backend" },
+        { id: "9f1a3b22-1cdf-4f8e-ae06-9e4ad7a2cd11", name: "Frontend" },
+      ],
+    }),
+  }
+);
+
+console.log((await response.json()).tabs);
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200
+{
+  "tabs": [
+    { "id": "86e11104-cdbb-42c9-bdc3-5212024ddb7b", "name": "Backend" },
+    { "id": "9f1a3b22-1cdf-4f8e-ae06-9e4ad7a2cd11", "name": "Frontend" }
+  ]
+}
+```
+</ResponseExample>

--- a/docs/cloud-api/sessions/v2-patch.mdx
+++ b/docs/cloud-api/sessions/v2-patch.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Update Session Tabs (v2)"
 api: "PATCH /api/v2/sessions/{session_id}"
-description: "Partial update for a session — currently supports the agent tab list"
+description: "Partial update for a session - currently supports the agent tab list"
 ---
 
-Partial update for a session. Currently the only supported field is `tabs` — the ordered list of agent chat tabs that appears in the workspace.
+Partial update for a session. Currently the only supported field is `tabs` - the ordered list of agent chat tabs that appears in the workspace.
 
 The `tabs` list is a **full replacement**: include every tab you want to keep, in the desired order. Each entry must have a UUID `id` and a non-empty `name`.
 
@@ -29,12 +29,12 @@ The `tabs` list is a **full replacement**: include every tab you want to keep, i
 ## Body
 
 <ParamField body="tabs" type="array" required>
-  Ordered list of tab objects. Full replacement — anything omitted is dropped.
+  Ordered list of tab objects. Full replacement - anything omitted is dropped.
 
   Each entry:
 
-  - **`id`** (string, required) — UUID v4
-  - **`name`** (string, required) — non-empty display name
+  - **`id`** (string, required) - UUID v4
+  - **`name`** (string, required) - non-empty display name
 </ParamField>
 
 ## Validation rules

--- a/docs/cloud-api/sessions/v2-refresh.mdx
+++ b/docs/cloud-api/sessions/v2-refresh.mdx
@@ -1,0 +1,85 @@
+---
+title: "Refresh Sandbox TTL (v2)"
+api: "POST /api/v2/sessions/{session_id}/refresh"
+description: "Extend the sandbox TTL — the v2 keepalive that replaces /heartbeat"
+---
+
+Extends the sandbox's idle timeout so it stays alive while the user is interacting. Call this periodically (e.g. every 5 minutes) while a workspace tab is open.
+
+This is the v2 replacement for the legacy [`POST /api/sessions/{session_id}/heartbeat`](/cloud-api/sessions/heartbeat). Unlike heartbeat, `/refresh` does not rely on `AsyncSandbox.connect()` as a side-effect-based keepalive — it explicitly extends the TTL via E2B's REST API.
+
+The session must be in `running` state.
+
+**Required scope:** `sessions:write`
+
+## Path Parameters
+
+<ParamField path="session_id" type="string" required>
+  The session ID.
+</ParamField>
+
+## Headers
+
+<ParamField header="Authorization" type="string" required>
+  Bearer token. Example: `Bearer runtm_xxx`
+</ParamField>
+
+<ParamField header="X-Organization-Id" type="string">
+  Required when the session belongs to an organization.
+</ParamField>
+
+## Behavior
+
+- Extends the sandbox TTL by `idle_timeout_minutes * 60` seconds (default 30 minutes).
+- E2B caps duration at 3600s, so longer values are clamped.
+- Reconciles with E2B before checking state. If the sandbox has been paused or expired between calls, returns an error so the caller can re-`start` the session.
+
+## Response
+
+<ResponseField name="ok" type="boolean">
+  Always `true` on success.
+</ResponseField>
+
+## Errors
+
+| Status | Meaning |
+|---|---|
+| `400` | Session is not in `running` state, or has no sandbox |
+| `404` | Session not found |
+| `502` | E2B refresh call failed |
+
+<RequestExample>
+```bash cURL
+curl -X POST "https://app.runtm.com/api/v2/sessions/86e11104-.../refresh" \
+  -H "Authorization: Bearer runtm_xxx"
+```
+
+```python Python
+import requests, time
+
+session_id = "86e11104-cdbb-42c9-bdc3-5212024ddb7b"
+while True:
+    requests.post(
+        f"https://app.runtm.com/api/v2/sessions/{session_id}/refresh",
+        headers={"Authorization": "Bearer runtm_xxx"},
+    )
+    time.sleep(300)  # every 5 min while the tab is open
+```
+
+```javascript JavaScript
+setInterval(async () => {
+  await fetch(
+    "https://app.runtm.com/api/v2/sessions/86e11104-.../refresh",
+    { method: "POST", headers: { "Authorization": "Bearer runtm_xxx" } }
+  );
+}, 5 * 60 * 1000);
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200
+{
+  "ok": true
+}
+```
+</ResponseExample>

--- a/docs/cloud-api/sessions/v2-refresh.mdx
+++ b/docs/cloud-api/sessions/v2-refresh.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Refresh Sandbox TTL (v2)"
 api: "POST /api/v2/sessions/{session_id}/refresh"
-description: "Extend the sandbox TTL — the v2 keepalive that replaces /heartbeat"
+description: "Extend the sandbox TTL - the v2 keepalive that replaces /heartbeat"
 ---
 
 Extends the sandbox's idle timeout so it stays alive while the user is interacting. Call this periodically (e.g. every 5 minutes) while a workspace tab is open.
 
-This is the v2 replacement for the legacy [`POST /api/sessions/{session_id}/heartbeat`](/cloud-api/sessions/heartbeat). Unlike heartbeat, `/refresh` does not rely on `AsyncSandbox.connect()` as a side-effect-based keepalive — it explicitly extends the TTL via E2B's REST API.
+This is the v2 replacement for the legacy [`POST /api/sessions/{session_id}/heartbeat`](/cloud-api/sessions/heartbeat). Unlike heartbeat, `/refresh` does not rely on a side-effect-based keepalive. It explicitly extends the TTL via the sandbox provider's REST API.
 
 The session must be in `running` state.
 
@@ -31,8 +31,8 @@ The session must be in `running` state.
 ## Behavior
 
 - Extends the sandbox TTL by `idle_timeout_minutes * 60` seconds (default 30 minutes).
-- E2B caps duration at 3600s, so longer values are clamped.
-- Reconciles with E2B before checking state. If the sandbox has been paused or expired between calls, returns an error so the caller can re-`start` the session.
+- The sandbox provider caps duration at 3600s, so longer values are clamped.
+- Reconciles with the sandbox provider before checking state. If the sandbox has been paused or expired between calls, returns an error so the caller can re-`start` the session.
 
 ## Response
 
@@ -46,7 +46,7 @@ The session must be in `running` state.
 |---|---|
 | `400` | Session is not in `running` state, or has no sandbox |
 | `404` | Session not found |
-| `502` | E2B refresh call failed |
+| `502` | Sandbox provider refresh call failed |
 
 <RequestExample>
 ```bash cURL

--- a/docs/cloud-api/sessions/v2-start.mdx
+++ b/docs/cloud-api/sessions/v2-start.mdx
@@ -1,20 +1,20 @@
 ---
 title: "Start Sandbox (v2)"
 api: "POST /api/v2/sessions/{session_id}/start"
-description: "Ensure the sandbox is running — resumes if paused, waits if provisioning"
+description: "Ensure the sandbox is running - resumes if paused, waits if provisioning"
 ---
 
-Reconciles the session's sandbox with E2B reality and ensures it is in `running` state. Unlike the legacy [`POST /api/sessions/{session_id}/start`](/cloud-api/sessions/start), this endpoint **only** handles sandbox lifecycle — it does not start a dev server or detect preview ports. Dev-server orchestration lives on dedicated endpoints (e.g. [`POST /api/v2/sessions/{id}/connect`](/cloud-api/sessions/v2-connect)).
+Reconciles the session's sandbox with the sandbox provider and ensures it is in `running` state. Unlike the legacy [`POST /api/sessions/{session_id}/start`](/cloud-api/sessions/start), this endpoint **only** handles sandbox lifecycle. It does not start a dev server or detect preview ports. Dev-server orchestration lives on dedicated endpoints (e.g. [`POST /api/v2/sessions/{id}/connect`](/cloud-api/sessions/v2-connect)).
 
 State transitions handled:
 
 | Current state | Action |
 |---|---|
 | `creating` | Polls until provisioning finishes (up to 120s) |
-| `paused` | Resumes the sandbox via E2B and updates the DB |
-| `running` | No-op — returns current state |
+| `paused` | Resumes the sandbox via the provider and updates the DB |
+| `running` | No-op - returns current state |
 | `destroyed` / `error` | `410 Gone` |
-| Sandbox missing in E2B | Marks session destroyed and returns `410` |
+| Sandbox missing in provider | Marks session destroyed and returns `410` |
 
 **Required scope:** `sessions:write`
 
@@ -39,7 +39,7 @@ State transitions handled:
 `200 OK` with a `SessionV2` object.
 
 <ResponseField name="id" type="string">Session ID.</ResponseField>
-<ResponseField name="state" type="string">Live sandbox state — `running` or `paused`.</ResponseField>
+<ResponseField name="state" type="string">Live sandbox state - `running` or `paused`.</ResponseField>
 <ResponseField name="agent" type="string">Coding agent.</ResponseField>
 <ResponseField name="template" type="string | null">Template the session was scaffolded from.</ResponseField>
 <ResponseField name="name" type="string | null">Display name.</ResponseField>
@@ -63,12 +63,12 @@ State transitions handled:
 </ResponseField>
 
 <ResponseField name="sandbox" type="object">
-  Live E2B sandbox info:
+  Live sandbox info from the provider:
 
-  - **`sandbox_id`** — E2B sandbox identifier
-  - **`state`** — `running` or `paused`
-  - **`started_at`** — ISO 8601
-  - **`end_at`** — ISO 8601 expiry
+  - **`sandbox_id`** - sandbox identifier
+  - **`state`** - `running` or `paused`
+  - **`started_at`** - ISO 8601
+  - **`end_at`** - ISO 8601 expiry
 </ResponseField>
 
 ## Errors

--- a/docs/cloud-api/sessions/v2-start.mdx
+++ b/docs/cloud-api/sessions/v2-start.mdx
@@ -1,0 +1,140 @@
+---
+title: "Start Sandbox (v2)"
+api: "POST /api/v2/sessions/{session_id}/start"
+description: "Ensure the sandbox is running — resumes if paused, waits if provisioning"
+---
+
+Reconciles the session's sandbox with E2B reality and ensures it is in `running` state. Unlike the legacy [`POST /api/sessions/{session_id}/start`](/cloud-api/sessions/start), this endpoint **only** handles sandbox lifecycle — it does not start a dev server or detect preview ports. Dev-server orchestration lives on dedicated endpoints (e.g. [`POST /api/v2/sessions/{id}/connect`](/cloud-api/sessions/v2-connect)).
+
+State transitions handled:
+
+| Current state | Action |
+|---|---|
+| `creating` | Polls until provisioning finishes (up to 120s) |
+| `paused` | Resumes the sandbox via E2B and updates the DB |
+| `running` | No-op — returns current state |
+| `destroyed` / `error` | `410 Gone` |
+| Sandbox missing in E2B | Marks session destroyed and returns `410` |
+
+**Required scope:** `sessions:write`
+
+## Path Parameters
+
+<ParamField path="session_id" type="string" required>
+  The session ID.
+</ParamField>
+
+## Headers
+
+<ParamField header="Authorization" type="string" required>
+  Bearer token. Example: `Bearer runtm_xxx`
+</ParamField>
+
+<ParamField header="X-Organization-Id" type="string">
+  Required when the session belongs to an organization.
+</ParamField>
+
+## Response
+
+`200 OK` with a `SessionV2` object.
+
+<ResponseField name="id" type="string">Session ID.</ResponseField>
+<ResponseField name="state" type="string">Live sandbox state — `running` or `paused`.</ResponseField>
+<ResponseField name="agent" type="string">Coding agent.</ResponseField>
+<ResponseField name="template" type="string | null">Template the session was scaffolded from.</ResponseField>
+<ResponseField name="name" type="string | null">Display name.</ResponseField>
+<ResponseField name="github_repo" type="string | null">GitHub `owner/repo` link.</ResponseField>
+<ResponseField name="github_branch" type="string | null">Active branch in the sandbox.</ResponseField>
+<ResponseField name="workspace_path" type="string">Working directory inside the sandbox (e.g. `/home/user`).</ResponseField>
+<ResponseField name="organization_id" type="string | null">Owning organization.</ResponseField>
+<ResponseField name="created_at" type="string">ISO 8601 creation timestamp.</ResponseField>
+<ResponseField name="updated_at" type="string | null">ISO 8601 last update timestamp.</ResponseField>
+<ResponseField name="services" type="object">
+  Named services exposed by the sandbox, e.g. `{ "frontend": 3000, "postgres": 5432 }`. Powers multi-port previews via [`/connect`](/cloud-api/sessions/v2-connect).
+</ResponseField>
+<ResponseField name="env" type="object">Env var **names** with masked values (`*****`). Secret values are never returned.</ResponseField>
+<ResponseField name="visibility" type="string">`private` or `team`.</ResponseField>
+<ResponseField name="total_cost_usd" type="number">Aggregate cost across all prompts.</ResponseField>
+<ResponseField name="tabs" type="array">
+  Ordered list of agent tabs: `[{ "id": "<uuid>", "name": "Chat 1" }]`. Defaults to one tab whose `id` equals the session id.
+</ResponseField>
+<ResponseField name="org_template_repos" type="array | null">
+  Multi-repo template entries (only set when the org template defines >1 repo).
+</ResponseField>
+
+<ResponseField name="sandbox" type="object">
+  Live E2B sandbox info:
+
+  - **`sandbox_id`** — E2B sandbox identifier
+  - **`state`** — `running` or `paused`
+  - **`started_at`** — ISO 8601
+  - **`end_at`** — ISO 8601 expiry
+</ResponseField>
+
+## Errors
+
+| Status | Meaning |
+|---|---|
+| `404` | Session not found or not owned by the caller |
+| `410` | Session destroyed, errored, or sandbox expired |
+| `502` | Sandbox not reachable / failed to resume |
+| `503` | Provisioning still in progress after 120s |
+
+<RequestExample>
+```bash cURL
+curl -X POST "https://app.runtm.com/api/v2/sessions/86e11104-.../start" \
+  -H "Authorization: Bearer runtm_xxx"
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://app.runtm.com/api/v2/sessions/86e11104-.../start",
+    headers={"Authorization": "Bearer runtm_xxx"},
+)
+
+session = response.json()
+print(f"Sandbox {session['sandbox']['sandbox_id']} is {session['state']}")
+```
+
+```javascript JavaScript
+const response = await fetch(
+  "https://app.runtm.com/api/v2/sessions/86e11104-.../start",
+  { method: "POST", headers: { "Authorization": "Bearer runtm_xxx" } }
+);
+
+const session = await response.json();
+console.log(`Sandbox ${session.sandbox.sandbox_id} is ${session.state}`);
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200
+{
+  "id": "86e11104-cdbb-42c9-bdc3-5212024ddb7b",
+  "state": "running",
+  "agent": "claude-code",
+  "template": null,
+  "name": "Refactor billing service",
+  "github_repo": "acme/billing",
+  "github_branch": "agent/86e11104",
+  "workspace_path": "/home/user",
+  "organization_id": "org_abc123",
+  "created_at": "2026-05-09T21:00:00Z",
+  "updated_at": "2026-05-09T21:30:00Z",
+  "services": { "frontend": 3000 },
+  "env": { "NODE_ENV": "*****" },
+  "visibility": "private",
+  "total_cost_usd": 0.23,
+  "tabs": [{ "id": "86e11104-cdbb-42c9-bdc3-5212024ddb7b", "name": "Chat 1" }],
+  "org_template_repos": null,
+  "sandbox": {
+    "sandbox_id": "sb_xyz",
+    "state": "running",
+    "started_at": "2026-05-09T21:00:30Z",
+    "end_at": "2026-05-09T22:00:30Z"
+  }
+}
+```
+</ResponseExample>

--- a/docs/cloud-api/sessions/workspace-state.mdx
+++ b/docs/cloud-api/sessions/workspace-state.mdx
@@ -62,7 +62,7 @@ response = requests.get(
 
 state = response.json()
 for port in state["detected_ports"]:
-    print(f"Port {port['port']} — {port['process']}")
+    print(f"Port {port['port']} - {port['process']}")
 ```
 
 ```javascript JavaScript
@@ -75,7 +75,7 @@ const response = await fetch(
 
 const state = await response.json();
 state.detected_ports.forEach((p) =>
-  console.log(`Port ${p.port} — ${p.process}`)
+  console.log(`Port ${p.port} - ${p.process}`)
 );
 ```
 </RequestExample>

--- a/docs/cloud-api/templates/build-logs.mdx
+++ b/docs/cloud-api/templates/build-logs.mdx
@@ -101,7 +101,7 @@ while (true) {
 {"type": "status", "message": "Build started", "timestamp": "2026-05-09T21:00:00Z"}
 {"type": "log", "message": "Cloning repository...", "timestamp": "2026-05-09T21:00:01Z"}
 {"type": "log", "message": "Installing dependencies...", "timestamp": "2026-05-09T21:00:15Z"}
-{"type": "log", "message": "Building E2B template...", "timestamp": "2026-05-09T21:01:00Z"}
+{"type": "log", "message": "Building template...", "timestamp": "2026-05-09T21:01:00Z"}
 {"type": "complete", "message": "Build completed successfully", "timestamp": "2026-05-09T21:03:00Z"}
 ```
 </ResponseExample>

--- a/docs/cloud-api/templates/build.mdx
+++ b/docs/cloud-api/templates/build.mdx
@@ -4,7 +4,7 @@ api: "POST /api/org-templates/{template_id}/build"
 description: "Trigger a template snapshot build"
 ---
 
-Triggers a new E2B template build for the organization template. The build runs asynchronously — use the [Build Logs](/cloud-api/templates/build-logs) endpoint to stream progress. Requires admin or owner role.
+Triggers a new template build for the organization template. The build runs asynchronously. Use the [Build Logs](/cloud-api/templates/build-logs) endpoint to stream progress. Requires admin or owner role.
 
 **Required scope:** `templates:build`
 

--- a/docs/cloud-api/templates/delete.mdx
+++ b/docs/cloud-api/templates/delete.mdx
@@ -4,7 +4,7 @@ api: "DELETE /api/org-templates/{template_id}"
 description: "Delete an organization template"
 ---
 
-Deletes an organization template and its associated secrets. The underlying E2B template image is not removed. Requires admin or owner role.
+Deletes an organization template and its associated secrets. The underlying template image is not removed. Requires admin or owner role.
 
 **Required scope:** `templates:delete`
 

--- a/docs/cloud-api/templates/get.mdx
+++ b/docs/cloud-api/templates/get.mdx
@@ -63,7 +63,7 @@ Returns the full detail of an organization template including its configuration,
 </ResponseField>
 
 <ResponseField name="e2b_template_id" type="string">
-  E2B template ID for sandbox creation.
+  Template ID for sandbox creation.
 </ResponseField>
 
 <ResponseField name="build_status" type="string | null">

--- a/docs/cloud-api/templates/list.mdx
+++ b/docs/cloud-api/templates/list.mdx
@@ -4,7 +4,7 @@ api: "GET /api/org-templates"
 description: "List organization templates with pagination"
 ---
 
-Returns a paginated list of organization templates. Templates define pre-configured sandbox environments with custom E2B images, repo patterns, and secrets.
+Returns a paginated list of organization templates. Templates define pre-configured sandbox environments with custom images, repo patterns, and secrets.
 
 **Required scope:** `templates:read`
 

--- a/docs/cloud-api/templates/save-snapshot.mdx
+++ b/docs/cloud-api/templates/save-snapshot.mdx
@@ -4,7 +4,7 @@ api: "POST /api/org-templates/{template_id}/save-snapshot"
 description: "Save current session state as a template snapshot"
 ---
 
-Saves the current state of a template's fix session as a new E2B template snapshot. This captures the sandbox filesystem so future sessions using this template start from this point. Requires admin or owner role.
+Saves the current state of a template's fix session as a new template snapshot. This captures the sandbox filesystem so future sessions using this template start from this point. Requires admin or owner role.
 
 **Required scope:** `templates:write`
 
@@ -35,7 +35,7 @@ Saves the current state of a template's fix session as a new E2B template snapsh
 </ResponseField>
 
 <ResponseField name="e2b_template_id" type="string">
-  The new E2B template ID for the snapshot.
+  The new template ID for the snapshot.
 </ResponseField>
 
 <ResponseField name="message" type="string">

--- a/docs/cloud-api/templates/secrets-list.mdx
+++ b/docs/cloud-api/templates/secrets-list.mdx
@@ -4,7 +4,7 @@ api: "GET /api/org-templates/{template_id}/secrets"
 description: "List secret names configured for a template"
 ---
 
-Returns the list of secret keys configured for a template. Values are never returned — only names and whether they are set.
+Returns the list of secret keys configured for a template. Values are never returned - only names and whether they are set.
 
 **Required scope:** `secrets:read`
 

--- a/docs/cloud-api/websockets/collaboration.mdx
+++ b/docs/cloud-api/websockets/collaboration.mdx
@@ -149,4 +149,4 @@ The server closes idle collaboration connections after 30 minutes of inactivity.
 
 ## Privacy
 
-Collaboration is only available on sessions with `team` visibility. Private sessions do not accept collaboration WebSocket connections — the token exchange returns `403`.
+Collaboration is only available on sessions with `team` visibility. Private sessions do not accept collaboration WebSocket connections - the token exchange returns `403`.

--- a/docs/cloud-api/websockets/overview.mdx
+++ b/docs/cloud-api/websockets/overview.mdx
@@ -53,10 +53,10 @@ WebSocket endpoints do not accept API keys directly. Instead, you exchange your 
 
 ## Connection lifecycle
 
-1. **Connect** — Open a WebSocket to the channel URL with a valid token.
-2. **Authenticate** — The server validates the token on connection. Invalid or expired tokens result in an immediate close with code `4001`.
-3. **Message flow** — Send and receive messages per the channel protocol.
-4. **Disconnect** — Either side can close the connection. The server closes idle connections after a timeout (varies by channel).
+1. **Connect** - Open a WebSocket to the channel URL with a valid token.
+2. **Authenticate** - The server validates the token on connection. Invalid or expired tokens result in an immediate close with code `4001`.
+3. **Message flow** - Send and receive messages per the channel protocol.
+4. **Disconnect** - Either side can close the connection. The server closes idle connections after a timeout (varies by channel).
 
 ## Reconnection
 
@@ -71,8 +71,8 @@ Implement exponential backoff for reconnection attempts to avoid flooding the se
 
 | WebSocket close code | Meaning |
 |---------------------|---------|
-| `4001` | Authentication failed — token is invalid or expired. |
-| `4003` | Forbidden — insufficient scope for this channel. |
+| `4001` | Authentication failed - token is invalid or expired. |
+| `4003` | Forbidden - insufficient scope for this channel. |
 | `4004` | Session not found or not accessible. |
 | `4009` | Session is in an invalid state (e.g. paused or destroyed). |
 | `1011` | Unexpected server error. |

--- a/docs/cloud-api/websockets/prompt.mdx
+++ b/docs/cloud-api/websockets/prompt.mdx
@@ -3,7 +3,7 @@ title: "Prompt WebSocket"
 description: "Stream prompts and agent output in real-time"
 ---
 
-The prompt WebSocket lets you send prompts to the coding agent and receive streaming output — tokens, tool calls, results, and completion signals — in real time.
+The prompt WebSocket lets you send prompts to the coding agent and receive streaming output - tokens, tool calls, results, and completion signals - in real time.
 
 ## Connection
 
@@ -15,7 +15,7 @@ Obtain `ws_token` from the [Token Exchange](/cloud-api/websockets/token-exchange
 
 **Required scope:** `sessions:prompt`
 
-Each prompt tab has its own WebSocket. The `tab_id` identifies which agent tab to connect to — sessions can run multiple agents in parallel across tabs.
+Each prompt tab has its own WebSocket. The `tab_id` identifies which agent tab to connect to - sessions can run multiple agents in parallel across tabs.
 
 ## Authentication
 
@@ -159,7 +159,7 @@ ws.onmessage = (event) => {
       console.log(`[Result: ${msg.output}]`);
       break;
     case "prompt_end":
-      console.log(`\n[Done — ${msg.usage.output_tokens} tokens]`);
+      console.log(`\n[Done - ${msg.usage.output_tokens} tokens]`);
       break;
     case "error":
       console.error(`\n[Error: ${msg.message}]`);

--- a/docs/cloud-api/websockets/terminal.mdx
+++ b/docs/cloud-api/websockets/terminal.mdx
@@ -3,7 +3,7 @@ title: "Terminal WebSocket"
 description: "Interactive terminal access via WebSocket"
 ---
 
-The terminal WebSocket provides full PTY access to the sandbox shell. It behaves like an SSH session — you send keystrokes, receive output, and can resize the terminal.
+The terminal WebSocket provides full PTY access to the sandbox shell. It behaves like an SSH session - you send keystrokes, receive output, and can resize the terminal.
 
 ## Connection
 

--- a/docs/cloud-api/websockets/token-exchange.mdx
+++ b/docs/cloud-api/websockets/token-exchange.mdx
@@ -4,7 +4,7 @@ api: "POST /api/sessions/{session_id}/ws-token"
 description: "Exchange an API key for a short-lived WebSocket token"
 ---
 
-Creates a short-lived JWT that authenticates a WebSocket connection. The token is scoped to a single session and capability. Tokens expire after 5 minutes — request a new one if the connection drops.
+Creates a short-lived JWT that authenticates a WebSocket connection. The token is scoped to a single session and capability. Tokens expire after 5 minutes - request a new one if the connection drops.
 
 **Required scope:** depends on the requested capability:
 

--- a/docs/concepts/agents.mdx
+++ b/docs/concepts/agents.mdx
@@ -3,7 +3,7 @@ title: Background Agents
 description: "Autonomous coding runs triggered from tickets, issues, and the API"
 ---
 
-Background agents are autonomous coding runs. You hand off a task — a Linear ticket, a GitHub issue, a Slack message, or an API call — and the agent picks it up, writes code, runs tests, and reports back with a pull request. No one needs to watch.
+Background agents are autonomous coding runs. You hand off a task - a Linear ticket, a GitHub issue, a Slack message, or an API call - and the agent picks it up, writes code, runs tests, and reports back with a pull request. No one needs to watch.
 
 Background agents use the same [coding agents](/concepts/coding-agents) and sandboxed VMs as interactive [sessions](/concepts/sessions). The difference is workflow:
 
@@ -49,12 +49,12 @@ flowchart LR
     style PR fill:#18181b,stroke:#18181b,stroke-width:2px,color:#fafafa
 ```
 
-1. **Trigger fires** — a Linear ticket is tagged, a Slack message is posted, or your code calls the API
-2. **Session spawns** — Runtime boots a sandboxed VM with the chosen [coding agent](/concepts/coding-agents), optionally from a [template](/concepts/templates) snapshot
-3. **Context applies** — org and user [instructions](/concepts/context), required [skills](/concepts/skills), and [guardrails](/concepts/guardrails) are loaded
-4. **Repository clones** — the linked GitHub repo is cloned into the workspace
-5. **Agent runs** — reads the prompt, plans, writes code, runs tests, iterates on errors
-6. **Output ships** — commits, opens a PR, posts back to the trigger source (Linear, Slack, etc.)
+1. **Trigger fires** - a Linear ticket is tagged, a Slack message is posted, or your code calls the API
+2. **Session spawns** - Runtime boots a sandboxed VM with the chosen [coding agent](/concepts/coding-agents), optionally from a [template](/concepts/templates) snapshot
+3. **Context applies** - org and user [instructions](/concepts/context), required [skills](/concepts/skills), and [guardrails](/concepts/guardrails) are loaded
+4. **Repository clones** - the linked GitHub repo is cloned into the workspace
+5. **Agent runs** - reads the prompt, plans, writes code, runs tests, iterates on errors
+6. **Output ships** - commits, opens a PR, posts back to the trigger source (Linear, Slack, etc.)
 
 The whole run is logged. Every prompt, tool call, file edit, command, and cost event is captured in [activity](/concepts/observability).
 
@@ -62,9 +62,9 @@ The whole run is logged. Every prompt, tool call, file edit, command, and cost e
 
 Background agents can run in different modes depending on how much autonomy you want:
 
-- **Autopilot** — the agent runs end-to-end without stopping for input
-- **Plan mode** — the agent generates a plan first, asks for approval, then executes
-- **Interactive** — you can step in mid-run by sending follow-up prompts
+- **Autopilot** - the agent runs end-to-end without stopping for input
+- **Plan mode** - the agent generates a plan first, asks for approval, then executes
+- **Interactive** - you can step in mid-run by sending follow-up prompts
 
 Mode is set at creation time.
 

--- a/docs/concepts/coding-agents.mdx
+++ b/docs/concepts/coding-agents.mdx
@@ -105,7 +105,7 @@ Valid values: `claude-code`, `codex`, `opencode`, `github-copilot`, `cursor-cli`
 
 Coding agents power two Runtime workflows:
 
-- **[Sessions](/concepts/sessions)** — interactive environments where you work alongside the agent in real time, sending prompts and watching output
-- **[Background agents](/concepts/agents)** — autonomous runs triggered from Linear, Slack, GitHub, or the API that produce a pull request without human intervention
+- **[Sessions](/concepts/sessions)** - interactive environments where you work alongside the agent in real time, sending prompts and watching output
+- **[Background agents](/concepts/agents)** - autonomous runs triggered from Linear, Slack, GitHub, or the API that produce a pull request without human intervention
 
 The same agent, same sandbox, same [context and guardrails](/concepts/context) apply in both cases. The difference is whether you're watching or not.

--- a/docs/concepts/context.mdx
+++ b/docs/concepts/context.mdx
@@ -202,7 +202,7 @@ The agent sees all of this as a single coherent system prompt and tool catalog b
 
 <CardGroup cols={2}>
   <Card title="Teach the agent your codebase" icon="brain" href="/guides/teach-the-agent-your-codebase">
-    AGENTS.md, skills, and org instructions — how the three layers compose.
+    AGENTS.md, skills, and org instructions - how the three layers compose.
   </Card>
   <Card title="Best practices" icon="shield" href="/guides/best-practices">
     Key hygiene, prompt design, and cost controls.

--- a/docs/guides/authentication-walkthrough.mdx
+++ b/docs/guides/authentication-walkthrough.mdx
@@ -9,7 +9,7 @@ For the full specification of every scope and role ceiling, see the [Scopes & Pe
 
 ## When to use this
 
-- You want to use Runtime programmatically — from your terminal, scripts, coding agents, or CI/CD pipelines
+- You want to use Runtime programmatically - from your terminal, scripts, coding agents, or CI/CD pipelines
 - You need to understand the difference between personal and organization keys
 - You want to establish a key rotation policy for your team
 
@@ -20,14 +20,14 @@ For the full specification of every scope and role ceiling, see the [Scopes & Pe
 
 ## Create a key
 
-Keys are created from the dashboard only — there is no programmatic key-creation endpoint. This prevents a compromised key from bootstrapping new credentials.
+Keys are created from the dashboard only - there is no programmatic key-creation endpoint. This prevents a compromised key from bootstrapping new credentials.
 
 <Steps>
   <Step title="Choose a context">
     Decide whether the key should act as **you personally** or as a **member of an organization**.
 
-    - **Personal key** — operates on your own sessions and secrets. Cannot touch org resources.
-    - **Organization key** — operates on resources owned by the organization. You must have the org selected in the org switcher when you create the key.
+    - **Personal key** - operates on your own sessions and secrets. Cannot touch org resources.
+    - **Organization key** - operates on resources owned by the organization. You must have the org selected in the org switcher when you create the key.
   </Step>
 
   <Step title="Pick scopes">
@@ -78,7 +78,7 @@ resp = requests.get(
     headers={"Authorization": "Bearer runtm_xxx"},
 )
 info = resp.json()
-print(f"Key {info['key_id']} — scopes: {info['scopes']}")
+print(f"Key {info['key_id']} - scopes: {info['scopes']}")
 ```
 
 ```javascript JavaScript
@@ -86,7 +86,7 @@ const resp = await fetch("https://app.runtm.com/auth/verify", {
   headers: { Authorization: "Bearer runtm_xxx" },
 });
 const info = await resp.json();
-console.log(`Key ${info.key_id} — scopes: ${info.scopes}`);
+console.log(`Key ${info.key_id} - scopes: ${info.scopes}`);
 ```
 
 </CodeGroup>
@@ -121,7 +121,7 @@ curl https://app.runtm.com/api/sessions \
 | Key type | `X-Organization-Id` header | Behavior |
 |----------|---------------------------|----------|
 | Personal | Omit or absent | Operates on personal resources |
-| Personal | Set to any value | `403` — personal keys cannot act as an org |
+| Personal | Set to any value | `403` - personal keys cannot act as an org |
 | Organization | Omit | Uses the key's org automatically |
 | Organization | Set to matching org | Works (redundant but harmless) |
 | Organization | Set to different org | `403` |
@@ -130,10 +130,10 @@ curl https://app.runtm.com/api/sessions \
 
 Apply the principle of least privilege:
 
-- Give CI keys only `sessions:read`, `sessions:write`, and `sessions:prompt` — not `sessions:delete` or `sessions:terminal`
+- Give CI keys only `sessions:read`, `sessions:write`, and `sessions:prompt` - not `sessions:delete` or `sessions:terminal`
 - Monitoring dashboards need only `sessions:read` and `activity:read`
 - Only org admins or owners should use `templates:write`, `guardrails:write`, or `integrations:write`
-- Never share a single key across multiple services — create one key per consumer
+- Never share a single key across multiple services - create one key per consumer
 
 ## Rotate a key
 
@@ -153,7 +153,7 @@ Runtime does not have a built-in "rotate" button. Instead, follow this sequence:
   </Step>
 
   <Step title="Revoke the old key">
-    In the dashboard, revoke the old key. Revocation is immediate — any in-flight requests using the old key fail with `401`.
+    In the dashboard, revoke the old key. Revocation is immediate - any in-flight requests using the old key fail with `401`.
   </Step>
 </Steps>
 
@@ -163,7 +163,7 @@ A user may have at most **3 active keys** per context (personal + each org). Key
 
 ## Revoke a key
 
-Navigate to **Settings > API Keys** in the dashboard and click **Revoke** next to the key. Revocation is immediate and permanent — the key ID is retained for audit but the key can never be used again.
+Navigate to **Settings > API Keys** in the dashboard and click **Revoke** next to the key. Revocation is immediate and permanent - the key ID is retained for audit but the key can never be used again.
 
 Revoke immediately when:
 

--- a/docs/guides/best-practices.mdx
+++ b/docs/guides/best-practices.mdx
@@ -34,7 +34,7 @@ A personal key cannot touch organization resources. An organization key cannot o
 
 ## Session lifecycle
 
-**Use `POST /sessions/{id}/start` instead of polling.** The start endpoint blocks until the session is running and the dev server is up. It is idempotent — calling it on an already-running session is a no-op.
+**Use `POST /sessions/{id}/start` instead of polling.** The start endpoint blocks until the session is running and the dev server is up. It is idempotent - calling it on an already-running session is a no-op.
 
 **Pause, don't destroy, if you might come back.** Paused sessions accrue no compute cost and resume in seconds with the filesystem intact. Destroyed sessions are permanently deleted.
 
@@ -96,11 +96,11 @@ See [Guardrails](/concepts/guardrails) for configuration details.
 
 **Use HTTPS only.** All API endpoints use TLS. Never downgrade to HTTP.
 
-**Scope org keys to the minimum role.** Member-role keys cannot mutate templates, secrets, guardrails, or integrations — even if those scopes are requested. Only admin or owner keys can.
+**Scope org keys to the minimum role.** Member-role keys cannot mutate templates, secrets, guardrails, or integrations - even if those scopes are requested. Only admin or owner keys can.
 
 **Audit with the Activity API.** The traces endpoint shows every prompt, tool call, and file change per session. Use it to audit what agents are doing in your organization.
 
-**Revoke compromised keys immediately.** Revocation is instant — any in-flight request using the old key fails with `401`.
+**Revoke compromised keys immediately.** Revocation is instant - any in-flight request using the old key fails with `401`.
 
 ## Next steps
 
@@ -109,7 +109,7 @@ See [Guardrails](/concepts/guardrails) for configuration details.
     Full key lifecycle walkthrough.
   </Card>
   <Card title="Teach the agent your codebase" icon="brain" href="/guides/teach-the-agent-your-codebase">
-    AGENTS.md, skills, and instructions — context that makes agents effective.
+    AGENTS.md, skills, and instructions - context that makes agents effective.
   </Card>
   <Card title="Scopes & Permissions" icon="shield" href="/cloud-api/scopes">
     Full scope catalog and role ceiling matrix.

--- a/docs/guides/long-running-prompts.mdx
+++ b/docs/guides/long-running-prompts.mdx
@@ -74,7 +74,7 @@ console.log(await resp.json());
 
 </CodeGroup>
 
-This endpoint is safe to call even when no prompt is running — it returns success either way. Use it as a "make sure nothing is running" gate before submitting a new prompt.
+This endpoint is safe to call even when no prompt is running - it returns success either way. Use it as a "make sure nothing is running" gate before submitting a new prompt.
 
 <Note>
 Canceling stops the agent, but file changes already written to disk are not reverted. Use **rewind** (below) to undo file changes.
@@ -82,7 +82,7 @@ Canceling stops the agent, but file changes already written to disk are not reve
 
 ## Rewind file changes
 
-`POST /api/sessions/{id}/prompt/rewind` restores the filesystem to a checkpoint captured during a prior prompt. The conversation history is preserved — only file contents are reverted.
+`POST /api/sessions/{id}/prompt/rewind` restores the filesystem to a checkpoint captured during a prior prompt. The conversation history is preserved - only file contents are reverted.
 
 ```bash
 curl -X POST "https://app.runtm.com/api/sessions/${SESSION_ID}/prompt/rewind" \
@@ -119,7 +119,7 @@ for event in data["events"]:
     if event["type"] == "user":
         print(f"User: {event['content'][:80]}")
     elif event["type"] == "completion":
-        print(f"Done — cost: ${event.get('cost_usd', 0):.4f}")
+        print(f"Done - cost: ${event.get('cost_usd', 0):.4f}")
 ```
 
 ```javascript JavaScript

--- a/docs/guides/managing-sessions-at-scale.mdx
+++ b/docs/guides/managing-sessions-at-scale.mdx
@@ -3,7 +3,7 @@ title: "Manage sessions at scale"
 description: "Session lifecycle, polling, heartbeats, retries, and error recovery"
 ---
 
-Sessions are the core unit of work in Runtime. This guide covers the patterns you need when managing sessions programmatically — whether you are calling the API from your own terminal, letting a coding agent spin up cloud environments, or orchestrating sessions from a CI pipeline.
+Sessions are the core unit of work in Runtime. This guide covers the patterns you need when managing sessions programmatically - whether you are calling the API from your own terminal, letting a coding agent spin up cloud environments, or orchestrating sessions from a CI pipeline.
 
 For the full endpoint reference, see [Manage Sessions](/cloud-api/sessions/manage) and [Lifecycle](/cloud-api/sessions/lifecycle).
 
@@ -163,7 +163,7 @@ await fetch(`${BASE}/sessions/${sessionId}/resume`, { method: "POST", headers })
 Key behaviors:
 
 - Pausing an already-paused session is a no-op (returns `200`)
-- Pausing while a prompt is running returns `409` — cancel the prompt first
+- Pausing while a prompt is running returns `409` - cancel the prompt first
 - Resuming an already-running session is a no-op
 - Any mutating endpoint (prompt, file write) on a paused session triggers an automatic resume
 
@@ -219,8 +219,8 @@ Your code should catch `410` and create a fresh session.
 
 Only one prompt runs per session at a time. If you submit a prompt while one is already in flight, you get `202` with `status: "already_running"`. Two strategies:
 
-1. **Wait and retry** — poll `GET /api/sessions/{id}` until `last_prompt.status` is `completed` or `error`, then submit.
-2. **Cancel and resubmit** — call `POST /api/sessions/{id}/prompt/cancel`, then submit the new prompt.
+1. **Wait and retry** - poll `GET /api/sessions/{id}` until `last_prompt.status` is `completed` or `error`, then submit.
+2. **Cancel and resubmit** - call `POST /api/sessions/{id}/prompt/cancel`, then submit the new prompt.
 
 ## Set a TTL for unattended runs
 

--- a/docs/guides/overview.mdx
+++ b/docs/guides/overview.mdx
@@ -3,7 +3,7 @@ title: Guides
 description: "Practical patterns for using the Runtime API"
 ---
 
-These guides cover the patterns and workflows you will use most often with the Runtime API — whether you are calling it from your terminal, letting a coding agent orchestrate cloud sessions, or integrating it into a CI pipeline or backend service. Each guide includes code samples in cURL, Python, and JavaScript.
+These guides cover the patterns and workflows you will use most often with the Runtime API - whether you are calling it from your terminal, letting a coding agent orchestrate cloud sessions, or integrating it into a CI pipeline or backend service. Each guide includes code samples in cURL, Python, and JavaScript.
 
 If you are new to Runtime, start with the [Quick Start](/quickstart) and the [API Overview](/cloud-api/overview), then come back here for deeper patterns.
 
@@ -45,6 +45,6 @@ If you are new to Runtime, start with the [Quick Start](/quickstart) and the [AP
     Key hygiene, scope selection, lifecycle management, prompt design, and cost controls.
   </Card>
   <Card title="Teach the agent your codebase" icon="brain" href="/guides/teach-the-agent-your-codebase">
-    AGENTS.md, skills, and org instructions — how the three context layers compose.
+    AGENTS.md, skills, and org instructions - how the three context layers compose.
   </Card>
 </CardGroup>

--- a/docs/guides/pulling-activity-and-telemetry.mdx
+++ b/docs/guides/pulling-activity-and-telemetry.mdx
@@ -61,7 +61,7 @@ Pass `X-Organization-Id` to scope results to a specific organization. Without it
 
 ## Personal summary
 
-`GET /sessions/telemetry/summary` returns aggregate totals for a time period — total sessions, total prompts, total cost, and averages:
+`GET /sessions/telemetry/summary` returns aggregate totals for a time period - total sessions, total prompts, total cost, and averages:
 
 ```bash
 curl "https://app.runtm.com/api/sessions/telemetry/summary?days=30" \
@@ -77,11 +77,11 @@ curl "https://app.runtm.com/api/sessions/telemetry/recent-prompts?limit=10" \
   -H "Authorization: Bearer runtm_xxx"
 ```
 
-This is useful for debugging — quickly see what prompts ran, which ones failed, and how much they cost.
+This is useful for debugging - quickly see what prompts ran, which ones failed, and how much they cost.
 
 ## Per-session usage
 
-`GET /sessions/{id}/telemetry/usage` returns detailed usage for a specific session — prompt count, total cost, token usage, and per-prompt breakdown:
+`GET /sessions/{id}/telemetry/usage` returns detailed usage for a specific session - prompt count, total cost, token usage, and per-prompt breakdown:
 
 ```bash
 curl "https://app.runtm.com/api/sessions/${SESSION_ID}/telemetry/usage" \

--- a/docs/guides/streaming-prompts-over-websockets.mdx
+++ b/docs/guides/streaming-prompts-over-websockets.mdx
@@ -3,7 +3,7 @@ title: "Stream prompts over WebSockets"
 description: "Token exchange, the Prompt WebSocket protocol, event types, and reconnection handling"
 ---
 
-The Prompt WebSocket gives you real-time, bidirectional access to an agent's work — tool calls, file edits, text output, and completion status as they happen. This guide covers the connection flow, event types, and patterns for robust integration.
+The Prompt WebSocket gives you real-time, bidirectional access to an agent's work - tool calls, file edits, text output, and completion status as they happen. This guide covers the connection flow, event types, and patterns for robust integration.
 
 For the full protocol specification, see the [Prompt WebSocket](/cloud-api/websockets/prompt) reference. For the simpler REST alternative, see [Run Prompt](/cloud-api/sessions/prompt).
 
@@ -133,7 +133,7 @@ After the prompt is accepted, the server streams events until a terminal `done` 
 | `todo_update` | Agent updated its task list | `metadata.todos` |
 | `task_activity` | Subtask lifecycle event | `metadata.task_id`, `metadata.subtype` |
 | `result` | Final prompt result | `metadata.cost_usd`, `metadata.usage`, `metadata.num_turns` |
-| `done` | Terminal frame — connection will close | (none) |
+| `done` | Terminal frame - connection will close | (none) |
 | `error` | Terminal error frame | `content` (error message) |
 
 ## Full example

--- a/docs/guides/teach-the-agent-your-codebase.mdx
+++ b/docs/guides/teach-the-agent-your-codebase.mdx
@@ -34,7 +34,7 @@ When a session boots, Runtime loads org instructions, user instructions, and tem
 
 ## AGENTS.md
 
-`AGENTS.md` is a markdown file in your repository root that teaches the agent about **this specific project**. It is read by every agent that works in the repo — Claude Code, Codex, Cursor, and others all respect it.
+`AGENTS.md` is a markdown file in your repository root that teaches the agent about **this specific project**. It is read by every agent that works in the repo - Claude Code, Codex, Cursor, and others all respect it.
 
 ### What to include
 
@@ -54,12 +54,12 @@ A good `AGENTS.md` covers:
 ## Architecture
 - FastAPI backend in `backend/app/`
 - Next.js frontend in `frontend/`
-- Routes are thin — delegate to services in `services/`
+- Routes are thin - delegate to services in `services/`
 
 ## Commands
-- `cd backend && pytest -q` — run backend tests
-- `cd frontend && npm run lint` — lint frontend
-- `cd frontend && npm run dev` — start frontend dev server
+- `cd backend && pytest -q` - run backend tests
+- `cd frontend && npm run lint` - lint frontend
+- `cd frontend && npm run dev` - start frontend dev server
 
 ## Conventions
 - Type hints on all Python functions
@@ -77,7 +77,7 @@ A good `AGENTS.md` covers:
 
 - **Keep it concise.** Agents process `AGENTS.md` on every prompt. Long files waste tokens and slow things down. Aim for 50-200 lines.
 - **Be explicit about "don'ts".** Constraints ("never do X") are often more valuable than instructions ("always do Y") because they prevent costly mistakes.
-- **Update it as the project evolves.** Treat `AGENTS.md` like documentation — it rots if you do not maintain it.
+- **Update it as the project evolves.** Treat `AGENTS.md` like documentation - it rots if you do not maintain it.
 - **Commit it to the repo.** `AGENTS.md` should live alongside the code it describes so every agent (and every team member) sees the same version.
 
 ## Org instructions
@@ -182,14 +182,14 @@ See [Skills](/concepts/skills) for the full skill format and authoring guide.
 
 When a session starts, context is assembled in this order:
 
-1. **Org instructions** load first — these are the broadest, most stable rules
-2. **User instructions** append — these add personal preferences
+1. **Org instructions** load first - these are the broadest, most stable rules
+2. **User instructions** append - these add personal preferences
 3. **Template instructions** merge in (if the session was created from a template)
 4. **Skills** are mounted into the workspace and their MCP servers configured
 5. **Knowledge sources** become available as agent tools
 6. The agent reads **AGENTS.md** from the repo root (if present)
 
-The agent sees all of this as a unified system prompt and tool catalog. There is no explicit precedence — later layers add to earlier ones. If they conflict, the agent uses its judgment, but in practice conflicts are rare because each layer serves a different scope.
+The agent sees all of this as a unified system prompt and tool catalog. There is no explicit precedence - later layers add to earlier ones. If they conflict, the agent uses its judgment, but in practice conflicts are rare because each layer serves a different scope.
 
 ### Best practices for layering
 

--- a/docs/guides/webhooks-and-triggers.mdx
+++ b/docs/guides/webhooks-and-triggers.mdx
@@ -3,7 +3,7 @@ title: "Webhooks and triggers"
 description: "Outbound webhook events Runtime emits and how to consume them from external systems"
 ---
 
-Runtime can push notifications to external systems when certain events happen in a session. This guide covers the outbound webhook system — what events are available, the payload format, and how to use webhooks to connect Runtime to your own tools and workflows.
+Runtime can push notifications to external systems when certain events happen in a session. This guide covers the outbound webhook system - what events are available, the payload format, and how to use webhooks to connect Runtime to your own tools and workflows.
 
 ## When to use this
 
@@ -148,9 +148,9 @@ These built-in triggers handle session creation, prompt dispatch, and result rep
 
 If you cannot run a webhook receiver, poll the session or activity endpoints instead:
 
-- **Session status**: `GET /api/sessions/{id}` — check `last_prompt.status` for `completed`, `error`, or `timed_out`
-- **Recent prompts**: `GET /sessions/telemetry/recent-prompts` — see the latest prompts across all sessions
-- **Activity**: `GET /sessions/telemetry/activity` — daily aggregate counts
+- **Session status**: `GET /api/sessions/{id}` - check `last_prompt.status` for `completed`, `error`, or `timed_out`
+- **Recent prompts**: `GET /sessions/telemetry/recent-prompts` - see the latest prompts across all sessions
+- **Activity**: `GET /sessions/telemetry/activity` - daily aggregate counts
 
 See [Pull activity and telemetry](/guides/pulling-activity-and-telemetry) for patterns.
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -145,6 +145,27 @@
       ]
     },
     {
+      "group": "Programmatic Agents (v0)",
+      "pages": [
+        "cloud-api/sessions/launch",
+        "cloud-api/sessions/v0-list",
+        "cloud-api/sessions/v0-create",
+        "cloud-api/sessions/v0-get",
+        "cloud-api/sessions/v0-prompt",
+        "cloud-api/sessions/v0-git",
+        "cloud-api/sessions/v0-delete"
+      ]
+    },
+    {
+      "group": "Sandbox Lifecycle (v2)",
+      "pages": [
+        "cloud-api/sessions/v2-start",
+        "cloud-api/sessions/v2-refresh",
+        "cloud-api/sessions/v2-patch",
+        "cloud-api/sessions/v2-connect"
+      ]
+    },
+    {
       "group": "Deploy",
       "pages": [
         "cloud-api/deploy/info",

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -111,37 +111,67 @@
         "cloud-api/sessions/delete",
         "cloud-api/sessions/rename",
         "cloud-api/sessions/visibility",
-        "cloud-api/sessions/pause",
-        "cloud-api/sessions/resume",
-        "cloud-api/sessions/start",
-        "cloud-api/sessions/collaborators",
-        "cloud-api/sessions/heartbeat",
-        "cloud-api/sessions/workspace-state",
-        "cloud-api/sessions/files-list",
-        "cloud-api/sessions/files-read",
-        "cloud-api/sessions/files-write",
-        "cloud-api/sessions/files-delete",
-        "cloud-api/sessions/files-rename",
-        "cloud-api/sessions/files-mkdir",
-        "cloud-api/sessions/files-search",
-        "cloud-api/sessions/files-upload",
-        "cloud-api/sessions/files-download",
-        "cloud-api/sessions/run-server",
-        "cloud-api/sessions/env-vars-get",
-        "cloud-api/sessions/env-vars-set",
-        "cloud-api/sessions/env-vars-delete",
-        "cloud-api/sessions/detected-env-vars",
-        "cloud-api/sessions/detect-env-vars",
-        "cloud-api/sessions/prompt",
-        "cloud-api/sessions/prompt-cancel",
-        "cloud-api/sessions/prompt-rewind",
-        "cloud-api/sessions/history",
-        "cloud-api/sessions/events",
-        "cloud-api/sessions/instructions-get",
-        "cloud-api/sessions/instructions-set",
-        "cloud-api/sessions/git-clone",
-        "cloud-api/sessions/git-operation",
-        "cloud-api/sessions/git-sync"
+        {
+          "group": "Lifecycle",
+          "pages": [
+            "cloud-api/sessions/pause",
+            "cloud-api/sessions/resume",
+            "cloud-api/sessions/start",
+            "cloud-api/sessions/heartbeat",
+            "cloud-api/sessions/workspace-state",
+            "cloud-api/sessions/collaborators"
+          ]
+        },
+        {
+          "group": "Prompts",
+          "pages": [
+            "cloud-api/sessions/prompt",
+            "cloud-api/sessions/prompt-cancel",
+            "cloud-api/sessions/prompt-rewind",
+            "cloud-api/sessions/history",
+            "cloud-api/sessions/events"
+          ]
+        },
+        {
+          "group": "Files",
+          "pages": [
+            "cloud-api/sessions/files-list",
+            "cloud-api/sessions/files-read",
+            "cloud-api/sessions/files-write",
+            "cloud-api/sessions/files-delete",
+            "cloud-api/sessions/files-rename",
+            "cloud-api/sessions/files-mkdir",
+            "cloud-api/sessions/files-search",
+            "cloud-api/sessions/files-upload",
+            "cloud-api/sessions/files-download",
+            "cloud-api/sessions/run-server"
+          ]
+        },
+        {
+          "group": "Env Vars",
+          "pages": [
+            "cloud-api/sessions/env-vars-get",
+            "cloud-api/sessions/env-vars-set",
+            "cloud-api/sessions/env-vars-delete",
+            "cloud-api/sessions/detected-env-vars",
+            "cloud-api/sessions/detect-env-vars"
+          ]
+        },
+        {
+          "group": "Instructions",
+          "pages": [
+            "cloud-api/sessions/instructions-get",
+            "cloud-api/sessions/instructions-set"
+          ]
+        },
+        {
+          "group": "Git",
+          "pages": [
+            "cloud-api/sessions/git-clone",
+            "cloud-api/sessions/git-operation",
+            "cloud-api/sessions/git-sync"
+          ]
+        }
       ]
     },
     {
@@ -165,26 +195,46 @@
         "cloud-api/templates/create",
         "cloud-api/templates/update-config",
         "cloud-api/templates/delete",
-        "cloud-api/templates/build",
-        "cloud-api/templates/build-logs",
-        "cloud-api/templates/build-logs-history",
-        "cloud-api/templates/secrets-list",
-        "cloud-api/templates/secrets-update",
-        "cloud-api/templates/secret-delete",
-        "cloud-api/templates/fix-session",
-        "cloud-api/templates/save-snapshot"
+        {
+          "group": "Builds",
+          "pages": [
+            "cloud-api/templates/build",
+            "cloud-api/templates/build-logs",
+            "cloud-api/templates/build-logs-history",
+            "cloud-api/templates/fix-session",
+            "cloud-api/templates/save-snapshot"
+          ]
+        },
+        {
+          "group": "Secrets",
+          "pages": [
+            "cloud-api/templates/secrets-list",
+            "cloud-api/templates/secrets-update",
+            "cloud-api/templates/secret-delete"
+          ]
+        }
       ]
     },
     {
       "group": "Secrets",
       "pages": [
-        "cloud-api/secrets/personal-list",
-        "cloud-api/secrets/personal-set",
-        "cloud-api/secrets/personal-delete",
-        "cloud-api/secrets/team-list",
-        "cloud-api/secrets/team-set",
-        "cloud-api/secrets/team-delete",
-        "cloud-api/secrets/resolved"
+        "cloud-api/secrets/resolved",
+        {
+          "group": "Personal",
+          "pages": [
+            "cloud-api/secrets/personal-list",
+            "cloud-api/secrets/personal-set",
+            "cloud-api/secrets/personal-delete"
+          ]
+        },
+        {
+          "group": "Team",
+          "pages": [
+            "cloud-api/secrets/team-list",
+            "cloud-api/secrets/team-set",
+            "cloud-api/secrets/team-delete"
+          ]
+        }
       ]
     },
     {
@@ -194,19 +244,24 @@
         "cloud-api/context/user-instructions-set",
         "cloud-api/context/org-instructions-get",
         "cloud-api/context/org-instructions-set",
-        "cloud-api/context/skills/list",
-        "cloud-api/context/skills/create",
-        "cloud-api/context/skills/get",
-        "cloud-api/context/skills/patch",
-        "cloud-api/context/skills/delete",
-        "cloud-api/context/skills/version",
-        "cloud-api/context/skills/publish",
-        "cloud-api/context/skills/resync",
-        "cloud-api/context/skills/presign-upload",
-        "cloud-api/context/skills/discover-in-repo",
-        "cloud-api/context/skills/import",
-        "cloud-api/context/skills/attachments-list",
-        "cloud-api/context/skills/attachments-replace"
+        {
+          "group": "Skills",
+          "pages": [
+            "cloud-api/context/skills/list",
+            "cloud-api/context/skills/create",
+            "cloud-api/context/skills/get",
+            "cloud-api/context/skills/patch",
+            "cloud-api/context/skills/delete",
+            "cloud-api/context/skills/version",
+            "cloud-api/context/skills/publish",
+            "cloud-api/context/skills/resync",
+            "cloud-api/context/skills/presign-upload",
+            "cloud-api/context/skills/discover-in-repo",
+            "cloud-api/context/skills/import",
+            "cloud-api/context/skills/attachments-list",
+            "cloud-api/context/skills/attachments-replace"
+          ]
+        }
       ]
     },
     {
@@ -238,29 +293,49 @@
     {
       "group": "Provider Keys",
       "pages": [
-        "cloud-api/provider-keys/user-get",
-        "cloud-api/provider-keys/user-set",
-        "cloud-api/provider-keys/user-delete",
-        "cloud-api/provider-keys/org-get",
-        "cloud-api/provider-keys/org-set",
-        "cloud-api/provider-keys/org-delete",
         "cloud-api/provider-keys/resolved",
-        "cloud-api/provider-keys/current-plan"
+        "cloud-api/provider-keys/current-plan",
+        {
+          "group": "User Keys",
+          "pages": [
+            "cloud-api/provider-keys/user-get",
+            "cloud-api/provider-keys/user-set",
+            "cloud-api/provider-keys/user-delete"
+          ]
+        },
+        {
+          "group": "Org Keys",
+          "pages": [
+            "cloud-api/provider-keys/org-get",
+            "cloud-api/provider-keys/org-set",
+            "cloud-api/provider-keys/org-delete"
+          ]
+        }
       ]
     },
     {
       "group": "Activity",
       "pages": [
-        "cloud-api/activity/personal-activity",
-        "cloud-api/activity/personal-summary",
-        "cloud-api/activity/recent-prompts",
-        "cloud-api/activity/session-usage",
-        "cloud-api/activity/team-summary",
-        "cloud-api/activity/team-activity",
-        "cloud-api/activity/team-members",
-        "cloud-api/activity/team-deploy-metrics",
-        "cloud-api/activity/team-events",
-        "cloud-api/activity/team-traces"
+        {
+          "group": "Personal",
+          "pages": [
+            "cloud-api/activity/personal-activity",
+            "cloud-api/activity/personal-summary",
+            "cloud-api/activity/recent-prompts",
+            "cloud-api/activity/session-usage"
+          ]
+        },
+        {
+          "group": "Team",
+          "pages": [
+            "cloud-api/activity/team-summary",
+            "cloud-api/activity/team-activity",
+            "cloud-api/activity/team-members",
+            "cloud-api/activity/team-deploy-metrics",
+            "cloud-api/activity/team-events",
+            "cloud-api/activity/team-traces"
+          ]
+        }
       ]
     },
     {

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -145,27 +145,6 @@
       ]
     },
     {
-      "group": "Programmatic Agents (v0)",
-      "pages": [
-        "cloud-api/sessions/launch",
-        "cloud-api/sessions/v0-list",
-        "cloud-api/sessions/v0-create",
-        "cloud-api/sessions/v0-get",
-        "cloud-api/sessions/v0-prompt",
-        "cloud-api/sessions/v0-git",
-        "cloud-api/sessions/v0-delete"
-      ]
-    },
-    {
-      "group": "Sandbox Lifecycle (v2)",
-      "pages": [
-        "cloud-api/sessions/v2-start",
-        "cloud-api/sessions/v2-refresh",
-        "cloud-api/sessions/v2-patch",
-        "cloud-api/sessions/v2-connect"
-      ]
-    },
-    {
       "group": "Deploy",
       "pages": [
         "cloud-api/deploy/info",


### PR DESCRIPTION
## Summary

The Sessions API reference was missing the v0 (programmatic API-key) and v2 (sandbox lifecycle) surfaces — only the launch endpoint existed for v0 and it wasn't even wired into the sidebar nav, so users searching for "launch" got no result.

This PR makes both versions discoverable and labels the legacy v1 endpoints they replace.

## Changes

**New v0 reference pages** (`Programmatic Agents (v0)` group):
- ``cloud-api/sessions/v0-list.mdx`` — `GET /api/v0/sessions`
- ``cloud-api/sessions/v0-create.mdx`` — `POST /api/v0/sessions`
- ``cloud-api/sessions/v0-get.mdx`` — `GET /api/v0/sessions/{id}` (with `last_prompt` polling fields, `prompt_history`, `lifecycle`)
- ``cloud-api/sessions/v0-prompt.mdx`` — `POST /api/v0/sessions/{id}/prompt` (SSE streaming)
- ``cloud-api/sessions/v0-git.mdx`` — `POST /api/v0/sessions/{id}/git` (commit, push, create PR, etc.)
- ``cloud-api/sessions/v0-delete.mdx`` — `DELETE /api/v0/sessions/{id}`

**New v2 reference pages** (`Sandbox Lifecycle (v2)` group):
- ``cloud-api/sessions/v2-start.mdx`` — `POST /api/v2/sessions/{id}/start` (sandbox-only, no dev-server)
- ``cloud-api/sessions/v2-refresh.mdx`` — `POST /api/v2/sessions/{id}/refresh` (replaces `/heartbeat`)
- ``cloud-api/sessions/v2-patch.mdx`` — `PATCH /api/v2/sessions/{id}` (tabs)
- ``cloud-api/sessions/v2-connect.mdx`` — `POST /api/v2/sessions/{id}/connect?port=N` (preview URL)

**Nav** (`docs/mint.json`): two new groups added immediately after `Sessions`. The previously-orphaned `cloud-api/sessions/launch` is now wired in under `Programmatic Agents (v0)`.

**Deprecations**: added `<Warning>` banners to ``cloud-api/sessions/start.mdx`` and ``cloud-api/sessions/heartbeat.mdx`` pointing at their v2 replacements.

**Cross-links**: ``launch.mdx`` now references the rest of the v0 surface so readers landing there can navigate to follow-up endpoints.

## Test plan

- [ ] Mintlify auto-deploy succeeds on merge (no validation errors in `mint.json`)
- [ ] `https://docs.runtm.com/cloud-api/sessions/launch` is reachable via sidebar search for "launch"
- [ ] All 10 new pages render and appear under the two new sidebar groups
- [ ] Deprecation warnings render on `start` and `heartbeat`


Made with [Cursor](https://cursor.com)