### PR TITLE
docs: re-expose Sessions API v0 + v2 nav groups

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -176,6 +176,27 @@
       ]
     },
     {
+      "group": "Programmatic Agents (v0)",
+      "pages": [
+        "cloud-api/sessions/launch",
+        "cloud-api/sessions/v0-list",
+        "cloud-api/sessions/v0-create",
+        "cloud-api/sessions/v0-get",
+        "cloud-api/sessions/v0-prompt",
+        "cloud-api/sessions/v0-git",
+        "cloud-api/sessions/v0-delete"
+      ]
+    },
+    {
+      "group": "Sandbox Lifecycle (v2)",
+      "pages": [
+        "cloud-api/sessions/v2-start",
+        "cloud-api/sessions/v2-refresh",
+        "cloud-api/sessions/v2-patch",
+        "cloud-api/sessions/v2-connect"
+      ]
+    },
+    {
       "group": "Deploy",
       "pages": [
         "cloud-api/deploy/info",


### PR DESCRIPTION
## Summary

Restores the two Sessions API sidebar groups that went live briefly and then disappeared:

- **Programmatic Agents (v0)** — `launch`, `v0-list`, `v0-create`, `v0-get`, `v0-prompt`, `v0-git`, `v0-delete`
- **Sandbox Lifecycle (v2)** — `v2-start`, `v2-refresh`, `v2-patch`, `v2-connect`

All 11 `.mdx` files already exist under `docs/cloud-api/sessions/` — they've just been orphaned from the sidebar since [75cdd68](https://github.com/runtm-ai/runtm/commit/75cdd68), so readers can only reach them via a direct link.

## What changed and why

- **Added in [#18](https://github.com/runtm-ai/runtm/pull/18) ([a625345](https://github.com/runtm-ai/runtm/commit/a625345))**: the v0 / v2 nav groups were introduced specifically to "make both versions discoverable and label the legacy v1 endpoints they replace."
- **Hidden in [75cdd68](https://github.com/runtm-ai/runtm/commit/75cdd68)**: bundled into a commit titled *"docs: remove E2B branding and em dashes from all doc pages,"* whose third bullet is: *"Hide Programmatic Agents (v0) and Sandbox Lifecycle (v2) nav groups from mint.json (pages kept on disk, just not wired into sidebar)."*
- **This PR**: re-adds those exact 21 lines back into `docs/mint.json`, restoring the original intent from #18.

## Diff

Pure additive change to `docs/mint.json`. No code, schemas, or scopes touched. The endpoints these pages document (`/api/v0/sessions/*`, `/api/v2/sessions/*`) use the existing `sessions:read` / `sessions:write` scopes already defined in `cloud-api/scopes.mdx`, so this surfaces nothing that isn't already accessible to API-key holders.

## For reviewers

Worth a sanity check:

1. **Was the hide intentional?** If v0/v2 were hidden because the endpoints aren't ready for public consumption (rollout, SLA, or naming concerns), this PR should be deferred — the bundled commit message reads more like grooming than a deliberate gating decision, but the original author would know best.
2. **Page accuracy.** The 11 pages have been frozen since May; quickly skim that response shapes / scope requirements still match production.
3. **There are also five aggregator/overview pages on disk that aren't in the nav** (`manage`, `lifecycle`, `metadata`, `instructions`, `env-vars`) — they look like they were superseded by the nested-collapsible-groups reorg in [e998289](https://github.com/runtm-ai/runtm/commit/e998289). Out of scope for this PR; flag if you want them addressed separately.

## Test plan

- [ ] `python3 -c "import json; json.load(open('docs/mint.json'))"` (validated locally — passes)
- [ ] All 11 referenced `.mdx` paths resolve (verified locally — all present)
- [ ] Mintlify preview renders the two new sidebar groups under "Sessions"