### PR TITLE
fix(api): rework DB pool config for PgBouncer + fix deployments N+1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Agent CLI**: `runtm-api session list` now uses the hosted cloud proxy URL consistently instead of leaking the internal `localhost:8081` backend URL when listing sessions through `https://app.runtm.com/api/cloud`
+- **API**: Reworked DB connection pool config to stop recurring `SSL connection has been closed unexpectedly` errors behind Fly MPG's PgBouncer
+  - Lowered `pool_recycle` from 1800s to 300s so connections are recycled well before the upstream pooler closes idle server connections — previously ~1/3 of `pool_pre_ping` probes were hitting dead connections
+  - Added TCP keepalives (`keepalives_idle=30`, `keepalives_interval=10`, `keepalives_count=3`) so the kernel detects half-open connections instead of failing on next use
+  - Reverted `pool_size` from 10 back to 5; the 0.2.18 bump to 10 did not resolve the SSL drops, and the recycle + keepalives changes address the root cause instead
+- **API**: Fixed N+1 query in `list_deployments` — eager-load `Deployment.provider_resource` via `joinedload` so `DeploymentResponse.from_db()` no longer issues one extra query per deployment to read `provider_resource.app_name`
 
 ## [0.2.21] - 2026-05-10
 

--- a/packages/api/runtm_api/db/session.py
+++ b/packages/api/runtm_api/db/session.py
@@ -30,14 +30,26 @@ def get_engine():
         _engine = create_engine(
             settings.database_url,
             pool_pre_ping=True,
-            pool_size=10,
+            pool_size=5,
             max_overflow=10,
             pool_timeout=30,
-            pool_recycle=1800,
+            # Recycle well below the upstream pooler's idle timeout. In prod the DB
+            # sits behind Fly MPG's PgBouncer, which closes idle server connections
+            # long before the previous 1800s -- ~1/3 of pre-ping probes were hitting
+            # dead connections ("SSL connection has been closed unexpectedly").
+            pool_recycle=300,
             pool_use_lifo=True,
-            connect_args={"connect_timeout": 5},
+            connect_args={
+                "connect_timeout": 5,
+                # TCP keepalives so the kernel notices half-open connections that
+                # the pooler/network dropped, instead of failing on next use.
+                "keepalives": 1,
+                "keepalives_idle": 30,
+                "keepalives_interval": 10,
+                "keepalives_count": 3,
+            },
         )
-        logger.info("Created SQLAlchemy engine (pool_size=10, max_overflow=10, lifo=True)")
+        logger.info("Created SQLAlchemy engine (pool_size=5, max_overflow=10, lifo=True)")
     return _engine
 
 

--- a/packages/api/runtm_api/routes/deployments.py
+++ b/packages/api/runtm_api/routes/deployments.py
@@ -18,7 +18,7 @@ from fastapi import (
 )
 from pydantic import BaseModel
 from sqlalchemy import and_
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from runtm_api.auth import get_auth_context, require_scope
 from runtm_api.core.config import Settings, get_settings
@@ -360,8 +360,17 @@ async def list_deployments(
     # Get total count
     total = query.count()
 
-    # Apply pagination and ordering
-    deployments = query.order_by(Deployment.created_at.desc()).offset(offset).limit(limit).all()
+    # Apply pagination and ordering.
+    # joinedload(provider_resource) eager-loads the one-to-one relationship in the
+    # same SELECT -- DeploymentResponse.from_db() reads provider_resource.app_name,
+    # which otherwise lazy-loads one extra query per row (N+1).
+    deployments = (
+        query.options(joinedload(Deployment.provider_resource))
+        .order_by(Deployment.created_at.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
 
     return DeploymentsListResponse(
         deployments=[DeploymentResponse.from_db(dep) for dep in deployments],


### PR DESCRIPTION
Stop recurring "SSL connection has been closed unexpectedly" errors behind Fly MPG's PgBouncer:
- Lower pool_recycle 1800s -> 300s so connections recycle before the upstream pooler closes idle server connections (~1/3 of pre-ping probes were hitting dead connections)
- Add TCP keepalives so the kernel detects half-open connections
- Revert pool_size 10 -> 5; the 0.2.18 bump did not fix the drops, recycle + keepalives address the root cause

Also fix an N+1 in list_deployments by eager-loading Deployment.provider_resource via joinedload, since DeploymentResponse.from_db() reads provider_resource.app_name.

## Description

Brief description of the changes in this PR.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Checklist

- [x] My code follows the project's style guidelines (`ruff check .` passes)
- [x] I have formatted my code (`ruff format .`)
- [ ] I have added tests that prove my fix/feature works
- [x] All tests pass (`pytest`)
- [ ] I have updated documentation if needed
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Describe how you tested these changes.

## Screenshots (if applicable)

Add screenshots for UI changes.
