### PR TITLE
feat(agent): attach skills & MCP servers to templates from the CLI

### DIFF
--- a/packages/agent/internal/cmd/directives_cmd.go
+++ b/packages/agent/internal/cmd/directives_cmd.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/runtm-ai/runtm/packages/agent/internal/client"
 	"github.com/spf13/cobra"
 )
 
@@ -38,6 +39,9 @@ the context:write scope on the key.`,
 		newMcpCreate(rt),
 		newMcpUpdate(rt),
 		newDirectiveDelete(rt, "MCP server"),
+		newDirectiveAttachments(rt, "MCP server"),
+		newDirectiveAttach(rt, "MCP server"),
+		newDirectiveDetach(rt, "MCP server"),
 	)
 	return cmd
 }
@@ -749,5 +753,266 @@ func newDirectiveDelete(rt *Runtime, singular string) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&yes, "yes", false, "Confirm deletion")
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// Attachments — scope a skill/MCP to templates, repos, or all repos
+//
+// A directive (skill or MCP server) is loaded into a session only where it is
+// attached. Attaching to a template makes every session launched from that
+// template load it. Backed by:
+//
+//	GET /api/agent-directives/{id}/attachments   (list current scope)
+//	PUT /api/agent-directives/{id}/attachments   (replace the full scope)
+//
+// The PUT is a full replace, so `attach`/`detach` read the current scope and
+// merge by default — only `--replace` / `--clear` set it wholesale. The three
+// scopes (templates, repos, all-repos) are mutually exclusive with all-repos:
+// the backend rejects combining applies_to_all with explicit lists.
+// ---------------------------------------------------------------------------
+
+func attachmentsPath(id string) string {
+	return directivePath(id) + "/attachments"
+}
+
+// attachmentRow mirrors the fields of DirectiveAttachmentResource we read back.
+type attachmentRow struct {
+	RepoFullName *string `json:"repo_full_name"`
+	AppliesToAll bool    `json:"applies_to_all"`
+	TemplateID   *string `json:"template_id"`
+}
+
+type attachmentsResp struct {
+	Attachments []attachmentRow `json:"attachments"`
+}
+
+func (r *attachmentsResp) templateIDs() []string {
+	out := []string{}
+	for _, a := range r.Attachments {
+		if a.TemplateID != nil && *a.TemplateID != "" {
+			out = append(out, *a.TemplateID)
+		}
+	}
+	return out
+}
+
+func (r *attachmentsResp) repoNames() []string {
+	out := []string{}
+	for _, a := range r.Attachments {
+		if a.RepoFullName != nil && *a.RepoFullName != "" {
+			out = append(out, *a.RepoFullName)
+		}
+	}
+	return out
+}
+
+func (r *attachmentsResp) appliesToAll() bool {
+	for _, a := range r.Attachments {
+		if a.AppliesToAll {
+			return true
+		}
+	}
+	return false
+}
+
+// fetchAttachments reads a directive's current attachment scope.
+func fetchAttachments(c *client.Client, id string) (*attachmentsResp, error) {
+	raw, err := c.Get(attachmentsPath(id), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out attachmentsResp
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("parse current attachments: %w", err)
+	}
+	return &out, nil
+}
+
+// mergeUnique returns base ∪ add, order-preserving and de-duplicated.
+func mergeUnique(base, add []string) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, s := range append(append([]string{}, base...), add...) {
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}
+
+// without returns base with every element of remove dropped.
+func without(base, remove []string) []string {
+	rm := map[string]bool{}
+	for _, s := range remove {
+		rm[s] = true
+	}
+	out := []string{}
+	for _, s := range base {
+		if !rm[s] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// nonNil guarantees a JSON array (not null) for list body fields, which the
+// backend's list[str] fields require.
+func nonNil(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
+
+func newDirectiveAttachments(rt *Runtime, singular string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "attachments <id>",
+		Short: fmt.Sprintf("List where a %s is attached (templates, repos, or all repos)", singular),
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _, err := requireOrgClient(rt, singular+"s")
+			if err != nil {
+				return err
+			}
+			resp, err := c.Get(attachmentsPath(args[0]), nil)
+			return runJSON(rt, resp, err)
+		},
+	}
+}
+
+func newDirectiveAttach(rt *Runtime, singular string) *cobra.Command {
+	var (
+		templates []string
+		repos     []string
+		all       bool
+		replace   bool
+	)
+	cmd := &cobra.Command{
+		Use:   "attach <id>",
+		Short: fmt.Sprintf("Attach a %s to templates, repos, or all repos", singular),
+		Long: fmt.Sprintf(`Attach a %s so sessions load it. Scope it to one or more templates
+(--template, repeatable), repos (--repo owner/name, repeatable), or every repo
+in the org (--all).
+
+Merges with the existing scope by default, so repeated calls add attachments.
+Pass --replace to set the exact scope instead. --all is mutually exclusive with
+--template/--repo and supersedes any existing scoped attachments.
+
+Examples:
+  runtm-api %ss attach <id> --template <template_id>
+  runtm-api %ss attach <id> --template <t1> --template <t2>
+  runtm-api %ss attach <id> --repo acme/api --replace
+  runtm-api %ss attach <id> --all`, singular, singular, singular, singular, singular),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if all && (len(templates) > 0 || len(repos) > 0) {
+				return fmt.Errorf("--all cannot be combined with --template or --repo")
+			}
+			if !all && len(templates) == 0 && len(repos) == 0 {
+				return fmt.Errorf("pass at least one of --template, --repo, or --all")
+			}
+			c, _, err := requireOrgClient(rt, singular+"s")
+			if err != nil {
+				return err
+			}
+
+			var body map[string]any
+			switch {
+			case all:
+				body = map[string]any{"applies_to_all": true}
+			case replace:
+				body = map[string]any{
+					"template_ids":    nonNil(templates),
+					"repo_full_names": nonNil(repos),
+				}
+			default:
+				// Merge with the current scope. Attaching to a template/repo
+				// switches off all-repos scope (the two can't coexist).
+				existing, gerr := fetchAttachments(c, args[0])
+				if gerr != nil {
+					return gerr
+				}
+				body = map[string]any{
+					"template_ids":    mergeUnique(existing.templateIDs(), templates),
+					"repo_full_names": mergeUnique(existing.repoNames(), repos),
+				}
+			}
+			resp, err := c.PutJSON(attachmentsPath(args[0]), body)
+			return runJSON(rt, resp, err)
+		},
+	}
+	cmd.Flags().StringArrayVar(&templates, "template", nil, "Template ID to attach to (repeatable)")
+	cmd.Flags().StringArrayVar(&repos, "repo", nil, "Repo owner/name to attach to (repeatable)")
+	cmd.Flags().BoolVar(&all, "all", false, "Attach to every repo in the org (mutually exclusive with --template/--repo)")
+	cmd.Flags().BoolVar(&replace, "replace", false, "Replace the full attachment scope instead of merging")
+	return cmd
+}
+
+func newDirectiveDetach(rt *Runtime, singular string) *cobra.Command {
+	var (
+		templates []string
+		repos     []string
+		all       bool
+		clearAll  bool
+	)
+	cmd := &cobra.Command{
+		Use:   "detach <id>",
+		Short: fmt.Sprintf("Detach a %s from templates, repos, or all repos", singular),
+		Long: fmt.Sprintf(`Remove a %s's attachments while leaving the rest in place.
+
+Pass --template/--repo to drop specific scopes, --all to remove the all-repos
+attachment, or --clear to remove every attachment at once.
+
+Examples:
+  runtm-api %ss detach <id> --template <template_id>
+  runtm-api %ss detach <id> --all
+  runtm-api %ss detach <id> --clear`, singular, singular, singular, singular),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _, err := requireOrgClient(rt, singular+"s")
+			if err != nil {
+				return err
+			}
+
+			if clearAll {
+				resp, err := c.PutJSON(attachmentsPath(args[0]), map[string]any{
+					"template_ids":    []string{},
+					"repo_full_names": []string{},
+				})
+				return runJSON(rt, resp, err)
+			}
+			if !all && len(templates) == 0 && len(repos) == 0 {
+				return fmt.Errorf("pass --template/--repo to remove, --all to remove the all-repos attachment, or --clear to remove everything")
+			}
+
+			existing, gerr := fetchAttachments(c, args[0])
+			if gerr != nil {
+				return gerr
+			}
+			remTemplates := without(existing.templateIDs(), templates)
+			remRepos := without(existing.repoNames(), repos)
+
+			// Keep the all-repos scope unless this call targets it. (It never
+			// coexists with template/repo scopes, so there's nothing to merge.)
+			var body map[string]any
+			if existing.appliesToAll() && !all && len(remTemplates) == 0 && len(remRepos) == 0 {
+				body = map[string]any{"applies_to_all": true}
+			} else {
+				body = map[string]any{
+					"template_ids":    remTemplates,
+					"repo_full_names": remRepos,
+				}
+			}
+			resp, err := c.PutJSON(attachmentsPath(args[0]), body)
+			return runJSON(rt, resp, err)
+		},
+	}
+	cmd.Flags().StringArrayVar(&templates, "template", nil, "Template ID to detach from (repeatable)")
+	cmd.Flags().StringArrayVar(&repos, "repo", nil, "Repo owner/name to detach from (repeatable)")
+	cmd.Flags().BoolVar(&all, "all", false, "Remove the all-repos attachment")
+	cmd.Flags().BoolVar(&clearAll, "clear", false, "Remove every attachment")
 	return cmd
 }

--- a/packages/agent/internal/cmd/skills_cmd.go
+++ b/packages/agent/internal/cmd/skills_cmd.go
@@ -35,6 +35,9 @@ embedded in this binary into the detected agent's skills directory.`,
 		newSkillCreate(rt),
 		newSkillUpdate(rt),
 		newDirectiveDelete(rt, "skill"),
