### PR TITLE
fix(ci): pass --frozen to uv version in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,8 +27,11 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.value }}
         run: |
+          # --frozen edits pyproject.toml only; without it newer uv re-locks the
+          # project and fails resolving the unpublished dev extras (runtm-agents,
+          # runtm-sandbox), which are workspace-only and not on PyPI.
           for pkg in cli worker api; do
-            (cd "packages/$pkg" && uv version "$VERSION")
+            (cd "packages/$pkg" && uv version --frozen "$VERSION")
           done
 
       - name: Build runtm (CLI)


### PR DESCRIPTION
## Description

The `Publish to PyPI` workflow has been failing on every push to `main` since the `uv` version bundled by `astral-sh/setup-uv@v5` started re-locking/syncing the project as a side effect of `uv version`.

In the **Set package versions** step:

```bash
for pkg in cli worker api; do
  (cd "packages/$pkg" && uv version "$VERSION")
done
```

resolving `packages/cli` now pulls in its `dev` optional-dependency group, which lists `runtm-agents` and `runtm-sandbox`. Those are workspace-only packages that are **never published to PyPI**, so resolution against the index fails:

```
× Because runtm-agents was not found in the package registry and
  runtm[dev] depends on runtm-agents>=0.1.0 ... unsatisfiable.
```

The fix adds `--frozen` so `uv version` only edits `pyproject.toml` without re-locking or resolving. The downstream `uv build` / `uv publish` steps don't resolve runtime deps, so they're unaffected.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/A — CI regression caught from failed `Publish` runs (e.g. run #27581997419).

## Checklist

- [x] My code follows the project's style guidelines (`ruff check .` passes)
- [x] I have formatted my code (`ruff format .`)
- [ ] I have added tests that prove my fix/feature works
- [x] All tests pass (`pytest`)
- [x] I have updated documentation if needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

> Note: this is a CI/workflow-only change, so no unit tests apply.

## Testing

Reproduced and verified locally with the same `uv` behavior:

- `cd packages/cli && uv version 0.2.119` → fails resolving `runtm-agents` (matches CI).
- `cd packages/cli && uv version --frozen --dry-run 0.2.119` → `runtm 0.2.21 => 0.2.119`, exit 0, no resolution step.

## Screenshots (if applicable)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)