### PR TITLE
feat(agent): add `skills pull` to materialize a template's skills locally

### DIFF
--- a/packages/agent/internal/cmd/skills_cmd.go
+++ b/packages/agent/internal/cmd/skills_cmd.go
@@ -39,6 +39,7 @@ embedded in this binary into the detected agent's skills directory.`,
 		newDirectiveAttach(rt, "skill"),
 		newDirectiveDetach(rt, "skill"),
 		newSkillsInstall(rt),
+		newSkillsPull(rt),
 	)
 	return cmd
 }

--- a/packages/agent/internal/cmd/skills_pull_cmd.go
+++ b/packages/agent/internal/cmd/skills_pull_cmd.go
@@ -1,0 +1,434 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/runtm-ai/runtm/packages/agent/internal/client"
+	"github.com/spf13/cobra"
+)
+
+// `runtm-api skills pull <template-id>` downloads every skill attached to a
+// template and writes it to disk, mirroring the layout a session gets when it
+// launches from that template (<target>/<skill-name>/SKILL.md). It is the
+// cloud counterpart to `skills install` (which only writes this binary's own
+// bundled skills) — here the files come from the org's skills via the API.
+
+// pulledSkillFile mirrors the SkillFile fields we need to write a file.
+type pulledSkillFile struct {
+	Path   string  `json:"path"`
+	Mode   string  `json:"mode"`
+	Inline *string `json:"inline"`
+	Ref    *string `json:"ref"`
+	URL    *string `json:"url"`
+}
+
+type pulledSkillContent struct {
+	EntryMd     string            `json:"entry_md"`
+	Files       []pulledSkillFile `json:"files"`
+	Frontmatter map[string]any    `json:"frontmatter"`
+}
+
+// pulledSkill is the subset of DirectiveResource the pull command reads.
+type pulledSkill struct {
+	ID          string              `json:"id"`
+	Name        string              `json:"name"`
+	DisplayName string              `json:"display_name"`
+	Description string              `json:"description"`
+	Content     *pulledSkillContent `json:"content"`
+}
+
+type pullListResp struct {
+	Directives    []pulledSkill `json:"directives"`
+	NextPageToken string        `json:"next_page_token"`
+	TotalSize     int           `json:"total_size"`
+}
+
+func newSkillsPull(rt *Runtime) *cobra.Command {
+	var (
+		target string
+		agents []string
+		repos  []string
+		force  bool
+	)
+	cmd := &cobra.Command{
+		Use:   "pull <template-id>",
+		Short: "Download a template's skills and write them to disk",
+		Long: `Download every skill attached to a template and write each one — its
+SKILL.md plus any bundled files — into the agent skills directories, exactly
+where a session gets them when it launches from the template:
+
+  ~/.claude/skills/<skill-name>/SKILL.md   (claude-code)
+  ~/.agents/skills/<skill-name>/SKILL.md   (codex)
+
+By default writes the claude-code layout (~/.claude/skills). Pass --agent codex
+for ~/.agents/skills, --agent all for both (repeat --agent to combine), or
+--target to write to one explicit directory instead. Existing skill directories
+are skipped unless --force is passed.
+
+Org-scoped: pass --org or RUNTM_ORG_ID, or use an org-scoped key. Needs the
+context:read scope.
+
+Example:
+  runtm-api skills pull <template_id>
+  runtm-api skills pull <template_id> --agent claude-code --agent codex --force`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			templateID := args[0]
+
+			roots, err := resolvePullTargets(target, agents)
+			if err != nil {
+				return err
+			}
+
+			c, _, err := requireOrgClient(rt, "skills")
+			if err != nil {
+				return err
+			}
+
+			skillsList, err := fetchTemplateSkills(c, templateID, repos)
+			if err != nil {
+				return err
+			}
+
+			written := []map[string]any{}
+			skipped := []map[string]any{}
+			for _, root := range roots {
+				for _, s := range skillsList {
+					skillDir := filepath.Join(root, sanitizeSkillName(s.Name))
+					if !force {
+						if _, statErr := os.Stat(skillDir); statErr == nil {
+							skipped = append(skipped, map[string]any{
+								"skill":  s.Name,
+								"path":   skillDir,
+								"reason": "directory exists (pass --force to overwrite)",
+							})
+							continue
+						}
+					}
+					files, werr := writeSkill(c, s, skillDir)
+					if werr != nil {
+						return fmt.Errorf("write skill %q: %w", s.Name, werr)
+					}
+					written = append(written, map[string]any{
+						"skill": s.Name,
+						"path":  skillDir,
+						"files": files,
+					})
+				}
+			}
+
+			rt.WriteObject(map[string]any{
+				"pulled":      true,
+				"template_id": templateID,
+				"targets":     roots,
+				"count":       len(written),
+				"skills":      written,
+				"skipped":     skipped,
+			})
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&target, "target", "", "Write to one explicit directory instead of the per-agent home defaults")
+	cmd.Flags().StringArrayVar(&agents, "agent", nil, "Agent skills layout: claude-code (~/.claude/skills), codex (~/.agents/skills), or all (repeatable; default claude-code)")
+	cmd.Flags().StringArrayVar(&repos, "repo", nil, "Also include skills attached to this repo (owner/name); repeatable. Matches how a template resolves its repo-scoped skills")
+	cmd.Flags().BoolVar(&force, "force", false, "Overwrite existing skill directories")
+	return cmd
+}
+
+// resolvePullTargets returns the destination skill roots. An explicit --target
+// wins; otherwise it maps each requested agent to its home-based skills
+// directory, matching where the server materializes skills into a sandbox
+// (~/.claude/skills for claude-code, ~/.agents/skills for codex).
+func resolvePullTargets(override string, agents []string) ([]string, error) {
+	if override != "" {
+		return []string{override}, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home directory: %w", err)
+	}
+	if len(agents) == 0 {
+		agents = []string{"claude-code"}
+	}
+
+	seen := map[string]bool{}
+	var roots []string
+	add := func(rel string) {
+		dir := filepath.Join(home, filepath.FromSlash(rel))
+		if !seen[dir] {
+			seen[dir] = true
+			roots = append(roots, dir)
+		}
+	}
+	for _, a := range agents {
+		switch a {
+		case "", "claude", "claude-code":
+			add(".claude/skills")
+		case "codex":
+			add(".agents/skills")
+		case "all":
+			add(".claude/skills")
+			add(".agents/skills")
+		default:
+			return nil, fmt.Errorf("invalid --agent %q (expected claude-code, codex, or all)", a)
+		}
+	}
+	return roots, nil
+}
+
+// fetchTemplateSkills lists every skill that materializes into a template,
+// matching the server's resolution: applies-to-all + template-scoped +
+// repo-scoped attachments. The backend list filter always folds in
+// applies_to_all, but template_id and repo_full_name narrow within a single
+// call, so each scope is queried separately and merged (deduped by id).
+func fetchTemplateSkills(c *client.Client, templateID string, repos []string) ([]pulledSkill, error) {
+	byID := map[string]pulledSkill{}
+	order := []string{}
+
+	addScope := func(scope func(url.Values)) error {
+		pageToken := ""
+		for {
+			q := url.Values{}
+			q.Set("type_family", "skill")
+			q.Set("include_content", "true")
+			q.Set("page_size", "100")
+			scope(q)
+			if pageToken != "" {
+				q.Set("page_token", pageToken)
+			}
+			raw, err := c.Get(directivesListPath, q)
+			if err != nil {
+				return err
+			}
+			var resp pullListResp
+			if err := json.Unmarshal(raw, &resp); err != nil {
+				return fmt.Errorf("parse skills list: %w", err)
+			}
+			for _, s := range resp.Directives {
+				if _, ok := byID[s.ID]; !ok {
+					order = append(order, s.ID)
+				}
+				byID[s.ID] = s
+			}
+			if resp.NextPageToken == "" {
+				break
+			}
+			pageToken = resp.NextPageToken
+		}
+		return nil
+	}
+
+	if err := addScope(func(q url.Values) { q.Set("template_id", templateID) }); err != nil {
+		return nil, err
+	}
+	for _, repo := range repos {
+		if strings.TrimSpace(repo) == "" {
+			continue
+		}
+		repo := repo
+		if err := addScope(func(q url.Values) { q.Set("repo_full_name", repo) }); err != nil {
+			return nil, err
+		}
+	}
+
+	out := make([]pulledSkill, 0, len(order))
+	for _, id := range order {
+		out = append(out, byID[id])
+	}
+	return out, nil
+}
+
+// writeSkill writes one skill's files into skillDir and returns the paths written.
+func writeSkill(c *client.Client, s pulledSkill, skillDir string) ([]string, error) {
+	if s.Content == nil {
+		return nil, fmt.Errorf("no content returned (the skill may be unavailable, or use a context:read key)")
+	}
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		return nil, err
+	}
+	entry := s.Content.EntryMd
+	if entry == "" {
+		entry = "SKILL.md"
+	}
+	var written []string
+	for _, f := range s.Content.Files {
+		data, err := resolveFileBytes(c, f)
+		if err != nil {
+			return nil, fmt.Errorf("file %q: %w", f.Path, err)
+		}
+		// The entry markdown must carry name/description frontmatter to be a
+		// valid on-disk skill; reconstruct it the way the server does at
+		// materialization time when it's missing.
+		if isEntryFile(f, entry) && (f.Mode == "" || f.Mode == "text") {
+			data = []byte(ensureSkillFrontmatter(s, s.Content, string(data)))
+		}
+		dest := filepath.Join(skillDir, filepath.FromSlash(cleanRelPath(f.Path)))
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(dest, data, 0o644); err != nil {
+			return nil, err
+		}
+		written = append(written, f.Path)
+	}
+	return written, nil
+}
+
+// resolveFileBytes returns a file's bytes from inline content or, for files
+// stored in object storage, by downloading the presigned URL.
+func resolveFileBytes(c *client.Client, f pulledSkillFile) ([]byte, error) {
+	if f.Inline != nil {
+		if f.Mode == "binary" {
+			decoded, err := base64.StdEncoding.DecodeString(*f.Inline)
+			if err != nil {
+				return nil, fmt.Errorf("decode binary inline: %w", err)
+			}
+			return decoded, nil
+		}
+		return []byte(*f.Inline), nil
+	}
+	if f.URL != nil && *f.URL != "" {
+		return downloadURL(*f.URL)
+	}
+	return nil, fmt.Errorf("file has neither inline content nor a download URL")
+}
+
+// downloadURL fetches a presigned object-storage URL with a plain client (no
+// API auth headers — the URL is already signed).
+func downloadURL(rawURL string) ([]byte, error) {
+	resp, err := http.Get(rawURL) //nolint:gosec // presigned URL minted by our API
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("download failed: HTTP %d", resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func isEntryFile(f pulledSkillFile, entry string) bool {
+	p := strings.TrimPrefix(f.Path, "./")
+	return p == "SKILL.md" || p == strings.TrimPrefix(entry, "./")
+}
+
+// cleanRelPath neutralizes any leading "./" and ".." escapes so a skill file
+// path can never be written outside its skill directory.
+func cleanRelPath(p string) string {
+	cleaned := filepath.Clean(string(filepath.Separator) + filepath.FromSlash(p))
+	return strings.TrimPrefix(cleaned, string(filepath.Separator))
+}
+
+// sanitizeSkillName keeps skill directory names to a single safe path segment.
+func sanitizeSkillName(name string) string {
+	name = strings.ReplaceAll(name, "..", "-")
+	name = strings.ReplaceAll(name, "/", "-")
+	name = strings.ReplaceAll(name, string(filepath.Separator), "-")
+	if strings.TrimSpace(name) == "" {
+		return "skill"
+	}
+	return name
+}
+
+// ensureSkillFrontmatter mirrors the server's materialization step: if the
+// SKILL.md already has name + description frontmatter it's returned untouched;
+// otherwise frontmatter is synthesized from stored frontmatter and the
+// directive's own metadata.
+func ensureSkillFrontmatter(s pulledSkill, content *pulledSkillContent, markdown string) string {
+	existing, body, _ := parseSimpleFrontmatter(markdown)
+	if existing["name"] != "" && existing["description"] != "" {
+		return markdown
+	}
+
+	name := firstNonEmpty(existing["name"], stringFromAny(content.Frontmatter["name"]), s.Name)
+	if name == "" {
+		name = "skill"
+	}
+	desc := firstNonEmpty(
+		existing["description"],
+		stringFromAny(content.Frontmatter["description"]),
+		s.Description,
+		s.DisplayName,
+	)
+	if desc == "" {
+		desc = "Use this skill when working with " + name + "."
+	}
+
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString("name: " + yamlScalar(name) + "\n")
+	b.WriteString("description: " + yamlScalar(desc) + "\n")
+	b.WriteString("---\n\n")
+	b.WriteString(strings.TrimLeft(body, "\n"))
+	return b.String()
+}
+
+// parseSimpleFrontmatter does a best-effort read of leading `--- ... ---` YAML,
+// enough to tell whether name/description are present. It is deliberately
+// minimal (scalar key: value pairs only).
+func parseSimpleFrontmatter(markdown string) (map[string]string, string, bool) {
+	fm := map[string]string{}
+	if !strings.HasPrefix(markdown, "---\n") && !strings.HasPrefix(markdown, "---\r\n") {
+		return fm, markdown, false
+	}
+	nl := strings.IndexByte(markdown, '\n')
+	rest := markdown[nl+1:]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return fm, markdown, false
+	}
+	header := rest[:end]
+	body := strings.TrimLeft(rest[end+len("\n---"):], "\r\n")
+	for _, line := range strings.Split(header, "\n") {
+		line = strings.TrimRight(line, "\r")
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		fm[strings.TrimSpace(k)] = strings.Trim(strings.TrimSpace(v), `"'`)
+	}
+	return fm, body, true
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func stringFromAny(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+// yamlScalar renders a string as a YAML scalar, quoting + escaping only when
+// the raw value could be misparsed.
+func yamlScalar(v string) string {
+	if v == "" {
+		return `""`
+	}
+	needsQuote := strings.ContainsAny(v, ":#\n\"'{}[]&*?|<>=!%@`,") ||
+		strings.HasPrefix(v, " ") || strings.HasSuffix(v, " ")
+	if !needsQuote {
+		return v
+	}
+	escaped := strings.ReplaceAll(v, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	escaped = strings.ReplaceAll(escaped, "\n", `\n`)
+	return `"` + escaped + `"`
+}

--- a/packages/agent/internal/cmd/skills_pull_cmd_test.go
+++ b/packages/agent/internal/cmd/skills_pull_cmd_test.go
@@ -1,0 +1,240 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureSkillFrontmatterPreservesExisting(t *testing.T) {
+	md := "---\nname: deploy-checks\ndescription: Run pre-deploy checks\n---\n\nBody here.\n"
+	s := pulledSkill{Name: "other", Description: "other desc"}
+	got := ensureSkillFrontmatter(s, &pulledSkillContent{}, md)
+	if got != md {
+		t.Fatalf("expected unchanged markdown, got:\n%s", got)
+	}
+}
+
+func TestEnsureSkillFrontmatterSynthesizesFromMetadata(t *testing.T) {
+	// No frontmatter at all; name/description come from the directive.
+	md := "Just the body, no frontmatter.\n"
+	s := pulledSkill{Name: "deploy-checks", Description: "Run pre-deploy checks"}
+	got := ensureSkillFrontmatter(s, &pulledSkillContent{}, md)
+
+	if !strings.HasPrefix(got, "---\n") {
+		t.Fatalf("expected frontmatter block, got:\n%s", got)
+	}
+	if !strings.Contains(got, "name: deploy-checks") {
+		t.Errorf("missing synthesized name:\n%s", got)
+	}
+	if !strings.Contains(got, "description: Run pre-deploy checks") {
+		t.Errorf("missing synthesized description:\n%s", got)
+	}
+	if !strings.Contains(got, "Just the body, no frontmatter.") {
+		t.Errorf("body dropped:\n%s", got)
+	}
+}
+
+func TestEnsureSkillFrontmatterFallsBackToStoredFrontmatter(t *testing.T) {
+	md := "Body only.\n"
+	s := pulledSkill{Name: "x"}
+	content := &pulledSkillContent{Frontmatter: map[string]any{
+		"name":        "from-store",
+		"description": "stored description",
+	}}
+	got := ensureSkillFrontmatter(s, content, md)
+	if !strings.Contains(got, "name: from-store") || !strings.Contains(got, "description: stored description") {
+		t.Fatalf("expected stored frontmatter to win over directive name, got:\n%s", got)
+	}
+}
+
+func TestCleanRelPathNeutralizesTraversal(t *testing.T) {
+	cases := map[string]string{
+		"SKILL.md":         "SKILL.md",
+		"./SKILL.md":       "SKILL.md",
+		"lib/helper.py":    filepath.FromSlash("lib/helper.py"),
+		"../../etc/passwd": filepath.FromSlash("etc/passwd"),
+		"a/../../../b.txt": "b.txt",
+	}
+	for in, want := range cases {
+		if got := cleanRelPath(in); got != want {
+			t.Errorf("cleanRelPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSanitizeSkillName(t *testing.T) {
+	cases := map[string]string{
+		"deploy-checks": "deploy-checks",
+		"a/b":           "a-b",
+		"../evil":       "--evil",
+		"":              "skill",
+	}
+	for in, want := range cases {
+		if got := sanitizeSkillName(in); got != want {
+			t.Errorf("sanitizeSkillName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestResolvePullTargets(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+	claude := filepath.Join(home, ".claude", "skills")
+	codex := filepath.Join(home, ".agents", "skills")
+
+	// Default: claude-code only.
+	got, err := resolvePullTargets("", nil)
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	if len(got) != 1 || got[0] != claude {
+		t.Errorf("default targets = %v, want [%s]", got, claude)
+	}
+
+	// all → both roots, deduped and ordered.
+	got, err = resolvePullTargets("", []string{"all"})
+	if err != nil {
+		t.Fatalf("all: %v", err)
+	}
+	if len(got) != 2 || got[0] != claude || got[1] != codex {
+		t.Errorf("all targets = %v, want [%s %s]", got, claude, codex)
+	}
+
+	// Repeated/overlapping agents dedupe to the same root set.
+	got, _ = resolvePullTargets("", []string{"claude-code", "codex", "claude"})
+	if len(got) != 2 || got[0] != claude || got[1] != codex {
+		t.Errorf("multi-agent targets = %v, want [%s %s]", got, claude, codex)
+	}
+
+	// Explicit --target wins, verbatim.
+	got, _ = resolvePullTargets("/tmp/x", []string{"all"})
+	if len(got) != 1 || got[0] != "/tmp/x" {
+		t.Errorf("override targets = %v, want [/tmp/x]", got)
+	}
+
+	if _, err := resolvePullTargets("", []string{"bogus"}); err == nil {
+		t.Error("expected error for invalid --agent")
+	}
+}
+
+func TestFetchTemplateSkillsPaginates(t *testing.T) {
+	page := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("template_id"); got != "tmpl_1" {
+			t.Errorf("template_id = %q, want tmpl_1", got)
+		}
+		if got := r.URL.Query().Get("type_family"); got != "skill" {
+			t.Errorf("type_family = %q, want skill", got)
+		}
+		if r.URL.Query().Get("include_content") != "true" {
+			t.Errorf("expected include_content=true")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if page == 0 {
+			page++
+			_, _ = w.Write([]byte(`{"directives":[{"id":"d1","name":"one","content":{"entry_md":"SKILL.md","files":[]}}],"next_page_token":"tok2","total_size":2}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"directives":[{"id":"d2","name":"two","content":{"entry_md":"SKILL.md","files":[]}}],"next_page_token":"","total_size":2}`))
+	}))
+	defer srv.Close()
+
+	skills, err := fetchTemplateSkills(newTestClient(srv.URL), "tmpl_1", nil)
+	if err != nil {
+		t.Fatalf("fetchTemplateSkills: %v", err)
+	}
+	if len(skills) != 2 || skills[0].Name != "one" || skills[1].Name != "two" {
+		t.Fatalf("unexpected skills: %+v", skills)
+	}
+}
+
+func TestFetchTemplateSkillsMergesScopesAndDedupes(t *testing.T) {
+	var scopes []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case q.Get("template_id") == "tmpl_1":
+			scopes = append(scopes, "template")
+			// applies_to_all (d0) + template-scoped (d1)
+			_, _ = w.Write([]byte(`{"directives":[{"id":"d0","name":"org-wide","content":{"files":[]}},{"id":"d1","name":"tmpl","content":{"files":[]}}],"next_page_token":"","total_size":2}`))
+		case q.Get("repo_full_name") == "acme/api":
+			scopes = append(scopes, "repo")
+			// applies_to_all again (d0, dup) + repo-scoped (d2)
+			_, _ = w.Write([]byte(`{"directives":[{"id":"d0","name":"org-wide","content":{"files":[]}},{"id":"d2","name":"repo","content":{"files":[]}}],"next_page_token":"","total_size":2}`))
+		default:
+			t.Errorf("unexpected query: %v", q)
+			_, _ = w.Write([]byte(`{"directives":[],"next_page_token":"","total_size":0}`))
+		}
+	}))
+	defer srv.Close()
+
+	skills, err := fetchTemplateSkills(newTestClient(srv.URL), "tmpl_1", []string{"acme/api", ""})
+	if err != nil {
+		t.Fatalf("fetchTemplateSkills: %v", err)
+	}
+	// d0 deduped across both scopes; order preserved by first sighting.
+	if len(skills) != 3 {
+		t.Fatalf("expected 3 deduped skills, got %d: %+v", len(skills), skills)
+	}
+	want := []string{"org-wide", "tmpl", "repo"}
+	for i, name := range want {
+		if skills[i].Name != name {
+			t.Errorf("skills[%d] = %q, want %q", i, skills[i].Name, name)
+		}
+	}
+	if len(scopes) != 2 || scopes[0] != "template" || scopes[1] != "repo" {
+		t.Errorf("expected template then repo scope calls, got %v", scopes)
+	}
+}
+
+func TestWriteSkillWritesEntryAndExtraFiles(t *testing.T) {
+	body := "Body text."
+	helper := "print('hi')"
+	s := pulledSkill{
+		Name:        "deploy-checks",
+		Description: "Run pre-deploy checks",
+		Content: &pulledSkillContent{
+			EntryMd: "SKILL.md",
+			Files: []pulledSkillFile{
+				{Path: "SKILL.md", Mode: "text", Inline: &body},
+				{Path: "lib/helper.py", Mode: "text", Inline: &helper},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, sanitizeSkillName(s.Name))
+	written, err := writeSkill(nil, s, skillDir)
+	if err != nil {
+		t.Fatalf("writeSkill: %v", err)
+	}
+	if len(written) != 2 {
+		t.Fatalf("expected 2 files written, got %v", written)
+	}
+
+	entry, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read entry: %v", err)
+	}
+	if !strings.Contains(string(entry), "name: deploy-checks") {
+		t.Errorf("entry missing synthesized frontmatter:\n%s", entry)
+	}
+	if !strings.Contains(string(entry), "Body text.") {
+		t.Errorf("entry missing body:\n%s", entry)
+	}
+
+	got, err := os.ReadFile(filepath.Join(skillDir, "lib", "helper.py"))
+	if err != nil {
+		t.Fatalf("read helper: %v", err)
+	}
+	if string(got) != helper {
+		t.Errorf("helper.py = %q, want %q", got, helper)
+	}
+}


### PR DESCRIPTION
## Description

Adds `runtm-api skills pull <template-id>` — downloads every skill that materializes into a template and writes it to disk in the exact layout a session gets at launch:

```
~/.claude/skills/<name>/SKILL.md   (claude-code)
~/.agents/skills/<name>/SKILL.md   (codex)
```

It lists the org's skills with content included, reconstructs `SKILL.md` frontmatter the way the server does, and writes inline / base64 / object-storage files (downloading presigned URLs directly), neutralizing path traversal in both skill names and file paths.

Scope matches the server's directive resolution — applies-to-all + template-scoped + repo-scoped:
- `--repo owner/name` (repeatable) queries each scope and merges/dedupes by id
- `--agent claude-code|codex|all` (repeatable) selects roots; `--target` overrides; `--force` overwrites

This is the **sandbox-side half** of moving skill materialization off the rebuild worker (the materialize → worker-OOM path): the sandbox pulls its own skills instead of the worker shuffling every blob through its RAM. The backend wiring that calls this (behind a default-off flag, with worker-side fallback) lands separately in `runtm-cloud`, and depends on this command shipping in a release first.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/A — tracked in the `runtm-cloud` `.plan/materialize-sandbox-pull.md` writeup.

## Checklist

- [x] My code follows the project's style guidelines (`gofmt` clean; `go vet ./...` passes)
- [x] I have formatted my code (`gofmt -w`)
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass (`go test ./...`)
- [x] N/A docs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

> Note: this is a Go package (`packages/agent`), so style/test gates are `gofmt` / `go vet` / `go test` rather than `ruff` / `pytest`.

## Testing

`go build ./...`, `go vet ./...`, and `go test ./...` all pass. New unit tests in `skills_pull_cmd_test.go`:

- frontmatter preserved when present; synthesized from directive metadata / stored frontmatter when missing
- path-traversal neutralization (`cleanRelPath`, `sanitizeSkillName`)
- `resolvePullTargets` — default claude-code root, `all` → both roots, agent dedupe, `--target` override, invalid agent error
- `fetchTemplateSkills` — pagination, and multi-scope (template + repo) merge/dedupe by id
- `writeSkill` — entry `SKILL.md` + nested file round-trip to a temp dir

Also exercised the binary directly: `--help`, invalid `--agent`, and missing-arg paths render the expected output / structured errors.

## Release notes

Release notes are auto-generated by goreleaser from Conventional Commit titles at tag time; this lands under **Features** as:
> add `skills pull` to materialize a template's skills locally

Suggested next tag: `packages/agent/v0.0.7` (current latest is `v0.0.6`). The backend rollout depends on this version being released and the in-sandbox `runtm-api` refreshing to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)