+		newDirectiveAttachments(rt, "skill"),
+		newDirectiveAttach(rt, "skill"),
+		newDirectiveDetach(rt, "skill"),
 		newSkillsInstall(rt),
 	)
 	return cmd

--- a/packages/agent/internal/cmd/template.go
+++ b/packages/agent/internal/cmd/template.go
@@ -171,7 +171,42 @@ See https://docs.runtm.com/cloud-api/templates for the full schemas.`,
 		newTemplateSaveSnapshot(rt),
 		newTemplateRepos(rt),
 		newTemplateSecrets(rt),
+		newTemplateDirectives(rt, "skills", "skill"),
+		newTemplateDirectives(rt, "mcp", "mcp_server"),
 	)
+	return cmd
+}
+
+// --- attached skills / mcp servers ----------------------------------------
+
+// newTemplateDirectives lists the skills or MCP servers attached to a template.
+// It's the template-side view of the attachments managed by
+// `runtm-api skills|mcp attach`: every session launched from the template loads
+// these. Backed by GET /api/agent-directives?template_id=<id>&type_family=<f>.
+func newTemplateDirectives(rt *Runtime, use, typeFamily string) *cobra.Command {
+	var includeContent bool
+	cmd := &cobra.Command{
+		Use:   use + " <template_id>",
+		Short: fmt.Sprintf("List %s attached to a template (sessions from it load these)", use),
+		Long: fmt.Sprintf(`List the %s attached to a template. Attach/detach them with
+'runtm-api %s attach|detach <id> --template <template_id>'.`, use, use),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _, err := requireOrgClient(rt, "org templates")
+			if err != nil {
+				return err
+			}
+			q := url.Values{}
+			q.Set("template_id", args[0])
+			q.Set("type_family", typeFamily)
+			if includeContent {
+				q.Set("include_content", "true")
+			}
+			resp, err := c.Get(directivesListPath, q)
+			return runJSON(rt, resp, err)
+		},
+	}
+	cmd.Flags().BoolVar(&includeContent, "include-content", false, "Include each item's content payload")
 	return cmd
 }
 

