### PR TITLE
feat(cli): interactive SSH/terminal sessions and org template management

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,21 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 
+      - name: Compute version
+        id: version
+        # Build-number versioning: 0.2.<run_number>. run_number is monotonic per
+        # workflow; the +100 floor keeps it safely above the last hand-published
+        # 0.2.21. Bump the "0.2" prefix below by hand when cutting a new minor.
+        run: echo "value=0.2.$((100 + ${{ github.run_number }}))" >> "$GITHUB_OUTPUT"
+
+      - name: Set package versions
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          for pkg in cli worker api; do
+            (cd "packages/$pkg" && uv version "$VERSION")
+          done
+
       - name: Build runtm (CLI)
         working-directory: packages/cli
         run: uv build
@@ -29,6 +44,8 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        run: uv publish packages/cli/dist/* packages/worker/dist/* packages/api/dist/*
+        # --check-url lets uv skip files already present on the index instead of
+        # failing the job, so pushes to main that don't bump the version are no-ops.
+        run: uv publish --check-url https://pypi.org/simple/ packages/cli/dist/* packages/worker/dist/* packages/api/dist/*
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -65,10 +65,11 @@ jobs:
 
       - name: Determine prerelease status
         id: prerelease
-        # v0.x.x or any tag with a `-suffix` (e.g. v1.0.0-rc1) ships as prerelease.
+        # Only tags with a `-suffix` (e.g. v1.0.0-rc1) ship as prerelease.
+        # Normal releases — including v0.x — publish as full releases.
         run: |
           CLEAN="${{ steps.version.outputs.clean_tag }}"
-          if [[ "${CLEAN}" =~ ^v0\. ]] || [[ "${CLEAN}" =~ - ]]; then
+          if [[ "${CLEAN}" =~ - ]]; then
             echo "flag=--prerelease" >> "$GITHUB_OUTPUT"
           else
             echo "flag=" >> "$GITHUB_OUTPUT"

--- a/packages/agent/go.mod
+++ b/packages/agent/go.mod
@@ -2,9 +2,14 @@ module github.com/runtm-ai/runtm/packages/agent
 
 go 1.23.4
 
-require github.com/spf13/cobra v1.10.2
+require (
+	github.com/coder/websocket v1.8.15
+	github.com/spf13/cobra v1.10.2
+	golang.org/x/term v0.27.0
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/sys v0.28.0 // indirect
 )

--- a/packages/agent/go.sum
+++ b/packages/agent/go.sum
@@ -1,3 +1,5 @@
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
@@ -7,4 +9,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
+golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/packages/agent/internal/cmd/root.go
+++ b/packages/agent/internal/cmd/root.go
@@ -45,6 +45,7 @@ Docs: https://docs.runtm.com`,
 	sessionCmd := NewSessionCommand(rt)
 	AddSessionExtras(sessionCmd, rt)
 	AddSessionDeploy(sessionCmd, rt)
+	AddSessionTerminal(sessionCmd, rt)
 
 	root.AddCommand(
 		NewAuthCommand(rt),
@@ -72,6 +73,12 @@ func Execute() int {
 	if err := build.cmd.Execute(); err != nil {
 		if errors.Is(err, errSilent) {
 			return ExitOK
+		}
+		// `session exec` mirrors the remote command's exit code; its output
+		// already went to stdout, so don't print an error envelope.
+		var ece *exitCodeError
+		if errors.As(err, &ece) {
+			return ece.ExitCode()
 		}
 		return build.rt.ReportError(err)
 	}

--- a/packages/agent/internal/cmd/session.go
+++ b/packages/agent/internal/cmd/session.go
@@ -54,22 +54,30 @@ See https://docs.runtm.com/cloud-api/sessions for endpoint details.`,
 
 func newSessionCreate(rt *Runtime) *cobra.Command {
 	var (
-		agent      string
-		template   string
-		mode       string
-		onComplete string
-		ttlMinutes int
-		repoFull   string
-		repoSize   int
-		source     string
+		agent        string
+		template     string
+		templateID   string
+		templateArgs map[string]string
+		mode         string
+		onComplete   string
+		ttlMinutes   int
+		repoFull     string
+		repoSize     int
+		source       string
 	)
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a session (POST /api/sessions/)",
-		Long: `Creates a session backed by an E2B sandbox. Without --template the session
-boots with a blank sandbox; pass --template to scaffold a project. Sessions
-booted from org templates today flow through the dashboard which sets the
-internal org_template metadata; the API CLI does not yet expose that path.
+		Long: `Creates a session backed by an E2B sandbox. With no flags the session boots
+a blank sandbox.
+
+Boot sources (highest precedence first):
+  --template-id <uuid>   Launch from a pre-built org template (use
+                         'runtm-api template list' to find the id). Pass
+                         per-session args with --template-args key=value.
+  --repo owner/repo      Clone a GitHub repo into a fresh sandbox.
+  --template <scaffold>  Scaffold a starter project (web-app, backend-service,
+                         static-site).
 
 See https://docs.runtm.com/cloud-api/sessions/create for the full schema.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -86,6 +94,16 @@ See https://docs.runtm.com/cloud-api/sessions/create for the full schema.`,
 			}
 			if template != "" {
 				body["template"] = template
+			}
+			if templateID != "" {
+				body["template_id"] = templateID
+			}
+			if len(templateArgs) > 0 {
+				args := make(map[string]any, len(templateArgs))
+				for k, v := range templateArgs {
+					args[k] = v
+				}
+				body["template_args"] = args
 			}
 			if mode != "" {
 				body["mode"] = mode
@@ -114,6 +132,8 @@ See https://docs.runtm.com/cloud-api/sessions/create for the full schema.`,
 	}
 	cmd.Flags().StringVar(&agent, "agent", "", "Coding agent (claude-code, codex, opencode, github-copilot, cursor-cli, devin-cli, gemini-cli)")
 	cmd.Flags().StringVar(&template, "template", "", "Project template scaffold (web-app, backend-service, static-site)")
+	cmd.Flags().StringVar(&templateID, "template-id", "", "Org template UUID to boot from (takes precedence over --template and --repo)")
+	cmd.Flags().StringToStringVar(&templateArgs, "template-args", nil, "Org template session args as key=value pairs (only with --template-id)")
 	cmd.Flags().StringVar(&mode, "mode", "", "Session mode: autopilot (default) or interactive")
 	cmd.Flags().StringVar(&onComplete, "on-complete", "", "Lifecycle action after prompts complete: pause, destroy, keep_alive")
 	cmd.Flags().IntVar(&ttlMinutes, "ttl-minutes", 0, "Max session lifetime in minutes (1-1440)")

--- a/packages/agent/internal/cmd/session_terminal_cmd.go
+++ b/packages/agent/internal/cmd/session_terminal_cmd.go
@@ -1,0 +1,441 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/runtm-ai/runtm/packages/agent/internal/auth"
+	"github.com/runtm-ai/runtm/packages/agent/internal/client"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// AddSessionTerminal attaches WebSocket-backed terminal commands to the session
+// command tree:
+//
+//	session connect <id>          interactive PTY (raw passthrough)
+//	session exec <id> -- <cmd>    run one command, capture output, exit code
+//
+// Both leverage the same /api/sessions/{id}/terminal WebSocket the dashboard
+// uses. Terminal access is gated by a short-lived signed token minted via
+// POST /api/sessions/{id}/ws-token (capability "terminal", scope
+// sessions:terminal), so the API key must carry that scope.
+func AddSessionTerminal(sessionCmd *cobra.Command, rt *Runtime) {
+	sessionCmd.AddCommand(
+		newSessionConnect(rt),
+		newSessionExec(rt),
+	)
+}
+
+// --- shared transport -----------------------------------------------------
+
+// mintTerminalToken exchanges the API key for a short-lived (5 min) terminal
+// token. The WebSocket endpoint does not accept the API key directly.
+func mintTerminalToken(c *client.Client, sessionID string) (string, error) {
+	resp, err := c.PostJSON(
+		"/sessions/"+url.PathEscape(sessionID)+"/ws-token",
+		map[string]any{"capability": "terminal"},
+	)
+	if err != nil {
+		return "", err
+	}
+	var out struct {
+		Token string `json:"token"`
+	}
+	if jerr := json.Unmarshal(resp, &out); jerr != nil || out.Token == "" {
+		return "", fmt.Errorf("could not parse terminal token from ws-token response: %w", jerr)
+	}
+	return out.Token, nil
+}
+
+// terminalWSURL turns the REST API base URL into the ws(s) terminal URL,
+// carrying the minted token plus PTY sizing/identity as query params.
+func terminalWSURL(apiURL, sessionID, token, terminalID string, cols, rows int) (string, error) {
+	u, err := url.Parse(strings.TrimRight(apiURL, "/"))
+	if err != nil {
+		return "", fmt.Errorf("invalid api url %q: %w", apiURL, err)
+	}
+	switch u.Scheme {
+	case "https":
+		u.Scheme = "wss"
+	case "http":
+		u.Scheme = "ws"
+	case "ws", "wss":
+		// already a websocket scheme
+	default:
+		return "", fmt.Errorf("unsupported api url scheme %q (expected http/https)", u.Scheme)
+	}
+	u.Path = u.Path + "/sessions/" + sessionID + "/terminal"
+	q := url.Values{}
+	q.Set("token", token)
+	q.Set("terminal", terminalID)
+	q.Set("user", "cli")
+	if cols > 0 {
+		q.Set("cols", strconv.Itoa(cols))
+	}
+	if rows > 0 {
+		q.Set("rows", strconv.Itoa(rows))
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// dialTerminal mints a token and opens the terminal WebSocket. The auth headers
+// mirror the REST client; the token query param is the real authorizer.
+func dialTerminal(ctx context.Context, c *client.Client, creds *auth.Credentials, sessionID, terminalID string, cols, rows int) (*websocket.Conn, error) {
+	token, err := mintTerminalToken(c, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	wsURL, err := terminalWSURL(creds.APIURL, sessionID, token, terminalID, cols, rows)
+	if err != nil {
+		return nil, err
+	}
+	h := http.Header{}
+	h.Set("Authorization", "Bearer "+creds.APIKey)
+	if creds.OrganizationID != "" {
+		h.Set("X-Organization-Id", creds.OrganizationID)
+	}
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: h})
+	if err != nil {
+		return nil, fmt.Errorf("terminal websocket dial failed: %w", err)
+	}
+	// PTY replay buffers on reconnect can be large; lift the default 32KiB cap.
+	conn.SetReadLimit(32 << 20)
+	return conn, nil
+}
+
+// safeConn serializes writes — coder/websocket forbids concurrent Write calls,
+// and `connect` writes input (stdin goroutine) and pong/resize (read loop).
+type safeConn struct {
+	c  *websocket.Conn
+	mu sync.Mutex
+}
+
+func (s *safeConn) write(ctx context.Context, typ websocket.MessageType, b []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.c.Write(ctx, typ, b)
+}
+
+// controlMessage is the text-frame envelope the terminal server emits.
+type controlMessage struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// --- connect (interactive PTY) -------------------------------------------
+
+func newSessionConnect(rt *Runtime) *cobra.Command {
+	var terminalID string
+	cmd := &cobra.Command{
+		Use:   "connect <session_id>",
+		Short: "Attach an interactive terminal to a session (WebSocket PTY)",
+		Long: `Opens a raw, interactive shell against the session's sandbox over the same
+WebSocket the dashboard terminal uses. Keystrokes (including Ctrl-C) pass
+straight through to the remote PTY. Resize the window and the remote PTY
+follows. Exit the remote shell ('exit' or Ctrl-D) to disconnect.
+
+Requires a TTY on stdin. For scripted, non-interactive command execution use
+'runtm-api session exec' instead.
+
+Scope required: sessions:terminal.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sessionID := args[0]
+			// Default to a fresh terminal per invocation (like opening a new
+			// tab) so reconnecting never replays a dead shell's state. Pass
+			// --terminal to attach to a specific one.
+			if terminalID == "" {
+				terminalID = fmt.Sprintf("cli-%d", time.Now().UnixNano())
+			}
+			stdinFd := int(os.Stdin.Fd())
+			if !term.IsTerminal(stdinFd) {
+				return fmt.Errorf("session connect requires an interactive terminal on stdin; use 'session exec' for scripted commands")
+			}
+
+			c, creds, err := rt.Client()
+			if err != nil {
+				return err
+			}
+
+			cols, rows, err := term.GetSize(stdinFd)
+			if err != nil || cols == 0 {
+				cols, rows = 80, 24
+			}
+
+			ctx, cancel := context.WithCancel(cmd.Context())
+			defer cancel()
+
+			conn, err := dialTerminal(ctx, c, creds, sessionID, terminalID, cols, rows)
+			if err != nil {
+				return err
+			}
+			defer conn.Close(websocket.StatusNormalClosure, "client done")
+			sc := &safeConn{c: conn}
+
+			// Raw mode so keystrokes/control chars flow untouched to the PTY.
+			oldState, err := term.MakeRaw(stdinFd)
+			if err != nil {
+				return fmt.Errorf("failed to set terminal raw mode: %w", err)
+			}
+			defer term.Restore(stdinFd, oldState)
+
+			// stdin -> websocket (binary frames).
+			go func() {
+				buf := make([]byte, 4096)
+				for {
+					n, readErr := os.Stdin.Read(buf)
+					if n > 0 {
+						if werr := sc.write(ctx, websocket.MessageBinary, buf[:n]); werr != nil {
+							cancel()
+							return
+						}
+					}
+					if readErr != nil {
+						cancel()
+						return
+					}
+				}
+			}()
+
+			// SIGWINCH -> resize control frame.
+			winch := make(chan os.Signal, 1)
+			signal.Notify(winch, syscall.SIGWINCH)
+			defer signal.Stop(winch)
+			go func() {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-winch:
+						nc, nr, gerr := term.GetSize(stdinFd)
+						if gerr != nil || nc == 0 {
+							continue
+						}
+						msg, _ := json.Marshal(map[string]any{"type": "resize", "cols": nc, "rows": nr})
+						_ = sc.write(ctx, websocket.MessageText, msg)
+					}
+				}
+			}()
+
+			// websocket -> stdout, plus control-frame handling.
+			for {
+				typ, data, rerr := conn.Read(ctx)
+				if rerr != nil {
+					// Normal close (remote shell exited) or our own cancel.
+					// Restore the terminal before printing so the hint renders
+					// in cooked mode, and remind the user the sandbox lives on
+					// — disconnecting does not pause it, and idle sandboxes
+					// eventually expire.
+					term.Restore(stdinFd, oldState)
+					fmt.Fprintf(rt.Stderr, "\nDisconnected — the sandbox is still running. Run 'runtm-api session pause %s' to preserve it (idle sandboxes expire).\n", sessionID)
+					return nil
+				}
+				if typ == websocket.MessageBinary {
+					os.Stdout.Write(data)
+					continue
+				}
+				var msg controlMessage
+				if json.Unmarshal(data, &msg) != nil {
+					continue
+				}
+				switch msg.Type {
+				case "ping":
+					pong, _ := json.Marshal(map[string]any{"type": "pong", "timestamp": time.Now().Unix()})
+					_ = sc.write(ctx, websocket.MessageText, pong)
+				case "error":
+					term.Restore(stdinFd, oldState)
+					fmt.Fprintf(rt.Stderr, "terminal error: %s\n", msg.Message)
+					return errSilent
+				case "sandbox_expired":
+					term.Restore(stdinFd, oldState)
+					fmt.Fprintf(rt.Stderr, "sandbox expired: %s\n", msg.Message)
+					return errSilent
+				}
+			}
+		},
+	}
+	cmd.Flags().StringVar(&terminalID, "terminal", "", "Attach to a specific terminal id (default: a fresh terminal each time; use 'default' to share the dashboard terminal)")
+	return cmd
+}
+
+// --- exec (one command, captured) ----------------------------------------
+
+// Markers are computed by the remote shell at runtime ($$ / $?), so the literal
+// command text the PTY echoes back ("__RUNTM_$$_S") can never false-match the
+// printed marker ("__RUNTM_<pid>_S"). The start regex captures the live pid.
+var execStartRe = regexp.MustCompile(`__RUNTM_(\d+)_S\r?\n`)
+
+// findExecStart looks for the start sentinel. On success it returns the remote
+// shell pid and the buffer slice positioned just after the marker (where the
+// command's real output begins).
+func findExecStart(buf []byte) (pid string, rest []byte, ok bool) {
+	m := execStartRe.FindSubmatchIndex(buf)
+	if m == nil {
+		return "", buf, false
+	}
+	return string(buf[m[2]:m[3]]), buf[m[1]:], true
+}
+
+// findExecEnd looks for the pid-bound end sentinel. On success it returns the
+// captured command output (everything before the marker) and the exit code.
+func findExecEnd(buf []byte, pid string) (output []byte, code int, ok bool) {
+	endRe := regexp.MustCompile(`__RUNTM_` + regexp.QuoteMeta(pid) + `_E(\d+)\r?\n`)
+	m := endRe.FindSubmatchIndex(buf)
+	if m == nil {
+		return nil, 0, false
+	}
+	code, _ = strconv.Atoi(string(buf[m[2]:m[3]]))
+	return buf[:m[0]], code, true
+}
+
+func newSessionExec(rt *Runtime) *cobra.Command {
+	var timeoutSec int
+	cmd := &cobra.Command{
+		Use:   "exec <session_id> -- <command> [args...]",
+		Short: "Run one command in a session over the terminal WebSocket",
+		Long: `Runs a single command inside the session's sandbox using the terminal
+WebSocket, streams its output to stdout, and exits with the command's exit
+code. A throwaway PTY is used so it never disturbs your interactive terminals.
+
+Put the command after '--' so its flags are not parsed by runtm-api:
+  runtm-api session exec <id> -- ls -la /workspace
+  runtm-api session exec <id> -- "npm test"
+
+Output is the raw PTY stream and may contain minor terminal formatting. Scope
+required: sessions:terminal.`,
+		Args: cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sessionID := args[0]
+			cmdLine := strings.TrimSpace(strings.Join(args[1:], " "))
+			if cmdLine == "" {
+				return fmt.Errorf("no command given; usage: session exec <id> -- <command>")
+			}
+
+			c, creds, err := rt.Client()
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			if timeoutSec > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
+				defer cancel()
+			}
+
+			// Unique, throwaway PTY id -> fresh shell, no clobbering UI terminals.
+			terminalID := fmt.Sprintf("cli-exec-%d", time.Now().UnixNano())
+			conn, err := dialTerminal(ctx, c, creds, sessionID, terminalID, 200, 50)
+			if err != nil {
+				return err
+			}
+			defer conn.Close(websocket.StatusNormalClosure, "exec done")
+			sc := &safeConn{c: conn}
+
+			// One command line: print start marker, run, print end marker + $?,
+			// then exit so the server tears the PTY down. Markers use $$ so the
+			// echoed input can't collide with the printed values.
+			payload := fmt.Sprintf(
+				"printf '__RUNTM_%%d_S\\n' \"$$\"; %s; __rc=$?; printf '__RUNTM_%%d_E%%d\\n' \"$$\" \"$__rc\"; exit\n",
+				cmdLine,
+			)
+
+			var (
+				buf     []byte
+				sent    bool
+				started bool
+				pid     string
+			)
+			sendOnce := func() error {
+				if sent {
+					return nil
+				}
+				sent = true
+				return sc.write(ctx, websocket.MessageBinary, []byte(payload))
+			}
+
+			for {
+				typ, data, rerr := conn.Read(ctx)
+				if rerr != nil {
+					return fmt.Errorf("connection closed before the command completed: %w", rerr)
+				}
+
+				if typ == websocket.MessageText {
+					var msg controlMessage
+					if json.Unmarshal(data, &msg) != nil {
+						continue
+					}
+					switch msg.Type {
+					case "connected":
+						if serr := sendOnce(); serr != nil {
+							return serr
+						}
+					case "ping":
+						pong, _ := json.Marshal(map[string]any{"type": "pong", "timestamp": time.Now().Unix()})
+						_ = sc.write(ctx, websocket.MessageText, pong)
+					case "error":
+						return fmt.Errorf("terminal error: %s", msg.Message)
+					case "sandbox_expired":
+						return fmt.Errorf("sandbox expired: %s", msg.Message)
+					}
+					continue
+				}
+
+				// Binary = PTY output. Ensure the command is sent even if no
+				// explicit "connected" frame arrived first.
+				if serr := sendOnce(); serr != nil {
+					return serr
+				}
+				buf = append(buf, data...)
+
+				if !started {
+					// Drop everything up to and including the start marker (the
+					// echoed input + shell prompt) so only real output remains.
+					pid, buf, started = findExecStart(buf)
+				}
+				if started {
+					if output, code, ok := findExecEnd(buf, pid); ok {
+						os.Stdout.Write(stripLeadingNewline(output))
+						if code != 0 {
+							return &exitCodeError{code: code}
+						}
+						return nil
+					}
+				}
+			}
+		},
+	}
+	cmd.Flags().IntVar(&timeoutSec, "timeout", 0, "Abort if the command runs longer than N seconds (0 = no timeout)")
+	return cmd
+}
+
+func stripLeadingNewline(b []byte) []byte {
+	if len(b) > 0 && b[0] == '\r' {
+		b = b[1:]
+	}
+	if len(b) > 0 && b[0] == '\n' {
+		b = b[1:]
+	}
+	return b
+}
+
+// exitCodeError carries a non-zero remote exit code up to Execute() so the CLI
+// process mirrors it without printing a spurious error envelope.
+type exitCodeError struct{ code int }
+
+func (e *exitCodeError) Error() string { return fmt.Sprintf("command exited with code %d", e.code) }
+func (e *exitCodeError) ExitCode() int { return e.code }

--- a/packages/agent/internal/cmd/session_terminal_cmd_test.go
+++ b/packages/agent/internal/cmd/session_terminal_cmd_test.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestTerminalWSURL(t *testing.T) {
+	cases := []struct {
+		name       string
+		apiURL     string
+		wantScheme string
+		wantPath   string
+	}{
+		{"local http", "http://localhost:8081/api", "ws", "/api/sessions/sess-1/terminal"},
+		{"prod https proxy", "https://app.runtm.com/api/cloud", "wss", "/api/cloud/sessions/sess-1/terminal"},
+		{"trailing slash", "http://localhost:8081/api/", "ws", "/api/sessions/sess-1/terminal"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := terminalWSURL(tc.apiURL, "sess-1", "tok123", "cli", 120, 40)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			u, err := url.Parse(raw)
+			if err != nil {
+				t.Fatalf("result not a valid url: %v", err)
+			}
+			if u.Scheme != tc.wantScheme {
+				t.Errorf("scheme = %q, want %q", u.Scheme, tc.wantScheme)
+			}
+			if u.Path != tc.wantPath {
+				t.Errorf("path = %q, want %q", u.Path, tc.wantPath)
+			}
+			q := u.Query()
+			if q.Get("token") != "tok123" {
+				t.Errorf("token = %q, want tok123", q.Get("token"))
+			}
+			if q.Get("cols") != "120" || q.Get("rows") != "40" {
+				t.Errorf("size = %sx%s, want 120x40", q.Get("cols"), q.Get("rows"))
+			}
+			if q.Get("terminal") != "cli" {
+				t.Errorf("terminal = %q, want cli", q.Get("terminal"))
+			}
+		})
+	}
+}
+
+func TestTerminalWSURL_BadScheme(t *testing.T) {
+	if _, err := terminalWSURL("ftp://nope/api", "s", "t", "cli", 80, 24); err == nil {
+		t.Fatal("expected error for unsupported scheme")
+	}
+}
+
+func TestFindExecStart(t *testing.T) {
+	// The PTY echoes the literal command (with $$), then the shell prints the
+	// resolved marker with the real pid. We must lock onto the printed one.
+	buf := []byte("printf '__RUNTM_%d_S\\n' \"$$\"; ls\r\n__RUNTM_4242_S\r\nfile-a\r\n")
+	pid, rest, ok := findExecStart(buf)
+	if !ok {
+		t.Fatal("expected start marker to be found")
+	}
+	if pid != "4242" {
+		t.Errorf("pid = %q, want 4242", pid)
+	}
+	if got := string(rest); got != "file-a\r\n" {
+		t.Errorf("rest = %q, want %q", got, "file-a\r\n")
+	}
+}
+
+func TestFindExecStart_NotYetPresent(t *testing.T) {
+	// Only the echoed command (with literal $$) has arrived — no real marker.
+	buf := []byte("printf '__RUNTM_%d_S\\n' \"$$\"; ls\r\n")
+	if _, _, ok := findExecStart(buf); ok {
+		t.Fatal("must not match the echoed command line containing $$")
+	}
+}
+
+func TestFindExecEnd(t *testing.T) {
+	buf := []byte("hello world\r\n__RUNTM_4242_E0\r\n")
+	out, code, ok := findExecEnd(buf, "4242")
+	if !ok {
+		t.Fatal("expected end marker to be found")
+	}
+	if code != 0 {
+		t.Errorf("code = %d, want 0", code)
+	}
+	if got := string(out); got != "hello world\r\n" {
+		t.Errorf("output = %q, want %q", got, "hello world\r\n")
+	}
+}
+
+func TestFindExecEnd_NonZeroCode(t *testing.T) {
+	buf := []byte("boom\r\n__RUNTM_77_E13\r\n")
+	out, code, ok := findExecEnd(buf, "77")
+	if !ok {
+		t.Fatal("expected end marker")
+	}
+	if code != 13 {
+		t.Errorf("code = %d, want 13", code)
+	}
+	if string(out) != "boom\r\n" {
+		t.Errorf("output = %q, want boom", string(out))
+	}
+}
+
+func TestFindExecEnd_WrongPidIgnored(t *testing.T) {
+	// An end marker for a different pid (shouldn't happen, but be strict).
+	buf := []byte("out\r\n__RUNTM_999_E0\r\n")
+	if _, _, ok := findExecEnd(buf, "4242"); ok {
+		t.Fatal("must not match end marker for a different pid")
+	}
+}
+
+func TestStripLeadingNewline(t *testing.T) {
+	cases := map[string]string{
+		"\nhello":   "hello",
+		"\r\nhello": "hello",
+		"hello":     "hello",
+		"":          "",
+	}
+	for in, want := range cases {
+		if got := string(stripLeadingNewline([]byte(in))); got != want {
+			t.Errorf("stripLeadingNewline(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/packages/agent/internal/cmd/template.go
+++ b/packages/agent/internal/cmd/template.go
@@ -1,13 +1,124 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/runtm-ai/runtm/packages/agent/internal/client"
 	"github.com/spf13/cobra"
 )
+
+// sessionArgInput is the JSON form accepted by --session-arg for full control
+// over a session argument (matches the backend SessionArgSchema). Pointers
+// distinguish "absent" from "explicit zero value" so defaults apply correctly.
+type sessionArgInput struct {
+	Key      string   `json:"key"`
+	Label    string   `json:"label"`
+	Type     string   `json:"type"`
+	Required *bool    `json:"required"`
+	Default  *string  `json:"default"`
+	Options  []string `json:"options"`
+	HelpText *string  `json:"help_text"`
+}
+
+// buildSessionArg normalizes and validates one session argument into the map
+// shape the PATCH /api/org-templates/{id} endpoint expects.
+func buildSessionArg(key, label, typ string, required bool, def any, options []string, helpText any) (map[string]any, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil, fmt.Errorf("session arg: key must not be empty")
+	}
+	if typ == "" {
+		typ = "text"
+	}
+	switch typ {
+	case "text", "select", "boolean":
+	default:
+		return nil, fmt.Errorf("session arg %q: type must be text, select, or boolean (got %q)", key, typ)
+	}
+	if label == "" {
+		label = key
+	}
+	if options == nil {
+		options = []string{}
+	}
+	if typ == "select" && len(options) == 0 {
+		return nil, fmt.Errorf("session arg %q: select type requires non-empty options", key)
+	}
+	return map[string]any{
+		"key":       key,
+		"label":     label,
+		"type":      typ,
+		"required":  required,
+		"default":   def,
+		"options":   options,
+		"help_text": helpText,
+	}, nil
+}
+
+// parseSessionArgs converts repeatable --session-arg specs into the session_args
+// payload. Each becomes an argument collected when a member launches a session
+// from the template and injected into the sandbox as an environment variable.
+//
+// Two forms are accepted per spec:
+//
+//	Shorthand (text args):
+//	  "KEY=DEFAULT"  -> optional text arg, defaulting to DEFAULT
+//	  "KEY"          -> required text arg, no default
+//
+//	JSON (full control over type/options/label/help_text/required):
+//	  '{"key":"ENV","type":"select","options":["dev","prod"],"default":"dev","required":true,"label":"Environment","help_text":"Target env"}'
+//	  '{"key":"VERBOSE","type":"boolean","default":"false"}'
+func parseSessionArgs(specs []string) ([]map[string]any, error) {
+	out := make([]map[string]any, 0, len(specs))
+	for _, spec := range specs {
+		s := strings.TrimSpace(spec)
+
+		if strings.HasPrefix(s, "{") {
+			var in sessionArgInput
+			if err := json.Unmarshal([]byte(s), &in); err != nil {
+				return nil, fmt.Errorf("invalid --session-arg JSON %q: %w", spec, err)
+			}
+			required := false
+			if in.Required != nil {
+				required = *in.Required
+			}
+			var def any
+			if in.Default != nil {
+				def = *in.Default
+			}
+			var help any
+			if in.HelpText != nil {
+				help = *in.HelpText
+			}
+			arg, err := buildSessionArg(in.Key, in.Label, in.Type, required, def, in.Options, help)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, arg)
+			continue
+		}
+
+		// Shorthand: KEY=DEFAULT (optional) or KEY (required), always text.
+		key := s
+		var def any
+		required := true
+		if i := strings.IndexByte(s, '='); i >= 0 {
+			key = s[:i]
+			def = s[i+1:]
+			required = false
+		}
+		arg, err := buildSessionArg(key, "", "text", required, def, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, arg)
+	}
+	return out, nil
+}
 
 // NewTemplateCommand returns `runtm template` for full org-template lifecycle.
 //
@@ -121,12 +232,22 @@ func newTemplateCreate(rt *Runtime) *cobra.Command {
 		githubRepo  string
 		branch      string
 		tier        string
+		build       bool
+		skipAgent   bool
+		sessionArgs []string
 	)
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a template from a GitHub repo (POST /api/org-templates)",
 		Long: `Creates the template record in 'pending' state. Trigger the build with
-'runtm template build <id>' after creation. The template is org-scoped.`,
+'runtm template build <id>' after creation, or pass --build to kick it off in
+the same call. --skip-agent (which implies --build) runs a clone-only build with
+no AI step -- the same "Skip AI setup" path the dashboard uses.
+
+Declare per-session arguments with --session-arg KEY=DEFAULT (repeatable); each
+is collected when a member launches a session from the template and injected as
+an environment variable. They are applied via a follow-up PATCH because the
+create endpoint does not accept them directly. The template is org-scoped.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if displayName == "" || githubRepo == "" {
 				return fmt.Errorf("--display-name and --github-repo are required")
@@ -148,7 +269,43 @@ func newTemplateCreate(rt *Runtime) *cobra.Command {
 				body["description"] = description
 			}
 			resp, err := c.PostJSON("/org-templates", body)
-			return runJSON(rt, resp, err)
+			if err != nil {
+				return runJSON(rt, resp, err)
+			}
+
+			// Nothing else to do -- emit the created template as-is.
+			if len(sessionArgs) == 0 && !build && !skipAgent {
+				return runJSON(rt, resp, nil)
+			}
+
+			var created struct {
+				ID string `json:"id"`
+			}
+			if jerr := json.Unmarshal(resp, &created); jerr != nil || created.ID == "" {
+				return fmt.Errorf("template created but its id could not be read for follow-up actions (set session args / build manually): %w", jerr)
+			}
+			path := "/org-templates/" + url.PathEscape(created.ID)
+
+			// Session args can't be set at create time -- PATCH them in.
+			if len(sessionArgs) > 0 {
+				parsed, perr := parseSessionArgs(sessionArgs)
+				if perr != nil {
+					return perr
+				}
+				patchResp, patchErr := c.PatchJSON(path, map[string]any{"session_args": parsed})
+				if patchErr != nil {
+					return runJSON(rt, patchResp, patchErr)
+				}
+				// The PATCH response carries the session_args; surface it unless
+				// we're also building (build response wins as the final state).
+				if !build && !skipAgent {
+					return runJSON(rt, patchResp, nil)
+				}
+			}
+
+			// --skip-agent only makes sense alongside a build, so it implies it.
+			buildResp, berr := c.PostJSON(path+"/build", map[string]any{"skip_agent": skipAgent})
+			return runJSON(rt, buildResp, berr)
 		},
 	}
 	cmd.Flags().StringVar(&displayName, "display-name", "", "Human-readable name (required)")
@@ -157,6 +314,9 @@ func newTemplateCreate(rt *Runtime) *cobra.Command {
 	cmd.Flags().StringVar(&githubRepo, "github-repo", "", "GitHub repo in owner/repo form (required)")
 	cmd.Flags().StringVar(&branch, "github-branch", "main", "Branch to clone")
 	cmd.Flags().StringVar(&tier, "tier", "basic", "Resource tier: basic, standard, max")
+	cmd.Flags().BoolVar(&build, "build", false, "Trigger the build immediately after creating")
+	cmd.Flags().BoolVar(&skipAgent, "skip-agent", false, "Clone-only build, no AI step (implies --build)")
+	cmd.Flags().StringArrayVar(&sessionArgs, "session-arg", nil, `Declare a session argument (repeatable). Shorthand: KEY=DEFAULT (optional text) or KEY (required text). For select/boolean/label/help, pass JSON: '{"key":"ENV","type":"select","options":["dev","prod"],"default":"dev"}'.`)
 	_ = cmd.MarkFlagRequired("display-name")
 	_ = cmd.MarkFlagRequired("github-repo")
 	return cmd
@@ -164,13 +324,21 @@ func newTemplateCreate(rt *Runtime) *cobra.Command {
 
 func newTemplateUpdate(rt *Runtime) *cobra.Command {
 	var (
-		displayName string
-		description string
+		displayName      string
+		description      string
+		sessionArgs      []string
+		restartAtStartup bool
+		startupScript    string
 	)
 	cmd := &cobra.Command{
 		Use:   "update <template_id>",
 		Short: "Update template metadata (PATCH /api/org-templates/{id})",
-		Args:  cobra.ExactArgs(1),
+		Long: `Update template fields. --session-arg replaces the full set of session
+arguments (pass it once per arg; omit to leave them unchanged). Shorthand:
+KEY=DEFAULT (optional text) or KEY (required text). For select/boolean/label/
+help, pass JSON per arg, e.g.
+'{"key":"ENV","type":"select","options":["dev","prod"],"default":"dev"}'.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, _, err := requireOrgClient(rt, "org templates")
 			if err != nil {
@@ -183,8 +351,21 @@ func newTemplateUpdate(rt *Runtime) *cobra.Command {
 			if cmd.Flags().Changed("description") {
 				body["description"] = description
 			}
+			if cmd.Flags().Changed("session-arg") {
+				parsed, perr := parseSessionArgs(sessionArgs)
+				if perr != nil {
+					return perr
+				}
+				body["session_args"] = parsed
+			}
+			if cmd.Flags().Changed("restart-at-startup") {
+				body["restart_at_startup"] = restartAtStartup
+			}
+			if cmd.Flags().Changed("startup-script") {
+				body["startup_script"] = startupScript
+			}
 			if len(body) == 0 {
-				return fmt.Errorf("pass at least one field to update (--display-name, --description)")
+				return fmt.Errorf("pass at least one field to update (--display-name, --description, --session-arg, --restart-at-startup, --startup-script)")
 			}
 			resp, err := c.PatchJSON("/org-templates/"+url.PathEscape(args[0]), body)
 			return runJSON(rt, resp, err)
@@ -192,6 +373,9 @@ func newTemplateUpdate(rt *Runtime) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&displayName, "display-name", "", "New display name")
 	cmd.Flags().StringVar(&description, "description", "", "New description (pass empty string to clear)")
+	cmd.Flags().StringArrayVar(&sessionArgs, "session-arg", nil, `Replace session args (repeatable). Shorthand KEY=DEFAULT / KEY, or JSON for select/boolean/label/help.`)
+	cmd.Flags().BoolVar(&restartAtStartup, "restart-at-startup", false, "Force-restart services (and run the startup script) on first sandbox boot")
+	cmd.Flags().StringVar(&startupScript, "startup-script", "", "Path to a startup script, relative to the workdir or absolute (empty string clears)")
 	return cmd
 }
 
@@ -288,13 +472,16 @@ func newTemplateBuildLogsHistory(rt *Runtime) *cobra.Command {
 func newTemplateFixSession(rt *Runtime) *cobra.Command {
 	var agent string
 	cmd := &cobra.Command{
-		Use:   "fix-session <template_id>",
-		Short: "Create a session against the template sandbox for iterative fixes",
-		Long: `Spins up an interactive session that boots the template's sandbox so an
-agent can investigate and fix issues. After the agent confirms the fix, call
-'runtm template save-snapshot <template_id> --session <session_id>' to
-promote the session state into the template snapshot.
+		Use:     "fix-session <template_id>",
+		Aliases: []string{"configure"},
+		Short:   "Open a session on the template's sandbox to configure it manually",
+		Long: `Spins up an interactive session that boots the template's sandbox so you (or
+an agent) can configure it by hand. The response includes a session_id; connect
+to it with 'runtm-api session connect <session_id>', make your changes, then run
+'runtm-api template save-snapshot <template_id> --session <session_id>' to
+promote the sandbox state into the template snapshot.
 
+Also available as 'runtm-api template configure <template_id>'.
 Required scope: templates:write.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/packages/agent/internal/cmd/template_test.go
+++ b/packages/agent/internal/cmd/template_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import "testing"
+
+func TestParseSessionArgs_Shorthand(t *testing.T) {
+	args, err := parseSessionArgs([]string{"BRANCH=main", "TOKEN"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 {
+		t.Fatalf("want 2 args, got %d", len(args))
+	}
+
+	// KEY=DEFAULT -> optional text with default
+	a := args[0]
+	if a["key"] != "BRANCH" || a["label"] != "BRANCH" || a["type"] != "text" {
+		t.Errorf("BRANCH base fields wrong: %#v", a)
+	}
+	if a["required"] != false {
+		t.Errorf("BRANCH should be optional, got required=%v", a["required"])
+	}
+	if a["default"] != "main" {
+		t.Errorf("BRANCH default = %v, want main", a["default"])
+	}
+
+	// KEY (no =) -> required, nil default
+	b := args[1]
+	if b["required"] != true {
+		t.Errorf("TOKEN should be required, got %v", b["required"])
+	}
+	if b["default"] != nil {
+		t.Errorf("TOKEN default = %v, want nil", b["default"])
+	}
+}
+
+func TestParseSessionArgs_JSONSelect(t *testing.T) {
+	spec := `{"key":"ENV","type":"select","options":["dev","prod"],"default":"dev","required":true,"label":"Environment","help_text":"Target env"}`
+	args, err := parseSessionArgs([]string{spec})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	a := args[0]
+	if a["key"] != "ENV" || a["type"] != "select" || a["label"] != "Environment" {
+		t.Errorf("select base fields wrong: %#v", a)
+	}
+	if a["required"] != true {
+		t.Errorf("required = %v, want true", a["required"])
+	}
+	if a["default"] != "dev" {
+		t.Errorf("default = %v, want dev", a["default"])
+	}
+	if a["help_text"] != "Target env" {
+		t.Errorf("help_text = %v, want 'Target env'", a["help_text"])
+	}
+	opts, ok := a["options"].([]string)
+	if !ok || len(opts) != 2 || opts[0] != "dev" || opts[1] != "prod" {
+		t.Errorf("options = %#v, want [dev prod]", a["options"])
+	}
+}
+
+func TestParseSessionArgs_JSONBoolean(t *testing.T) {
+	args, err := parseSessionArgs([]string{`{"key":"VERBOSE","type":"boolean","default":"false"}`})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	a := args[0]
+	if a["type"] != "boolean" || a["default"] != "false" {
+		t.Errorf("boolean fields wrong: %#v", a)
+	}
+	// label defaults to key, options default to empty slice, required defaults false
+	if a["label"] != "VERBOSE" || a["required"] != false {
+		t.Errorf("boolean defaults wrong: %#v", a)
+	}
+	if opts, ok := a["options"].([]string); !ok || len(opts) != 0 {
+		t.Errorf("options should default to empty slice, got %#v", a["options"])
+	}
+}
+
+func TestParseSessionArgs_Errors(t *testing.T) {
+	cases := map[string]string{
+		"empty key shorthand": "=oops",
+		"select no options":   `{"key":"ENV","type":"select"}`,
+		"bad type":            `{"key":"X","type":"number"}`,
+		"malformed json":      `{"key":"X",`,
+		"empty json key":      `{"type":"text"}`,
+	}
+	for name, spec := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseSessionArgs([]string{spec}); err == nil {
+				t.Errorf("expected error for %q, got nil", spec)
+			}
+		})
+	}
+}
+
+func TestParseSessionArgs_HelpTextOmittedIsNil(t *testing.T) {
+	// help_text and default absent -> nil (JSON null), not empty string.
+	args, err := parseSessionArgs([]string{`{"key":"X","type":"text"}`})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if args[0]["help_text"] != nil {
+		t.Errorf("help_text = %v, want nil", args[0]["help_text"])
+	}
+	if args[0]["default"] != nil {
+		t.Errorf("default = %v, want nil", args[0]["default"])
+	}
+}

--- a/packages/agent/internal/skills/files/SKILL.md
+++ b/packages/agent/internal/skills/files/SKILL.md
@@ -2,7 +2,7 @@
 name: runtm
 description: "Runtm (Runtime) Cloud CLI for AI agents. Full cloud-API surface: sessions (CRUD + files + env + deploy + lifecycle + history + events + visibility + collaborators), org templates (CRUD + build + fix-session + snapshot + secrets), activity telemetry, secrets, instructions, guardrails, integrations. Trigger on: runtm, runtime, runtm cloud, runtime cloud, runtm session, runtime session, cloud sandbox."
 metadata:
-  version: "0.4.0"
+  version: "0.6.0"
   repository: https://github.com/runtm-ai/runtm
   tags: runtm,runtime,cli,sandboxes,coding-agents
 ---
@@ -15,6 +15,40 @@ CLI for [Runtm Cloud](https://app.runtm.com) -- the hosted control plane for clo
 
 Full API reference: https://docs.runtm.com/cloud-api
 
+## Most common path: template → session → run commands
+
+The everyday loop is **create a template, boot a session from it, then connect or exec into it**. Memorize this:
+
+```bash
+# 1. Create a template from a repo. --skip-agent does a clone-only build (no AI
+#    step -> fast) and implies --build, so the build kicks off immediately.
+runtm-api template create \
+  --display-name "NuvoOS Dev Environment" \
+  --github-repo runtm-ai/landing-page \
+  --github-branch main \
+  --tier standard \
+  --name template \
+  --skip-agent
+# -> {"id": "28f6e6e6-d73d-4f21-8b1f-312e17e8f47b", "build_status": "pending", ...}
+
+# 2. Wait until the template is ready (only "ready" templates can boot sessions)
+runtm-api template get 28f6e6e6-d73d-4f21-8b1f-312e17e8f47b | jq -r .build_status
+
+# 3. Boot a session from the template
+runtm-api session create --template-id 28f6e6e6-d73d-4f21-8b1f-312e17e8f47b
+# -> {"id": "a6414511-4430-4e1f-8c51-8ea8824dadec", "state": "creating", ...}
+
+# 4a. Attach an interactive shell (raw PTY; requires a TTY on stdin)
+runtm-api session connect a6414511-4430-4e1f-8c51-8ea8824dadec
+
+# 4b. Or run one command non-interactively and capture its output + exit code
+runtm-api session exec a6414511-4430-4e1f-8c51-8ea8824dadec -- pwd
+```
+
+Use `session connect` when a human wants a live shell; use `session exec` for scripted, one-shot commands (it streams stdout and exits with the command's exit code). Both need the `sessions:terminal` scope. See the `runtm-sessions` skill for the full recipe.
+
+To parameterize a template, declare **session arguments** with `--session-arg` (each becomes an env var in the session); supply values at boot with `session create --template-id <uuid> --template-args KEY=VALUE`. See the `runtm-templates` skill.
+
 ## Quick Reference
 
 ### Sessions
@@ -24,6 +58,10 @@ Full API reference: https://docs.runtm.com/cloud-api
 | List sessions | `runtm-api session list` |
 | Launch agent + prompt | `runtm-api session launch --prompt "<task>"` |
 | Create blank session | `runtm-api session create --agent claude-code` |
+| Create session from org template | `runtm-api session create --template-id <uuid>` |
+| Boot template session with arg values | `runtm-api session create --template-id <uuid> --template-args KEY=VALUE` |
+| Attach interactive terminal (PTY) | `runtm-api session connect <id>` |
+| Run one command (scripted) | `runtm-api session exec <id> -- <command>` |
 | Stream prompt | `runtm-api session prompt <id> "<task>"` |
 | Stream live event bus | `runtm-api session events <id>` |
 | Poll status (last_prompt) | `runtm-api session status <id>` |
@@ -55,6 +93,8 @@ Full API reference: https://docs.runtm.com/cloud-api
 | List templates | `runtm-api template list` |
 | Get template detail | `runtm-api template get <tmpl_id>` |
 | Create new template | `runtm-api template create --display-name "..." --github-repo owner/repo` |
+| Create + clone-only build (no AI step) | `runtm-api template create --display-name "..." --github-repo owner/repo --skip-agent` |
+| Declare session args (create/update) | `runtm-api template create ... --session-arg KEY=DEFAULT --session-arg '{"key":"ENV","type":"select","options":["dev","prod"]}'` |
 | Update metadata | `runtm-api template update <tmpl_id> --display-name "..."` |
 | Delete template | `runtm-api template delete <tmpl_id> --yes` |
 | Trigger build | `runtm-api template build <tmpl_id>` |
@@ -170,6 +210,7 @@ If `authenticated: false`, ask the user to set `RUNTM_API_KEY` (or run `runtm-ap
 | `session list\|get\|status\|history\|workspace-state\|collaborators` | `sessions:read` |
 | `session create\|destroy\|rename\|pause\|resume\|git\|visibility\|heartbeat\|run-server` | `sessions:write` (`sessions:delete` for destroy) |
 | `session launch` | `sessions:write` + `sessions:prompt` |
+| `session connect\|exec` | `sessions:terminal` |
 | `session prompt\|prompt-cancel\|events` | `sessions:prompt` |
 | `session prompt-rewind` | `sessions:write` |
 | `session file read\|list\|search` | `sessions:read` |

--- a/packages/agent/internal/skills/files/runtm-sessions.md
+++ b/packages/agent/internal/skills/files/runtm-sessions.md
@@ -2,7 +2,7 @@
 name: runtm-sessions
 description: "Multi-step workflow recipes for Runtm Cloud sessions: launching agents, iterating with prompts, polling status, reading/writing files, managing env vars, and opening PRs."
 metadata:
-  version: "0.2.0"
+  version: "0.4.0"
   tags: runtm,runtime,sessions,workflows,sandboxes
 ---
 
@@ -14,6 +14,9 @@ Workflow recipes for the `runtm-api session` subcommands. For endpoint details s
 
 | Goal | Use |
 |------|-----|
+| Boot a session from a prebuilt org template | `session create --template-id <uuid>` |
+| Run a single shell command in a session | `session exec <id> -- <command>` (scripted, returns its exit code) |
+| Open a live interactive shell | `session connect <id>` (raw PTY; needs a TTY) |
 | Fire-and-forget background task | `session launch` (v0 -- creates + prompts in one call) |
 | Interactive, streaming response right now | `session create` then `session prompt` |
 | Iterate on the same session across prompts | `session prompt` repeatedly with the same `<id>` |
@@ -22,6 +25,59 @@ Workflow recipes for the `runtm-api session` subcommands. For endpoint details s
 | Hold a sandbox without spending | `session pause` then `session resume` later |
 | Edit files programmatically | `session file write` |
 | Inject configuration | `session env set <id> KEY=VAL ...` |
+
+## Recipe: boot a session from a template, then run commands
+
+This is the most common path -- create a template once, then spin up sessions from it and drive them with `connect` / `exec`.
+
+```bash
+# 1. Create a template (clone-only build; --skip-agent implies --build)
+runtm-api template create \
+  --display-name "NuvoOS Dev Environment" \
+  --github-repo runtm-ai/landing-page \
+  --github-branch main \
+  --tier standard \
+  --name template \
+  --skip-agent
+# -> {"id": "28f6e6e6-d73d-4f21-8b1f-312e17e8f47b", "build_status": "pending", ...}
+
+# 2. Wait until it is ready (only "ready" templates boot)
+runtm-api template get 28f6e6e6-d73d-4f21-8b1f-312e17e8f47b | jq -r .build_status
+
+# 3. Create a session from the template
+runtm-api session create --template-id 28f6e6e6-d73d-4f21-8b1f-312e17e8f47b
+# -> {"id": "a6414511-4430-4e1f-8c51-8ea8824dadec", "state": "creating", ...}
+# If the template declares session args, supply values with --template-args
+# (repeatable / comma-separated), e.g. --template-args BRANCH=dev,ENV=staging.
+# See the runtm-templates skill for declaring args with --session-arg.
+
+# 4. Run a command non-interactively (waits for it to finish, prints output)
+runtm-api session exec a6414511-4430-4e1f-8c51-8ea8824dadec -- pwd
+
+# 5. Or attach a live interactive shell
+runtm-api session connect a6414511-4430-4e1f-8c51-8ea8824dadec
+```
+
+## Recipe: run commands in a session (connect vs exec)
+
+Two ways to get a shell against a session's sandbox, both over the same terminal WebSocket the dashboard uses (scope: `sessions:terminal`):
+
+```bash
+# Non-interactive: run one command, stream its output, exit with its exit code.
+# A throwaway PTY is used, so it never disturbs interactive terminals. Put the
+# command after `--` so runtm-api does not parse its flags.
+runtm-api session exec <id> -- pwd
+runtm-api session exec <id> -- ls -la /workspace
+runtm-api session exec <id> -- "npm test"
+runtm-api session exec <id> --timeout 120 -- ./long-build.sh   # abort after N seconds
+
+# Interactive: attach a raw PTY. Keystrokes (incl. Ctrl-C) pass through; window
+# resizes follow. Requires a TTY on stdin. Exit the remote shell to disconnect.
+runtm-api session connect <id>
+runtm-api session connect <id> --terminal default   # share the dashboard terminal
+```
+
+Use `exec` for automation and scripted checks; use `connect` only when a human is at a real terminal. `exec` output is the raw PTY stream and may contain minor terminal formatting.
 
 ## Recipe: launch an agent from scratch
 

--- a/packages/agent/internal/skills/files/runtm-templates.md
+++ b/packages/agent/internal/skills/files/runtm-templates.md
@@ -2,7 +2,7 @@
 name: runtm-templates
 description: "Full lifecycle workflows for Runtm Cloud org templates: discover, create, build, monitor builds, fix broken templates via fix-session, save snapshots, manage template secrets."
 metadata:
-  version: "0.2.0"
+  version: "0.4.0"
   tags: runtm,runtime,templates,org,workflows
 ---
 
@@ -74,7 +74,75 @@ runtm-api template build-logs tmpl_abc...
 runtm-api template get tmpl_abc... | jq '{build_status, has_all_required}'
 ```
 
-If `--skip-agent` is passed to `build`, the agent step is skipped (faster but the user has to finish env setup inside a session).
+### Faster: create + clone-only build in one call (`--skip-agent`)
+
+`--skip-agent` on `template create` runs a clone-only build with no AI step, and **implies `--build`** -- so steps 2 and 3 above collapse into a single command. Best when the repo just needs cloning and you'll finish setup inside a session.
+
+```bash
+runtm-api template create \
+  --display-name "NuvoOS Dev Environment" \
+  --github-repo runtm-ai/landing-page \
+  --github-branch main \
+  --tier standard \
+  --name template \
+  --skip-agent
+# -> {"id": "28f6e6e6-d73d-4f21-8b1f-312e17e8f47b", "build_status": "pending", ...}
+
+# Poll until ready, then boot a session from it:
+runtm-api template get 28f6e6e6-... | jq -r .build_status   # wait for "ready"
+runtm-api session create --template-id 28f6e6e6-...
+# Then drive the session with `session exec <id> -- <cmd>` or `session connect <id>`
+# (see the runtm-sessions skill).
+```
+
+`--display-name` and `--github-repo` are required. `--name` sets the slug (auto-derived from the repo if omitted); `--tier` is one of basic / standard / max. Passing `--skip-agent` to the standalone `template build` command skips the AI step on a rebuild the same way.
+
+## Recipe: declare session arguments
+
+Session arguments are values collected when a member launches a session from the template; each is injected into the sandbox as an **environment variable**. Declare them on `template create` or `template update` with the repeatable `--session-arg` flag.
+
+Two forms per `--session-arg`:
+
+| Form | Meaning |
+|------|---------|
+| `KEY=DEFAULT` | Optional text arg, defaulting to `DEFAULT` |
+| `KEY` (no `=`) | **Required** text arg, no default |
+| `'{"key":...}'` (JSON) | Full control: type (`text`/`select`/`boolean`), `options`, `default`, `required`, `label`, `help_text` |
+
+A `select` arg requires a non-empty `options` array. `label` defaults to the key.
+
+```bash
+# Create a template that declares three session args
+runtm-api template create --display-name 'Rich Args Demo' \
+  --github-repo runtm-ai/landing-page --tier standard \
+  --session-arg BRANCH=main \
+  --session-arg '{"key":"ENV","type":"select","options":["dev","staging","prod"],"default":"dev","required":true,"label":"Environment","help_text":"Target deploy env"}' \
+  --session-arg '{"key":"VERBOSE","type":"boolean","default":"false","label":"Verbose logging"}' \
+  --skip-agent
+# BRANCH -> optional text (default "main"); ENV -> required dropdown; VERBOSE -> checkbox.
+```
+
+On `create`, session args are applied via a follow-up `PATCH` (the create endpoint doesn't accept them directly), so the create works with or without `--build` / `--skip-agent`.
+
+On `update`, `--session-arg` **replaces the entire set** (it's not additive). Pass every arg you want to keep:
+
+```bash
+# Replace the template's session args with a single BRANCH arg
+runtm-api template update 9ff0e46a-ff1f-4440-b2ee-410b07984584 --session-arg BRANCH=main
+```
+
+### Supplying values at launch
+
+When booting a session from a template, pass values for its declared args with `--template-args KEY=VALUE` (repeatable / comma-separated; only valid with `--template-id`). Omitted optional args fall back to their default; missing required args are rejected.
+
+```bash
+runtm-api session create \
+  --template-id 9ff0e46a-ff1f-4440-b2ee-410b07984584 \
+  --template-args BRANCH=dev \
+  --agent claude-code \
+  --mode interactive
+# The sandbox boots with BRANCH=dev (plus ENV/VERBOSE defaults) in its environment.
+```
 
 ## Recipe: fix a broken template
 

--- a/packages/agent/skills/SKILL.md
+++ b/packages/agent/skills/SKILL.md
@@ -2,7 +2,7 @@
 name: runtm
 description: "Runtm (Runtime) Cloud CLI for AI agents. Full cloud-API surface: sessions (CRUD + files + env + deploy + lifecycle + history + events + visibility + collaborators), org templates (CRUD + build + fix-session + snapshot + secrets), activity telemetry, secrets, instructions, guardrails, integrations. Trigger on: runtm, runtime, runtm cloud, runtime cloud, runtm session, runtime session, cloud sandbox."
 metadata:
-  version: "0.4.0"
+  version: "0.6.0"
   repository: https://github.com/runtm-ai/runtm
   tags: runtm,runtime,cli,sandboxes,coding-agents
 ---
@@ -15,6 +15,40 @@ CLI for [Runtm Cloud](https://app.runtm.com) -- the hosted control plane for clo
 
 Full API reference: https://docs.runtm.com/cloud-api
 
+## Most common path: template → session → run commands
+
+The everyday loop is **create a template, boot a session from it, then connect or exec into it**. Memorize this:
+
+```bash
+# 1. Create a template from a repo. --skip-agent does a clone-only build (no AI
+#    step -> fast) and implies --build, so the build kicks off immediately.
+runtm-api template create \
+  --display-name "NuvoOS Dev Environment" \
+  --github-repo runtm-ai/landing-page \
+  --github-branch main \
+  --tier standard \
+  --name template \
+  --skip-agent
+# -> {"id": "28f6e6e6-d73d-4f21-8b1f-312e17e8f47b", "build_status": "pending", ...}
+
+# 2. Wait until the template is ready (only "ready" templates can boot sessions)
+runtm-api template get 28f6e6e6-d73d-4f21-8b1f-312e17e8f47b | jq -r .build_status
+
+# 3. Boot a session from the template
+runtm-api session create --template-id 28f6e6e6-d73d-4f21-8b1f-312e17e8f47b
+# -> {"id": "a6414511-4430-4e1f-8c51-8ea8824dadec", "state": "creating", ...}
+
+# 4a. Attach an interactive shell (raw PTY; requires a TTY on stdin)
+runtm-api session connect a6414511-4430-4e1f-8c51-8ea8824dadec
+
+# 4b. Or run one command non-interactively and capture its output + exit code
+runtm-api session exec a6414511-4430-4e1f-8c51-8ea8824dadec -- pwd
+```
+
+Use `session connect` when a human wants a live shell; use `session exec` for scripted, one-shot commands (it streams stdout and exits with the command's exit code). Both need the `sessions:terminal` scope. See the `runtm-sessions` skill for the full recipe.
+
+To parameterize a template, declare **session arguments** with `--session-arg` (each becomes an env var in the session); supply values at boot with `session create --template-id <uuid> --template-args KEY=VALUE`. See the `runtm-templates` skill.
+
 ## Quick Reference
 
 ### Sessions
@@ -24,6 +58,10 @@ Full API reference: https://docs.runtm.com/cloud-api
 | List sessions | `runtm-api session list` |
 | Launch agent + prompt | `runtm-api session launch --prompt "<task>"` |
 | Create blank session | `runtm-api session create --agent claude-code` |
+| Create session from org template | `runtm-api session create --template-id <uuid>` |
+| Boot template session with arg values | `runtm-api session create --template-id <uuid> --template-args KEY=VALUE` |
+| Attach interactive terminal (PTY) | `runtm-api session connect <id>` |
+| Run one command (scripted) | `runtm-api session exec <id> -- <command>` |
 | Stream prompt | `runtm-api session prompt <id> "<task>"` |
 | Stream live event bus | `runtm-api session events <id>` |
 | Poll status (last_prompt) | `runtm-api session status <id>` |
@@ -55,6 +93,8 @@ Full API reference: https://docs.runtm.com/cloud-api
 | List templates | `runtm-api template list` |
 | Get template detail | `runtm-api template get <tmpl_id>` |
 | Create new template | `runtm-api template create --display-name "..." --github-repo owner/repo` |
+| Create + clone-only build (no AI step) | `runtm-api template create --display-name "..." --github-repo owner/repo --skip-agent` |
+| Declare session args (create/update) | `runtm-api template create ... --session-arg KEY=DEFAULT --session-arg '{"key":"ENV","type":"select","options":["dev","prod"]}'` |
 | Update metadata | `runtm-api template update <tmpl_id> --display-name "..."` |
 | Delete template | `runtm-api template delete <tmpl_id> --yes` |
 | Trigger build | `runtm-api template build <tmpl_id>` |
@@ -170,6 +210,7 @@ If `authenticated: false`, ask the user to set `RUNTM_API_KEY` (or run `runtm-ap
 | `session list\|get\|status\|history\|workspace-state\|collaborators` | `sessions:read` |
 | `session create\|destroy\|rename\|pause\|resume\|git\|visibility\|heartbeat\|run-server` | `sessions:write` (`sessions:delete` for destroy) |
 | `session launch` | `sessions:write` + `sessions:prompt` |
+| `session connect\|exec` | `sessions:terminal` |
 | `session prompt\|prompt-cancel\|events` | `sessions:prompt` |
 | `session prompt-rewind` | `sessions:write` |
 | `session file read\|list\|search` | `sessions:read` |

--- a/packages/agent/skills/runtm-sessions.md
+++ b/packages/agent/skills/runtm-sessions.md
@@ -2,7 +2,7 @@
 name: runtm-sessions
 description: "Multi-step workflow recipes for Runtm Cloud sessions: launching agents, iterating with prompts, polling status, reading/writing files, managing env vars, and opening PRs."
 metadata:
-  version: "0.2.0"
+  version: "0.4.0"
   tags: runtm,runtime,sessions,workflows,sandboxes
 ---
 
@@ -14,6 +14,9 @@ Workflow recipes for the `runtm-api session` subcommands. For endpoint details s
 
 | Goal | Use |
 |------|-----|
+| Boot a session from a prebuilt org template | `session create --template-id <uuid>` |
+| Run a single shell command in a session | `session exec <id> -- <command>` (scripted, returns its exit code) |
+| Open a live interactive shell | `session connect <id>` (raw PTY; needs a TTY) |
 | Fire-and-forget background task | `session launch` (v0 -- creates + prompts in one call) |
 | Interactive, streaming response right now | `session create` then `session prompt` |
 | Iterate on the same session across prompts | `session prompt` repeatedly with the same `<id>` |
@@ -22,6 +25,59 @@ Workflow recipes for the `runtm-api session` subcommands. For endpoint details s
 | Hold a sandbox without spending | `session pause` then `session resume` later |
 | Edit files programmatically | `session file write` |
 | Inject configuration | `session env set <id> KEY=VAL ...` |
+
+## Recipe: boot a session from a template, then run commands
+
+This is the most common path -- create a template once, then spin up sessions from it and drive them with `connect` / `exec`.
+
+```bash
+# 1. Create a template (clone-only build; --skip-agent implies --build)
+runtm-api template create \
+  --display-name "NuvoOS Dev Environment" \
+  --github-repo runtm-ai/landing-page \
+  --github-branch main \
+  --tier standard \
+  --name template \
+  --skip-agent
+# -> {"id": "28f6e6e6-d73d-4f21-8b1f-312e17e8f47b", "build_status": "pending", ...}
+
+# 2. Wait until it is ready (only "ready" templates boot)
+runtm-api template get 28f6e6e6-d73d-4f21-8b1f-312e17e8f47b | jq -r .build_status
+
+# 3. Create a session from the template
+runtm-api session create --template-id 28f6e6e6-d73d-4f21-8b1f-312e17e8f47b
+# -> {"id": "a6414511-4430-4e1f-8c51-8ea8824dadec", "state": "creating", ...}
+# If the template declares session args, supply values with --template-args
+# (repeatable / comma-separated), e.g. --template-args BRANCH=dev,ENV=staging.
+# See the runtm-templates skill for declaring args with --session-arg.
+
+# 4. Run a command non-interactively (waits for it to finish, prints output)
+runtm-api session exec a6414511-4430-4e1f-8c51-8ea8824dadec -- pwd
+
+# 5. Or attach a live interactive shell
+runtm-api session connect a6414511-4430-4e1f-8c51-8ea8824dadec
+```
+
+## Recipe: run commands in a session (connect vs exec)
+
+Two ways to get a shell against a session's sandbox, both over the same terminal WebSocket the dashboard uses (scope: `sessions:terminal`):
+
+```bash
+# Non-interactive: run one command, stream its output, exit with its exit code.
+# A throwaway PTY is used, so it never disturbs interactive terminals. Put the
+# command after `--` so runtm-api does not parse its flags.
+runtm-api session exec <id> -- pwd
+runtm-api session exec <id> -- ls -la /workspace
+runtm-api session exec <id> -- "npm test"
+runtm-api session exec <id> --timeout 120 -- ./long-build.sh   # abort after N seconds
+
+# Interactive: attach a raw PTY. Keystrokes (incl. Ctrl-C) pass through; window
+# resizes follow. Requires a TTY on stdin. Exit the remote shell to disconnect.
+runtm-api session connect <id>
+runtm-api session connect <id> --terminal default   # share the dashboard terminal
+```
+
+Use `exec` for automation and scripted checks; use `connect` only when a human is at a real terminal. `exec` output is the raw PTY stream and may contain minor terminal formatting.
 
 ## Recipe: launch an agent from scratch
 

--- a/packages/agent/skills/runtm-templates.md
+++ b/packages/agent/skills/runtm-templates.md
@@ -2,7 +2,7 @@
 name: runtm-templates
 description: "Full lifecycle workflows for Runtm Cloud org templates: discover, create, build, monitor builds, fix broken templates via fix-session, save snapshots, manage template secrets."
 metadata:
-  version: "0.2.0"
+  version: "0.4.0"
   tags: runtm,runtime,templates,org,workflows
 ---
 
@@ -74,7 +74,75 @@ runtm-api template build-logs tmpl_abc...
 runtm-api template get tmpl_abc... | jq '{build_status, has_all_required}'
 ```
 
-If `--skip-agent` is passed to `build`, the agent step is skipped (faster but the user has to finish env setup inside a session).
+### Faster: create + clone-only build in one call (`--skip-agent`)
+
+`--skip-agent` on `template create` runs a clone-only build with no AI step, and **implies `--build`** -- so steps 2 and 3 above collapse into a single command. Best when the repo just needs cloning and you'll finish setup inside a session.
+
+```bash
+runtm-api template create \
+  --display-name "NuvoOS Dev Environment" \
+  --github-repo runtm-ai/landing-page \
+  --github-branch main \
+  --tier standard \
+  --name template \
+  --skip-agent
+# -> {"id": "28f6e6e6-d73d-4f21-8b1f-312e17e8f47b", "build_status": "pending", ...}
+
+# Poll until ready, then boot a session from it:
+runtm-api template get 28f6e6e6-... | jq -r .build_status   # wait for "ready"
+runtm-api session create --template-id 28f6e6e6-...
+# Then drive the session with `session exec <id> -- <cmd>` or `session connect <id>`
+# (see the runtm-sessions skill).
+```
+
+`--display-name` and `--github-repo` are required. `--name` sets the slug (auto-derived from the repo if omitted); `--tier` is one of basic / standard / max. Passing `--skip-agent` to the standalone `template build` command skips the AI step on a rebuild the same way.
+
+## Recipe: declare session arguments
+
+Session arguments are values collected when a member launches a session from the template; each is injected into the sandbox as an **environment variable**. Declare them on `template create` or `template update` with the repeatable `--session-arg` flag.
+
+Two forms per `--session-arg`:
+
+| Form | Meaning |
+|------|---------|
+| `KEY=DEFAULT` | Optional text arg, defaulting to `DEFAULT` |
+| `KEY` (no `=`) | **Required** text arg, no default |
+| `'{"key":...}'` (JSON) | Full control: type (`text`/`select`/`boolean`), `options`, `default`, `required`, `label`, `help_text` |
+
+A `select` arg requires a non-empty `options` array. `label` defaults to the key.
+
+```bash
+# Create a template that declares three session args
+runtm-api template create --display-name 'Rich Args Demo' \
+  --github-repo runtm-ai/landing-page --tier standard \
+  --session-arg BRANCH=main \
+  --session-arg '{"key":"ENV","type":"select","options":["dev","staging","prod"],"default":"dev","required":true,"label":"Environment","help_text":"Target deploy env"}' \
+  --session-arg '{"key":"VERBOSE","type":"boolean","default":"false","label":"Verbose logging"}' \
+  --skip-agent
+# BRANCH -> optional text (default "main"); ENV -> required dropdown; VERBOSE -> checkbox.
+```
+
+On `create`, session args are applied via a follow-up `PATCH` (the create endpoint doesn't accept them directly), so the create works with or without `--build` / `--skip-agent`.
+
+On `update`, `--session-arg` **replaces the entire set** (it's not additive). Pass every arg you want to keep:
+
+```bash
+# Replace the template's session args with a single BRANCH arg
+runtm-api template update 9ff0e46a-ff1f-4440-b2ee-410b07984584 --session-arg BRANCH=main
+```
+
+### Supplying values at launch
+
+When booting a session from a template, pass values for its declared args with `--template-args KEY=VALUE` (repeatable / comma-separated; only valid with `--template-id`). Omitted optional args fall back to their default; missing required args are rejected.
+
+```bash
+runtm-api session create \
+  --template-id 9ff0e46a-ff1f-4440-b2ee-410b07984584 \
+  --template-args BRANCH=dev \
+  --agent claude-code \
+  --mode interactive
+# The sandbox boots with BRANCH=dev (plus ENV/VERBOSE defaults) in its environment.
+```
 
 ## Recipe: fix a broken template
 

--- a/packages/cli/runtm_cli/api_client.py
+++ b/packages/cli/runtm_cli/api_client.py
@@ -828,9 +828,7 @@ class APIClient:
             self._handle_error(response)
         return response.json().get("templates", [])
 
-    def get_org_template(
-        self, template_id: str, org_id: str | None = None
-    ) -> dict[str, Any]:
+    def get_org_template(self, template_id: str, org_id: str | None = None) -> dict[str, Any]:
         """Get a single org template's full detail (including session args)."""
         response = httpx.get(
             f"{self.api_url}/v0/org-templates/{template_id}",

--- a/packages/cli/runtm_cli/api_client.py
+++ b/packages/cli/runtm_cli/api_client.py
@@ -802,6 +802,73 @@ class APIClient:
             check_url=data.get("check_url"),
         )
 
+    # ------------------------------------------------------------------
+    # Org templates (CLI-facing /api/v0/org-templates surface)
+    # ------------------------------------------------------------------
+
+    def _org_headers(self, org_id: str | None = None) -> dict[str, str]:
+        """Headers for org-scoped calls, adding X-Organization-Id when set.
+
+        When omitted, the backend derives the org from the API key's own
+        organization association, so org-scoped keys work without a flag.
+        """
+        headers = self._headers()
+        if org_id:
+            headers["X-Organization-Id"] = org_id
+        return headers
+
+    def list_org_templates(self, org_id: str | None = None) -> list[dict[str, Any]]:
+        """List org templates. Returns the raw template dicts."""
+        response = httpx.get(
+            f"{self.api_url}/v0/org-templates",
+            headers=self._org_headers(org_id),
+            timeout=self.timeout,
+        )
+        if response.status_code >= 400:
+            self._handle_error(response)
+        return response.json().get("templates", [])
+
+    def get_org_template(
+        self, template_id: str, org_id: str | None = None
+    ) -> dict[str, Any]:
+        """Get a single org template's full detail (including session args)."""
+        response = httpx.get(
+            f"{self.api_url}/v0/org-templates/{template_id}",
+            headers=self._org_headers(org_id),
+            timeout=self.timeout,
+        )
+        if response.status_code >= 400:
+            self._handle_error(response)
+        return response.json()
+
+    def create_org_template(
+        self, payload: dict[str, Any], org_id: str | None = None
+    ) -> dict[str, Any]:
+        """Create an org template (optionally with session_args)."""
+        response = httpx.post(
+            f"{self.api_url}/v0/org-templates",
+            json=payload,
+            headers=self._org_headers(org_id),
+            timeout=self.timeout,
+        )
+        if response.status_code >= 400:
+            self._handle_error(response)
+        return response.json()
+
+    def update_org_template(
+        self, template_id: str, payload: dict[str, Any], org_id: str | None = None
+    ) -> dict[str, Any]:
+        """Update an org template's config (including session_args)."""
+        response = httpx.patch(
+            f"{self.api_url}/v0/org-templates/{template_id}",
+            json=payload,
+            headers=self._org_headers(org_id),
+            timeout=self.timeout,
+        )
+        if response.status_code >= 400:
+            self._handle_error(response)
+        return response.json()
+
 
 ALWAYS_EXCLUDE_PATTERNS = [
     # Git

--- a/packages/cli/runtm_cli/commands/__init__.py
+++ b/packages/cli/runtm_cli/commands/__init__.py
@@ -22,6 +22,12 @@ from runtm_cli.commands.secrets import (
 )
 from runtm_cli.commands.session import session_app
 from runtm_cli.commands.status import status_command
+from runtm_cli.commands.template import (
+    template_create_command,
+    template_edit_command,
+    template_list_command,
+    template_show_command,
+)
 from runtm_cli.commands.validate import validate_command
 
 __all__ = [
@@ -43,5 +49,9 @@ __all__ = [
     "secrets_unset_command",
     "session_app",
     "status_command",
+    "template_create_command",
+    "template_edit_command",
+    "template_list_command",
+    "template_show_command",
     "validate_command",
 ]

--- a/packages/cli/runtm_cli/commands/template.py
+++ b/packages/cli/runtm_cli/commands/template.py
@@ -1,0 +1,312 @@
+"""Template command - manage org templates and their session arguments.
+
+Talks to the cloud control plane's CLI-facing template API
+(``/api/v0/org-templates``). Requires an API key with ``templates:read`` /
+``templates:write`` scopes (org admins only) and runs against an organization
+— the org is taken from the API key, or overridden with ``--org``.
+
+Session arguments are declared with repeatable ``--arg`` flags using a compact
+``field=value`` syntax, comma-separated, e.g.::
+
+    runtm template create "My Template" --repo acme/app \\
+      --arg 'key=BRANCH,label=Git Branch,type=select,options=main|staging,default=main,required=true' \\
+      --arg 'key=DEBUG,label=Debug mode,type=boolean,default=false'
+
+Fields: ``key`` (required), ``label`` (defaults to key), ``type``
+(text|select|boolean, default text), ``required`` (true/false), ``default``,
+``options`` (``|``-separated, for select), ``help``/``help_text``. Field values
+may not contain commas; use ``|`` to separate select options.
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from runtm_shared.errors import RuntmError
+
+from ..api_client import APIClient
+from ..config import get_token
+
+console = Console()
+
+_VALID_ARG_TYPES = {"text", "select", "boolean"}
+_TRUE_STRINGS = {"true", "1", "yes", "on"}
+_FALSE_STRINGS = {"false", "0", "no", "off"}
+# Recognized field names inside a --arg spec (maps aliases to schema keys).
+_ARG_FIELDS = {
+    "key": "key",
+    "label": "label",
+    "type": "type",
+    "required": "required",
+    "default": "default",
+    "options": "options",
+    "help": "help_text",
+    "help_text": "help_text",
+}
+
+
+def _require_auth() -> None:
+    if not get_token():
+        console.print("[red]✗[/red] Not authenticated. Run `runtm login` first.")
+        raise typer.Exit(1)
+
+
+def _parse_bool(value: str, *, field: str) -> bool:
+    v = value.strip().lower()
+    if v in _TRUE_STRINGS:
+        return True
+    if v in _FALSE_STRINGS:
+        return False
+    console.print(f"[red]✗[/red] Invalid boolean for '{field}': {value!r} (use true/false).")
+    raise typer.Exit(1)
+
+
+def _parse_arg_spec(spec: str) -> dict:
+    """Parse one ``--arg 'key=...,label=...'`` spec into a session-arg dict.
+
+    Raises typer.Exit(1) with a clear message on malformed input.
+    """
+    fields: dict[str, str] = {}
+    for raw_pair in spec.split(","):
+        pair = raw_pair.strip()
+        if not pair:
+            continue
+        if "=" not in pair:
+            console.print(
+                f"[red]✗[/red] Bad --arg segment {pair!r}: expected field=value."
+            )
+            raise typer.Exit(1)
+        name, value = pair.split("=", 1)
+        name = name.strip().lower()
+        if name not in _ARG_FIELDS:
+            valid = ", ".join(sorted(set(_ARG_FIELDS)))
+            console.print(f"[red]✗[/red] Unknown --arg field {name!r}. Valid: {valid}.")
+            raise typer.Exit(1)
+        fields[_ARG_FIELDS[name]] = value.strip()
+
+    key = fields.get("key")
+    if not key:
+        console.print(f"[red]✗[/red] --arg {spec!r} is missing required 'key'.")
+        raise typer.Exit(1)
+
+    arg_type = fields.get("type", "text").lower()
+    if arg_type not in _VALID_ARG_TYPES:
+        console.print(
+            f"[red]✗[/red] Invalid type {arg_type!r} for '{key}'. "
+            f"Valid: {', '.join(sorted(_VALID_ARG_TYPES))}."
+        )
+        raise typer.Exit(1)
+
+    out: dict = {
+        "key": key,
+        "label": fields.get("label") or key,
+        "type": arg_type,
+        "required": _parse_bool(fields["required"], field=f"{key}.required")
+        if "required" in fields
+        else False,
+    }
+    if "default" in fields:
+        out["default"] = fields["default"]
+    if "help_text" in fields:
+        out["help_text"] = fields["help_text"]
+    if arg_type == "select":
+        options = [o.strip() for o in fields.get("options", "").split("|") if o.strip()]
+        if not options:
+            console.print(
+                f"[red]✗[/red] select arg '{key}' needs options=a|b|c."
+            )
+            raise typer.Exit(1)
+        out["options"] = options
+    return out
+
+
+def _parse_args(specs: list[str]) -> list[dict]:
+    parsed = [_parse_arg_spec(s) for s in specs]
+    keys = [a["key"] for a in parsed]
+    dupes = {k for k in keys if keys.count(k) > 1}
+    if dupes:
+        console.print(f"[red]✗[/red] Duplicate session arg key(s): {', '.join(sorted(dupes))}.")
+        raise typer.Exit(1)
+    return parsed
+
+
+def _print_session_args(session_args: list[dict]) -> None:
+    if not session_args:
+        console.print("[dim]No session arguments.[/dim]")
+        return
+    table = Table(title="Session arguments", show_header=True)
+    table.add_column("Key", style="cyan")
+    table.add_column("Label", style="white")
+    table.add_column("Type", style="magenta")
+    table.add_column("Required", style="dim")
+    table.add_column("Default", style="green")
+    table.add_column("Options", style="yellow")
+    for a in session_args:
+        table.add_row(
+            a.get("key", ""),
+            a.get("label", ""),
+            a.get("type", "text"),
+            "yes" if a.get("required") else "no",
+            "" if a.get("default") in (None, "") else str(a.get("default")),
+            " | ".join(a.get("options") or []),
+        )
+    console.print(table)
+
+
+def _handle(e: RuntmError) -> None:
+    console.print(f"[red]✗[/red] {e.message}")
+    if e.recovery_hint:
+        console.print(f"    {e.recovery_hint}")
+    raise typer.Exit(1)
+
+
+def template_list_command(org_id: str | None = None) -> None:
+    """List org templates."""
+    from runtm_cli.telemetry import command_span
+
+    with command_span("template_list"):
+        _require_auth()
+        client = APIClient()
+        try:
+            templates = client.list_org_templates(org_id=org_id)
+        except RuntmError as e:
+            _handle(e)
+
+        if not templates:
+            console.print("[dim]No templates found for this organization.[/dim]")
+            return
+
+        table = Table(title="Org templates", show_header=True)
+        table.add_column("ID", style="dim")
+        table.add_column("Name", style="cyan")
+        table.add_column("Display name", style="white")
+        table.add_column("Args", style="yellow")
+        table.add_column("Build", style="magenta")
+        for t in templates:
+            table.add_row(
+                str(t.get("id", "")),
+                str(t.get("name", "")),
+                str(t.get("display_name", "")),
+                str(len(t.get("session_args") or [])),
+                str(t.get("build_status") or ""),
+            )
+        console.print(table)
+
+
+def template_show_command(template_id: str, org_id: str | None = None) -> None:
+    """Show a single template's details and session arguments."""
+    from runtm_cli.telemetry import command_span
+
+    with command_span("template_show"):
+        _require_auth()
+        client = APIClient()
+        try:
+            t = client.get_org_template(template_id, org_id=org_id)
+        except RuntmError as e:
+            _handle(e)
+
+        console.print(f"[cyan]{t.get('display_name')}[/cyan]  [dim]({t.get('name')})[/dim]")
+        console.print(f"  ID:    {t.get('id')}")
+        if t.get("github_repo"):
+            console.print(f"  Repo:  {t.get('github_repo')}@{t.get('github_branch')}")
+        console.print(f"  Tier:  {t.get('tier')}")
+        console.print(f"  Build: {t.get('build_status')}")
+        console.print()
+        _print_session_args(t.get("session_args") or [])
+
+
+def template_create_command(
+    display_name: str,
+    *,
+    repo: str | None = None,
+    branch: str = "main",
+    tier: str = "basic",
+    agents: list[str] | None = None,
+    description: str | None = None,
+    name: str | None = None,
+    arg_specs: list[str] | None = None,
+    org_id: str | None = None,
+) -> None:
+    """Create a template, optionally with session arguments in one call."""
+    from runtm_cli.telemetry import command_span
+
+    with command_span("template_create"):
+        _require_auth()
+        session_args = _parse_args(arg_specs or [])
+
+        payload: dict = {"display_name": display_name, "tier": tier}
+        if repo:
+            payload["github_repo"] = repo
+            payload["github_branch"] = branch
+        if description:
+            payload["description"] = description
+        if name:
+            payload["name"] = name
+        if agents:
+            payload["agents"] = agents
+        if session_args:
+            payload["session_args"] = session_args
+
+        client = APIClient()
+        try:
+            t = client.create_org_template(payload, org_id=org_id)
+        except RuntmError as e:
+            _handle(e)
+
+        console.print(
+            f"[green]✓[/green] Created template [cyan]{t.get('display_name')}[/cyan] "
+            f"[dim]({t.get('id')})[/dim]"
+        )
+        console.print()
+        _print_session_args(t.get("session_args") or [])
+
+
+def template_edit_command(
+    template_id: str,
+    *,
+    arg_specs: list[str] | None = None,
+    clear_args: bool = False,
+    display_name: str | None = None,
+    org_id: str | None = None,
+) -> None:
+    """Edit a template's session arguments (and/or display name).
+
+    Session args are replaced wholesale: ``--arg`` sets the complete list,
+    ``--clear-args`` removes them all. Use ``runtm template show`` to view the
+    current set first.
+    """
+    from runtm_cli.telemetry import command_span
+
+    with command_span("template_edit"):
+        _require_auth()
+
+        if arg_specs and clear_args:
+            console.print("[red]✗[/red] Pass either --arg or --clear-args, not both.")
+            raise typer.Exit(1)
+
+        payload: dict = {}
+        if clear_args:
+            payload["session_args"] = []
+        elif arg_specs:
+            payload["session_args"] = _parse_args(arg_specs)
+        if display_name is not None:
+            payload["display_name"] = display_name
+
+        if not payload:
+            console.print(
+                "[yellow]Nothing to update.[/yellow] Pass --arg, --clear-args, "
+                "or --display-name."
+            )
+            raise typer.Exit(1)
+
+        client = APIClient()
+        try:
+            t = client.update_org_template(template_id, payload, org_id=org_id)
+        except RuntmError as e:
+            _handle(e)
+
+        console.print(f"[green]✓[/green] Updated template [dim]{t.get('id')}[/dim]")
+        console.print()
+        _print_session_args(t.get("session_args") or [])

--- a/packages/cli/runtm_cli/commands/template.py
+++ b/packages/cli/runtm_cli/commands/template.py
@@ -74,9 +74,7 @@ def _parse_arg_spec(spec: str) -> dict:
         if not pair:
             continue
         if "=" not in pair:
-            console.print(
-                f"[red]✗[/red] Bad --arg segment {pair!r}: expected field=value."
-            )
+            console.print(f"[red]✗[/red] Bad --arg segment {pair!r}: expected field=value.")
             raise typer.Exit(1)
         name, value = pair.split("=", 1)
         name = name.strip().lower()
@@ -114,9 +112,7 @@ def _parse_arg_spec(spec: str) -> dict:
     if arg_type == "select":
         options = [o.strip() for o in fields.get("options", "").split("|") if o.strip()]
         if not options:
-            console.print(
-                f"[red]✗[/red] select arg '{key}' needs options=a|b|c."
-            )
+            console.print(f"[red]✗[/red] select arg '{key}' needs options=a|b|c.")
             raise typer.Exit(1)
         out["options"] = options
     return out
@@ -296,8 +292,7 @@ def template_edit_command(
 
         if not payload:
             console.print(
-                "[yellow]Nothing to update.[/yellow] Pass --arg, --clear-args, "
-                "or --display-name."
+                "[yellow]Nothing to update.[/yellow] Pass --arg, --clear-args, or --display-name."
             )
             raise typer.Exit(1)
 

--- a/packages/cli/runtm_cli/main.py
+++ b/packages/cli/runtm_cli/main.py
@@ -629,10 +629,14 @@ def template_show(
 @template_app.command("create")
 def template_create(
     display_name: str = typer.Argument(..., help="Human-friendly template name"),
-    repo: str = typer.Option(None, "--repo", help="GitHub repo (owner/repo). Omit for a repo-less template"),
+    repo: str = typer.Option(
+        None, "--repo", help="GitHub repo (owner/repo). Omit for a repo-less template"
+    ),
     branch: str = typer.Option("main", "--branch", help="Git branch"),
     tier: str = typer.Option("basic", "--tier", help="Sandbox tier: basic, standard, max"),
-    agent: list[str] = typer.Option(None, "--agent", help="Coding agent(s) to build for. Repeatable"),
+    agent: list[str] = typer.Option(
+        None, "--agent", help="Coding agent(s) to build for. Repeatable"
+    ),
     description: str = typer.Option(None, "--description", help="Template description"),
     name: str = typer.Option(None, "--name", help="Template slug (auto-derived if omitted)"),
     arg: list[str] = typer.Option(None, "--arg", "-a", help=_ARG_HELP),

--- a/packages/cli/runtm_cli/main.py
+++ b/packages/cli/runtm_cli/main.py
@@ -81,6 +81,10 @@ from runtm_cli.commands import (
     secrets_unset_command,
     session_app,
     status_command,
+    template_create_command,
+    template_edit_command,
+    template_list_command,
+    template_show_command,
     validate_command,
 )
 from runtm_cli.commands.admin import admin_app
@@ -581,6 +585,100 @@ def secrets_unset(
     from pathlib import Path
 
     secrets_unset_command(key=key, path=Path(path))
+
+
+# Template subcommand group
+template_app = typer.Typer(
+    name="template",
+    help="Manage org templates and their session arguments.",
+    no_args_is_help=True,
+)
+app.add_typer(template_app, name="template")
+
+_ARG_HELP = (
+    "Session arg as 'key=...,label=...,type=text|select|boolean,"
+    "required=true,default=...,options=a|b|c,help=...'. Repeatable."
+)
+
+
+@template_app.command("list")
+def template_list(
+    org: str = typer.Option(None, "--org", help="Organization ID (defaults to the API key's org)"),
+) -> None:
+    """List org templates.
+
+    Example:
+        runtm template list
+    """
+    template_list_command(org_id=org)
+
+
+@template_app.command("show")
+def template_show(
+    template_id: str = typer.Argument(..., help="Template ID"),
+    org: str = typer.Option(None, "--org", help="Organization ID (defaults to the API key's org)"),
+) -> None:
+    """Show a template's details and session arguments.
+
+    Example:
+        runtm template show 1a2b3c
+    """
+    template_show_command(template_id, org_id=org)
+
+
+@template_app.command("create")
+def template_create(
+    display_name: str = typer.Argument(..., help="Human-friendly template name"),
+    repo: str = typer.Option(None, "--repo", help="GitHub repo (owner/repo). Omit for a repo-less template"),
+    branch: str = typer.Option("main", "--branch", help="Git branch"),
+    tier: str = typer.Option("basic", "--tier", help="Sandbox tier: basic, standard, max"),
+    agent: list[str] = typer.Option(None, "--agent", help="Coding agent(s) to build for. Repeatable"),
+    description: str = typer.Option(None, "--description", help="Template description"),
+    name: str = typer.Option(None, "--name", help="Template slug (auto-derived if omitted)"),
+    arg: list[str] = typer.Option(None, "--arg", "-a", help=_ARG_HELP),
+    org: str = typer.Option(None, "--org", help="Organization ID (defaults to the API key's org)"),
+) -> None:
+    """Create an org template, optionally with session arguments.
+
+    Example:
+        runtm template create "My Template" --repo acme/app \\
+          --arg 'key=BRANCH,label=Git Branch,type=select,options=main|staging,default=main' \\
+          --arg 'key=DEBUG,label=Debug mode,type=boolean,default=false'
+    """
+    template_create_command(
+        display_name,
+        repo=repo,
+        branch=branch,
+        tier=tier,
+        agents=agent or None,
+        description=description,
+        name=name,
+        arg_specs=arg or [],
+        org_id=org,
+    )
+
+
+@template_app.command("edit")
+def template_edit(
+    template_id: str = typer.Argument(..., help="Template ID"),
+    arg: list[str] = typer.Option(None, "--arg", "-a", help=_ARG_HELP + " Replaces the full set"),
+    clear_args: bool = typer.Option(False, "--clear-args", help="Remove all session arguments"),
+    display_name: str = typer.Option(None, "--display-name", help="New display name"),
+    org: str = typer.Option(None, "--org", help="Organization ID (defaults to the API key's org)"),
+) -> None:
+    """Edit a template's session arguments (replaces the full set).
+
+    Example:
+        runtm template edit 1a2b3c --arg 'key=BRANCH,label=Branch,default=main'
+        runtm template edit 1a2b3c --clear-args
+    """
+    template_edit_command(
+        template_id,
+        arg_specs=arg or [],
+        clear_args=clear_args,
+        display_name=display_name,
+        org_id=org,
+    )
 
 
 # Config subcommand group

--- a/packages/cli/tests/test_template.py
+++ b/packages/cli/tests/test_template.py
@@ -1,0 +1,97 @@
+"""Tests for template.py CLI command — session-arg spec parsing."""
+
+import pytest
+import typer
+
+from runtm_cli.commands.template import _parse_arg_spec, _parse_args
+
+
+class TestParseArgSpec:
+    """Tests for parsing a single --arg spec into a session-arg dict."""
+
+    def test_minimal_spec_defaults_to_text(self) -> None:
+        result = _parse_arg_spec("key=BRANCH")
+        assert result == {
+            "key": "BRANCH",
+            "label": "BRANCH",  # defaults to key
+            "type": "text",
+            "required": False,
+        }
+
+    def test_full_select_spec(self) -> None:
+        result = _parse_arg_spec(
+            "key=BRANCH,label=Git Branch,type=select,"
+            "options=main|staging|prod,default=main,required=true"
+        )
+        assert result == {
+            "key": "BRANCH",
+            "label": "Git Branch",
+            "type": "select",
+            "required": True,
+            "default": "main",
+            "options": ["main", "staging", "prod"],
+        }
+
+    def test_boolean_spec(self) -> None:
+        result = _parse_arg_spec("key=DEBUG,type=boolean,default=false")
+        assert result["type"] == "boolean"
+        assert result["default"] == "false"
+        assert "options" not in result
+
+    def test_help_alias(self) -> None:
+        result = _parse_arg_spec("key=NOTE,help=some help")
+        assert result["help_text"] == "some help"
+
+    def test_help_text_field(self) -> None:
+        result = _parse_arg_spec("key=NOTE,help_text=other help")
+        assert result["help_text"] == "other help"
+
+    def test_required_truthy_variants(self) -> None:
+        for v in ("true", "1", "yes", "on"):
+            assert _parse_arg_spec(f"key=X,required={v}")["required"] is True
+        for v in ("false", "0", "no", "off"):
+            assert _parse_arg_spec(f"key=X,required={v}")["required"] is False
+
+    def test_missing_key_exits(self) -> None:
+        with pytest.raises(typer.Exit):
+            _parse_arg_spec("label=No Key")
+
+    def test_unknown_field_exits(self) -> None:
+        with pytest.raises(typer.Exit):
+            _parse_arg_spec("key=X,bogus=1")
+
+    def test_invalid_type_exits(self) -> None:
+        with pytest.raises(typer.Exit):
+            _parse_arg_spec("key=X,type=number")
+
+    def test_invalid_boolean_exits(self) -> None:
+        with pytest.raises(typer.Exit):
+            _parse_arg_spec("key=X,required=maybe")
+
+    def test_select_without_options_exits(self) -> None:
+        with pytest.raises(typer.Exit):
+            _parse_arg_spec("key=X,type=select")
+
+    def test_segment_without_equals_exits(self) -> None:
+        with pytest.raises(typer.Exit):
+            _parse_arg_spec("key=X,justtext")
+
+
+class TestParseArgs:
+    """Tests for parsing a list of --arg specs."""
+
+    def test_multiple_specs(self) -> None:
+        result = _parse_args(
+            [
+                "key=BRANCH,type=select,options=main|dev",
+                "key=DEBUG,type=boolean",
+            ]
+        )
+        assert [a["key"] for a in result] == ["BRANCH", "DEBUG"]
+
+    def test_empty_list(self) -> None:
+        assert _parse_args([]) == []
+
+    def test_duplicate_keys_exit(self) -> None:
+        with pytest.raises(typer.Exit):
+            _parse_args(["key=DUP", "key=DUP"])


### PR DESCRIPTION
## Description

Improves the `runtm` CLI and the Go agent with first-class support for **interactive SSH/terminal sessions** and **org template management**, plus refreshed skill docs and release-workflow fixes.

- **Terminal/SSH sessions (Go agent):** new `session_terminal_cmd` adds interactive terminal attach for sandbox sessions (`packages/agent/internal/cmd/session_terminal_cmd.go`, with tests).
- **Org templates (Python CLI + Go agent):** new `runtm template` command group (`create`/`list`/`update`/…) talking to the cloud control plane's `/api/v0/org-templates` API, including a compact repeatable `--arg 'key=…,label=…,type=…'` syntax for declaring session arguments. Mirrored in the Go agent's `template.go`.
- **API client:** new org-template methods in `api_client.py`.
- **Skills/docs:** updated `SKILL.md`, `runtm-sessions.md`, and `runtm-templates.md` (both `skills/` and bundled `internal/skills/files/`) to document the new flows.
- **CI/release (`ci:` commit):** `publish.yml` now stamps a build-number version before publishing and uses `uv publish --check-url` so no-op pushes to `main` are idempotent; `release-agent.yml` no longer marks `v0.x` agent tags as prereleases.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/A

## Checklist

- [x] My code follows the project's style guidelines (`ruff check .` passes)
- [x] I have formatted my code (`ruff format .`)
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass (`pytest`)
- [x] I have updated documentation if needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `ruff check packages/cli` → **All checks passed!**
- `ruff format --check packages/cli` → clean (applied `ruff format` to the new/changed CLI files in a dedicated `style(cli)` commit).
- `pytest packages/cli/tests/test_template.py` → **15 passed** (new template-command tests).
- `go test ./...` in `packages/agent` → **ok** (includes new `session_terminal_cmd_test.go` and `template_test.go`).

> Note: `packages/cli/tests/test_session.py` reports failures in a clean local checkout only because the `runtm-agents`/sandbox package isn't installed — these are environmental and unrelated to this branch (no CLI session code is changed here).

## Release impact

This repo has no hand-authored CHANGELOG/release-notes file; releases are automated, so there's no notes document to edit. For reference on merge:

- **PyPI (`publish.yml`):** merging to `main` auto-publishes `runtm`/`runtm-worker`/`runtm-api` at `0.2.<run_number>`. No GitHub release or release notes are produced.
- **Go agent (`release-agent.yml`):** binaries + release notes are generated from the workflow's fixed install-snippet template on a `packages/agent/vX.Y.Z` tag push — independent of this PR.

All three commits are Conventional Commits (`feat(cli)`, `ci`, `style(cli)`), so the merge (squash or merge-commit) follows the repo's standard history pattern.

## Screenshots (if applicable)

N/A — CLI-only changes.