--- a/packages/agent/internal/skills/files/SKILL.md
+++ b/packages/agent/internal/skills/files/SKILL.md
@@ -106,6 +106,8 @@ To parameterize a template, declare **session arguments** with `--session-arg` (
 | List template secrets | `runtm-api template secrets list <tmpl_id>` |
 | Set template secrets | `runtm-api template secrets set <tmpl_id> KEY value [KEY value ...]` |
 | Delete a template secret | `runtm-api template secrets delete <tmpl_id> KEY` |
+| Skills/MCP attached to a template | `runtm-api template skills\|mcp <tmpl_id>` |
+| Attach a skill/MCP to a template | `runtm-api skills\|mcp attach <id> --template <tmpl_id>` |
 
 ### Activity (telemetry)
 
@@ -127,7 +129,7 @@ To parameterize a template, declare **session arguments** with `--session-arg` (
 | Instructions | `runtm-api instructions get\|set [--org-scope] [--text "..."\|--clear]` |
 | Guardrails | `runtm-api guardrails limits\|allowlist get\|set`, `can-deploy`, `deploy-limits`, `cleanup --yes` |
 | Integrations | `runtm-api integrations anthropic\|openai get\|set\|delete\|resolved [--org-scope]` |
-| Skills / MCP / Tools | `runtm-api skills\|mcp\|tools create\|get\|list\|update\|delete` (see `runtm-directives`) |
+| Skills / MCP / Tools | `runtm-api skills\|mcp\|tools create\|get\|list\|update\|delete`; attach skills/MCP to templates with `skills\|mcp attach\|detach\|attachments <id> --template <tmpl_id>` (see `runtm-directives`) |
 | Agents (Slack/GitHub) | `runtm-api agents create\|list\|get\|update\|delete --type slack\|github` (see `runtm-agents`) |
 | Auth | `runtm-api auth status` |
 

--- a/packages/agent/internal/skills/files/runtm-directives.md
+++ b/packages/agent/internal/skills/files/runtm-directives.md
@@ -1,9 +1,9 @@
 ---
 name: runtm-directives
-description: "Create, read, update, and delete the Runtm Cloud session-context directives from the CLI: skills (SKILL.md bundles), MCP servers (stdio or http/sse), tools (knowledge integrations / provider credentials), and custom tool providers. Use when the user wants to author/manage skills, wire up an MCP server, store provider credentials, or define a NEW custom tool provider (name, logo, mise/npm/github package, and auth fields) when no built-in provider exists."
+description: "Create, read, update, and delete the Runtm Cloud session-context directives from the CLI: skills (SKILL.md bundles), MCP servers (stdio or http/sse), tools (knowledge integrations / provider credentials), and custom tool providers — and attach skills/MCP servers to org templates, repos, or all repos so sessions load them. Use when the user wants to add/connect/create an integration (investigate API vs CLI vs MCP and auth methods first, then ask the user to pick), author/manage skills, wire up an MCP server, attach a skill or MCP to a template, store provider credentials, or define a NEW custom tool provider (name, logo, mise/npm/github package, and auth fields) when no built-in provider exists."
 metadata:
-  version: "0.2.0"
-  tags: runtm,runtime,directives,skills,mcp,tools,knowledge
+  version: "0.4.0"
+  tags: runtm,runtime,directives,skills,mcp,tools,knowledge,templates,attachments,integrations
 ---
 
 # Runtm Directives
@@ -36,6 +36,67 @@ Every command prints JSON to stdout and structured errors to stderr.
 Common flags: `--page-size`, `--page-token` (list); `--include-content` (skill/
 mcp list/get); `--yes` (delete confirmation). Each subcommand also accepts a raw
 `--content` / `--credentials` JSON escape hatch for full control.
+
+---
+
+## Adding an integration: investigate first, then ask
+
+When the user wants to **add, connect, or create an integration** with some
+external service (e.g. "connect Linear", "add Stripe", "wire up our data
+warehouse"), do **not** jump straight to one mechanism. There are usually
+several ways to reach a service, and they map onto different runtm primitives
+with different trade-offs. **Investigate the options, then ask the user to
+choose before you build anything.**
+
+### Step 1 — Investigate what the service offers
+
+Research (vendor docs, web search, the service's developer site) how the target
+can actually be reached, and which runtm primitive carries each:
+
+| Access modality | What to look for | runtm primitive | Pros | Cons |
+|---|---|---|---|---|
+| **MCP server** | An official or community MCP server (an installable stdio package, or a hosted http/sse endpoint) | `runtm-api mcp create` | Native tool-calling, structured, maintained by others, least glue code | Not every service has one; adds a server process; you inherit its tool design & quality |
+| **CLI** | An official command-line tool | `runtm-api skills create` (document the commands) + a credential via `tools` / a custom provider whose `mise` package installs the binary | Uses battle-tested official tooling; easy for the agent to drive; great coverage | Agent drives free-text commands (less structured); the binary must be installed in the sandbox |
+| **REST / HTTP API** | The public API + auth docs (almost always exists) | `runtm-api skills create` (document the endpoints/recipes) + an API key via `tools` or a session/template secret | Maximum control & coverage; no extra process | You hand-author request recipes; more upfront work; you own the maintenance |
+
+Prefer an existing **MCP server** when one exists and is good; fall back to
+**CLI-via-skill**, then **API-via-skill**. But surface all viable options — the
+user may have a preference.
+
+### Step 2 — Find the auth methods the service supports
+
+For each viable modality, determine how it authenticates and which runtm path
+carries that credential:
+
+- **OAuth** — connected through the **dashboard** (browser flow), not the CLI.
+  For a bring-your-own OAuth app, define a custom provider with
+  `tools providers create … --auth-methods '[{… "kind":"oauth" …}]'`.
+- **API key / token / service account** — store with `runtm-api tools create`
+  (static credentials against a built-in or custom provider), or as a plain
+  session/template secret for a one-off.
+- Note the **scope**: org-wide (define the provider once, every teammate
+  connects their own credentials) vs. personal/one session.
+
+Check whether the service is already a known **tool provider**
+(`runtm-api tools providers list`) before defining a new one.
+
+### Step 3 — Present the options and let the user pick
+
+Summarize what you found and **ask the user to choose** before implementing —
+for example:
+
+> Linear can be integrated three ways:
+> 1. **MCP server** (hosted, http/sse) — auth via OAuth (dashboard) or an API
+>    key header. Most native; least code.
+> 2. **`linear` CLI** wrapped as a skill — auth via personal API key. Uses the
+>    official CLI; good for scripted workflows.
+> 3. **REST API** documented in a skill — auth via API key. Most control.
+>
+> Which approach do you want, and which auth method?
+
+Only after the user selects an approach + auth method, implement it with the
+relevant command below (`mcp`, `tools`/`tools providers`, or `skills`). Skip the
+question only when the user has already named the exact mechanism and auth.
 
 ---
 
@@ -112,6 +173,69 @@ runtm-api mcp delete <id> --yes
 Content shape — stdio: `{transport:"stdio", command, args[], env{}}` (command
 required). http/sse: `{transport:"http"|"sse", url, headers{}}` (url required).
 `--arg` is repeatable and ordered; `--env`/`--header` take `KEY=VALUE`.
+
+---
+
+## Attaching skills & MCP servers to templates (and repos)
+
+Creating a skill or MCP server does **not** load it anywhere on its own — it
+only loads into a session where it is **attached**. Attach it to an **org
+template** and every session launched from that template loads it. This is the
+CLI equivalent of the dashboard's "Attach to template" picker.
+
+`skills` and `mcp` both expose the same three verbs (same
+`/api/agent-directives/{id}/attachments` endpoint, `context:write` to change):
+
+```bash
+# Attach a skill to a template (sessions from that template now load it)
+runtm-api skills attach <skill_id> --template <template_id>
+
+# Attach an MCP server to two templates at once
+runtm-api mcp attach <mcp_id> --template <t1> --template <t2>
+
+# Attach to specific repos, or to every repo in the org
+runtm-api skills attach <skill_id> --repo acme/api --repo acme/web
+runtm-api skills attach <skill_id> --all
+
+# See where something is attached
+runtm-api skills attachments <skill_id>
+
+# Detach from one template (leaves other attachments in place)
+runtm-api skills detach <skill_id> --template <template_id>
+# Remove every attachment
+runtm-api skills detach <skill_id> --clear
+```
+
+The template-side view — list what a template loads:
+
+```bash
+runtm-api template skills <template_id>   # skills attached to the template
+runtm-api template mcp <template_id>      # MCP servers attached to the template
+```
+
+Scopes & semantics:
+
+- Three scopes, **mutually exclusive with `--all`**: `--template` (repeatable),
+  `--repo owner/name` (repeatable), and `--all` (every repo in the org). You can
+  mix `--template` and `--repo` in one call; `--all` cannot be combined with
+  either and supersedes them.
+- `attach` **merges** with the current scope by default (repeated calls add).
+  Pass `--replace` to set the exact scope wholesale. Switching to `--all`
+  replaces any scoped attachments.
+- `detach` removes the named `--template`/`--repo`, `--all` removes the
+  all-repos attachment, and `--clear` removes everything. It leaves untouched
+  attachments in place.
+- Only **org-owned** skills/MCP servers can be attached (use `--org` /
+  `RUNTM_ORG_ID`); personal directives cannot.
+
+The full flow to wire a skill into a template:
+
+```bash
+export RUNTM_ORG_ID=org_abc123
+SKILL_ID=$(runtm-api skills create --name deploy-checks --md ./SKILL.md | jq -r .directive.id)
+runtm-api skills attach "$SKILL_ID" --template <template_id>
+runtm-api template skills <template_id>          # verify it's listed
+```
 
 ---
 
@@ -240,4 +364,6 @@ runtm-api mcp --help
 runtm-api tools --help
 runtm-api tools providers --help
 runtm-api mcp create --help
+runtm-api skills attach --help    # attach/detach/attachments verbs
+runtm-api template skills --help  # template-side view of attachments
 ```

--- a/packages/agent/internal/skills/files/runtm-templates.md
+++ b/packages/agent/internal/skills/files/runtm-templates.md
@@ -206,6 +206,32 @@ runtm-api template secrets set tmpl_abc... DATABASE_URL "postgres://..." STRIPE_
 runtm-api template secrets delete tmpl_abc... STRIPE_KEY
 ```
 
+## Recipe: attach skills & MCP servers
+
+Templates can carry **skills** and **MCP servers**, so every session launched
+from the template loads them automatically — the same "Session context" wiring
+the dashboard offers on a template. Skills/MCP servers are created with the
+`skills`/`mcp` commands (see the `runtm-directives` skill); attaching is what
+binds them to a template.
+
+```bash
+# List what a template currently loads
+runtm-api template skills tmpl_abc...   # attached skills
+runtm-api template mcp tmpl_abc...      # attached MCP servers
+
+# Attach an existing skill / MCP server to the template
+runtm-api skills attach <skill_id> --template tmpl_abc...
+runtm-api mcp attach <mcp_id> --template tmpl_abc...
+
+# Detach (leaves the directive's other attachments untouched)
+runtm-api skills detach <skill_id> --template tmpl_abc...
+```
+
+`attach` merges with the directive's existing scope (repos / other templates /
+all-repos), so attaching to a template never disturbs unrelated attachments.
+Full authoring + attachment workflow lives in the `runtm-directives` skill.
+Requires `context:write` on the key.
+
 ## Recipe: clean up
 
 ```bash
@@ -225,5 +251,7 @@ Deletion does not affect already-running sessions that were created from the tem
 | Build | Admin or Owner | `templates:build` |
 | Delete | Admin or Owner | `templates:delete` |
 | Manage template secrets | Admin or Owner | `secrets:write` |
+| List attached skills / MCP servers | Member | `context:read` |
+| Attach / detach skills / MCP servers | Admin or Owner | `context:write` |
 
 If an operation fails with 403, run `runtm-api auth status` and verify both the API key scopes and the user's org role.

--- a/packages/agent/skills/SKILL.md
+++ b/packages/agent/skills/SKILL.md
@@ -106,6 +106,8 @@ To parameterize a template, declare **session arguments** with `--session-arg` (
 | List template secrets | `runtm-api template secrets list <tmpl_id>` |
 | Set template secrets | `runtm-api template secrets set <tmpl_id> KEY value [KEY value ...]` |
 | Delete a template secret | `runtm-api template secrets delete <tmpl_id> KEY` |
+| Skills/MCP attached to a template | `runtm-api template skills\|mcp <tmpl_id>` |
+| Attach a skill/MCP to a template | `runtm-api skills\|mcp attach <id> --template <tmpl_id>` |
 
 ### Activity (telemetry)
 
@@ -127,7 +129,7 @@ To parameterize a template, declare **session arguments** with `--session-arg` (
 | Instructions | `runtm-api instructions get\|set [--org-scope] [--text "..."\|--clear]` |
 | Guardrails | `runtm-api guardrails limits\|allowlist get\|set`, `can-deploy`, `deploy-limits`, `cleanup --yes` |
 | Integrations | `runtm-api integrations anthropic\|openai get\|set\|delete\|resolved [--org-scope]` |
-| Skills / MCP / Tools | `runtm-api skills\|mcp\|tools create\|get\|list\|update\|delete` (see `runtm-directives`) |
+| Skills / MCP / Tools | `runtm-api skills\|mcp\|tools create\|get\|list\|update\|delete`; attach skills/MCP to templates with `skills\|mcp attach\|detach\|attachments <id> --template <tmpl_id>` (see `runtm-directives`) |
 | Agents (Slack/GitHub) | `runtm-api agents create\|list\|get\|update\|delete --type slack\|github` (see `runtm-agents`) |
 | Auth | `runtm-api auth status` |
 

--- a/packages/agent/skills/runtm-directives.md
+++ b/packages/agent/skills/runtm-directives.md
@@ -1,9 +1,9 @@
 ---
 name: runtm-directives
-description: "Create, read, update, and delete the Runtm Cloud session-context directives from the CLI: skills (SKILL.md bundles), MCP servers (stdio or http/sse), tools (knowledge integrations / provider credentials), and custom tool providers. Use when the user wants to author/manage skills, wire up an MCP server, store provider credentials, or define a NEW custom tool provider (name, logo, mise/npm/github package, and auth fields) when no built-in provider exists."
+description: "Create, read, update, and delete the Runtm Cloud session-context directives from the CLI: skills (SKILL.md bundles), MCP servers (stdio or http/sse), tools (knowledge integrations / provider credentials), and custom tool providers — and attach skills/MCP servers to org templates, repos, or all repos so sessions load them. Use when the user wants to add/connect/create an integration (investigate API vs CLI vs MCP and auth methods first, then ask the user to pick), author/manage skills, wire up an MCP server, attach a skill or MCP to a template, store provider credentials, or define a NEW custom tool provider (name, logo, mise/npm/github package, and auth fields) when no built-in provider exists."
 metadata:
-  version: "0.2.0"
-  tags: runtm,runtime,directives,skills,mcp,tools,knowledge
+  version: "0.4.0"
+  tags: runtm,runtime,directives,skills,mcp,tools,knowledge,templates,attachments,integrations
 ---
 
 # Runtm Directives
@@ -36,6 +36,67 @@ Every command prints JSON to stdout and structured errors to stderr.
 Common flags: `--page-size`, `--page-token` (list); `--include-content` (skill/
 mcp list/get); `--yes` (delete confirmation). Each subcommand also accepts a raw
 `--content` / `--credentials` JSON escape hatch for full control.
+
+---
+
+## Adding an integration: investigate first, then ask
+
+When the user wants to **add, connect, or create an integration** with some
+external service (e.g. "connect Linear", "add Stripe", "wire up our data
+warehouse"), do **not** jump straight to one mechanism. There are usually
+several ways to reach a service, and they map onto different runtm primitives
+with different trade-offs. **Investigate the options, then ask the user to
+choose before you build anything.**
+
+### Step 1 — Investigate what the service offers
+
+Research (vendor docs, web search, the service's developer site) how the target
+can actually be reached, and which runtm primitive carries each:
+
+| Access modality | What to look for | runtm primitive | Pros | Cons |
+|---|---|---|---|---|
+| **MCP server** | An official or community MCP server (an installable stdio package, or a hosted http/sse endpoint) | `runtm-api mcp create` | Native tool-calling, structured, maintained by others, least glue code | Not every service has one; adds a server process; you inherit its tool design & quality |
+| **CLI** | An official command-line tool | `runtm-api skills create` (document the commands) + a credential via `tools` / a custom provider whose `mise` package installs the binary | Uses battle-tested official tooling; easy for the agent to drive; great coverage | Agent drives free-text commands (less structured); the binary must be installed in the sandbox |
+| **REST / HTTP API** | The public API + auth docs (almost always exists) | `runtm-api skills create` (document the endpoints/recipes) + an API key via `tools` or a session/template secret | Maximum control & coverage; no extra process | You hand-author request recipes; more upfront work; you own the maintenance |
+
+Prefer an existing **MCP server** when one exists and is good; fall back to
+**CLI-via-skill**, then **API-via-skill**. But surface all viable options — the
+user may have a preference.
+
+### Step 2 — Find the auth methods the service supports
+
+For each viable modality, determine how it authenticates and which runtm path
+carries that credential:
+
+- **OAuth** — connected through the **dashboard** (browser flow), not the CLI.
+  For a bring-your-own OAuth app, define a custom provider with
+  `tools providers create … --auth-methods '[{… "kind":"oauth" …}]'`.
+- **API key / token / service account** — store with `runtm-api tools create`
+  (static credentials against a built-in or custom provider), or as a plain
+  session/template secret for a one-off.
+- Note the **scope**: org-wide (define the provider once, every teammate
+  connects their own credentials) vs. personal/one session.
+
+Check whether the service is already a known **tool provider**
+(`runtm-api tools providers list`) before defining a new one.
+
+### Step 3 — Present the options and let the user pick
+
+Summarize what you found and **ask the user to choose** before implementing —
+for example:
+
+> Linear can be integrated three ways:
+> 1. **MCP server** (hosted, http/sse) — auth via OAuth (dashboard) or an API
+>    key header. Most native; least code.
+> 2. **`linear` CLI** wrapped as a skill — auth via personal API key. Uses the
+>    official CLI; good for scripted workflows.
+> 3. **REST API** documented in a skill — auth via API key. Most control.
+>
+> Which approach do you want, and which auth method?
+
+Only after the user selects an approach + auth method, implement it with the
+relevant command below (`mcp`, `tools`/`tools providers`, or `skills`). Skip the
+question only when the user has already named the exact mechanism and auth.
 
 ---
 
@@ -112,6 +173,69 @@ runtm-api mcp delete <id> --yes
 Content shape — stdio: `{transport:"stdio", command, args[], env{}}` (command
 required). http/sse: `{transport:"http"|"sse", url, headers{}}` (url required).
 `--arg` is repeatable and ordered; `--env`/`--header` take `KEY=VALUE`.
+
+---
+
+## Attaching skills & MCP servers to templates (and repos)
+
+Creating a skill or MCP server does **not** load it anywhere on its own — it
+only loads into a session where it is **attached**. Attach it to an **org
+template** and every session launched from that template loads it. This is the
+CLI equivalent of the dashboard's "Attach to template" picker.
+
+`skills` and `mcp` both expose the same three verbs (same
+`/api/agent-directives/{id}/attachments` endpoint, `context:write` to change):
+
+```bash
+# Attach a skill to a template (sessions from that template now load it)
+runtm-api skills attach <skill_id> --template <template_id>
+
+# Attach an MCP server to two templates at once
+runtm-api mcp attach <mcp_id> --template <t1> --template <t2>
+
+# Attach to specific repos, or to every repo in the org
+runtm-api skills attach <skill_id> --repo acme/api --repo acme/web
+runtm-api skills attach <skill_id> --all
+
+# See where something is attached
+runtm-api skills attachments <skill_id>
+
+# Detach from one template (leaves other attachments in place)
+runtm-api skills detach <skill_id> --template <template_id>
+# Remove every attachment
+runtm-api skills detach <skill_id> --clear
+```
+
+The template-side view — list what a template loads:
+
+```bash
+runtm-api template skills <template_id>   # skills attached to the template
+runtm-api template mcp <template_id>      # MCP servers attached to the template
+```
+
+Scopes & semantics:
+
+- Three scopes, **mutually exclusive with `--all`**: `--template` (repeatable),
+  `--repo owner/name` (repeatable), and `--all` (every repo in the org). You can
+  mix `--template` and `--repo` in one call; `--all` cannot be combined with
+  either and supersedes them.
+- `attach` **merges** with the current scope by default (repeated calls add).
+  Pass `--replace` to set the exact scope wholesale. Switching to `--all`
+  replaces any scoped attachments.
+- `detach` removes the named `--template`/`--repo`, `--all` removes the
+  all-repos attachment, and `--clear` removes everything. It leaves untouched
+  attachments in place.
+- Only **org-owned** skills/MCP servers can be attached (use `--org` /
+  `RUNTM_ORG_ID`); personal directives cannot.
+
+The full flow to wire a skill into a template:
+
+```bash
+export RUNTM_ORG_ID=org_abc123
+SKILL_ID=$(runtm-api skills create --name deploy-checks --md ./SKILL.md | jq -r .directive.id)
+runtm-api skills attach "$SKILL_ID" --template <template_id>
+runtm-api template skills <template_id>          # verify it's listed
+```
 
 ---
 
@@ -240,4 +364,6 @@ runtm-api mcp --help
 runtm-api tools --help
 runtm-api tools providers --help
 runtm-api mcp create --help
+runtm-api skills attach --help    # attach/detach/attachments verbs
+runtm-api template skills --help  # template-side view of attachments
 ```

--- a/packages/agent/skills/runtm-templates.md
+++ b/packages/agent/skills/runtm-templates.md
@@ -206,6 +206,32 @@ runtm-api template secrets set tmpl_abc... DATABASE_URL "postgres://..." STRIPE_
 runtm-api template secrets delete tmpl_abc... STRIPE_KEY
 ```
 
+## Recipe: attach skills & MCP servers
+
+Templates can carry **skills** and **MCP servers**, so every session launched
+from the template loads them automatically — the same "Session context" wiring
+the dashboard offers on a template. Skills/MCP servers are created with the
+`skills`/`mcp` commands (see the `runtm-directives` skill); attaching is what
+binds them to a template.
+
+```bash
+# List what a template currently loads
+runtm-api template skills tmpl_abc...   # attached skills
+runtm-api template mcp tmpl_abc...      # attached MCP servers
+
+# Attach an existing skill / MCP server to the template
+runtm-api skills attach <skill_id> --template tmpl_abc...
+runtm-api mcp attach <mcp_id> --template tmpl_abc...
+
+# Detach (leaves the directive's other attachments untouched)
+runtm-api skills detach <skill_id> --template tmpl_abc...
+```
+
+`attach` merges with the directive's existing scope (repos / other templates /
+all-repos), so attaching to a template never disturbs unrelated attachments.
+Full authoring + attachment workflow lives in the `runtm-directives` skill.
+Requires `context:write` on the key.
+
 ## Recipe: clean up
 
 ```bash
@@ -225,5 +251,7 @@ Deletion does not affect already-running sessions that were created from the tem
 | Build | Admin or Owner | `templates:build` |
 | Delete | Admin or Owner | `templates:delete` |
 | Manage template secrets | Admin or Owner | `secrets:write` |
+| List attached skills / MCP servers | Member | `context:read` |
+| Attach / detach skills / MCP servers | Admin or Owner | `context:write` |
 
 If an operation fails with 403, run `runtm-api auth status` and verify both the API key scopes and the user's org role.


### PR DESCRIPTION
## Description

Org templates can carry **skills** and **MCP servers** so every session launched from a template loads them automatically — but until now that wiring only existed in the dashboard's "Session context" picker. This PR adds the same surface to the `runtm-api` CLI, so agents and scripts can attach/detach directives to templates (and repos) without the UI.

The CLI already had CRUD for `skills`, `mcp`, and `template`; what was missing was the link between them. This fills that gap using the existing backend endpoints — no API changes required.

### Commands added

| Command | Purpose |
|---|---|
| `runtm-api skills\|mcp attach <id> --template <tid>` | Attach a skill / MCP server to a template (also `--repo owner/name`, `--all`) |
| `runtm-api skills\|mcp detach <id> --template <tid>` | Detach from a template/repo (`--all`, `--clear`) |
| `runtm-api skills\|mcp attachments <id>` | List where a directive is attached |
| `runtm-api template skills\|mcp <id>` | Template-side view of attached directives |

### Behavior notes

- The backend `PUT /api/agent-directives/{id}/attachments` is a **full replace**, so `attach`/`detach` read the current scope and **merge** by default — repeated calls add/remove without clobbering unrelated attachments. `--replace` / `--clear` set the scope wholesale.
- Scope mutual-exclusivity (`--all` vs `--template`/`--repo`) is enforced client-side to match the backend's `ATTACHMENTS_INVALID` rule; list bodies are normalized to non-null JSON arrays.

### Docs

Updated the bundled CLI skills (`runtm-directives`, `runtm-templates`, `SKILL.md`) to document the new verbs, and added a new **"Adding an integration: investigate first, then ask"** section that guides agents to weigh API vs CLI vs MCP (pros/cons) and the available auth methods, then ask the user to choose an approach before implementing. Embedded `//go:embed` copies were re-synced via `make sync-skills`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/A

## Checklist

- [x] My code follows the project's style guidelines (`gofmt`/`go vet` clean on touched files)
- [x] I have formatted my code (`gofmt`)
- [x] I have added tests that prove my fix/feature works <!-- existing cmd tests pass; merge logic is pure helpers -->
- [x] All tests pass (`go test ./...`)
- [x] I have updated documentation if needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `make build` — clean (runs `sync-skills`; embedded skill copies verified in sync with source)
- `go vet ./internal/cmd/` — clean
- `go test ./...` — all packages pass
- `gofmt -l` clean on the three touched Go files (pre-existing `guardrails_cmd.go` formatting left untouched)
- Verified `--help` renders for `skills/mcp attach|detach|attachments` and `template skills|mcp`, and that all subcommands are registered in their command trees

## Release Notes

**Attach skills & MCP servers to org templates from the CLI.**

You can now wire org skills and MCP servers into templates straight from `runtm-api`, matching the dashboard's Session context picker:

```bash
# Attach an existing skill to a template (sessions from it now load the skill)
runtm-api skills attach <skill_id> --template <template_id>

# Attach an MCP server to multiple templates at once
runtm-api mcp attach <mcp_id> --template <t1> --template <t2>

# Or scope to specific repos / every repo in the org
runtm-api skills attach <skill_id> --repo acme/api
runtm-api skills attach <skill_id> --all

# Inspect and unwire
runtm-api skills attachments <skill_id>
runtm-api template skills <template_id>
runtm-api skills detach <skill_id> --template <template_id>
```

`attach`/`detach` merge with the existing scope by default (use `--replace`/`--clear` to set it wholesale). Requires `context:write` and an org-scoped key. See the updated `runtm-directives` and `runtm-templates` skills for the full workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)