### PR TITLE
docs: align OSS machine tier references

### DIFF
--- a/docs/open-source/api/deployments/create.mdx
+++ b/docs/open-source/api/deployments/create.mdx
@@ -31,7 +31,7 @@ Deploy a new application or update an existing one. Accepts a multipart form wit
 </ParamField>
 
 <ParamField query="tier" type="string">
-  Override machine tier: `starter`, `standard`, `performance`
+  Override machine tier: `starter`, `performance`, `pro`
 </ParamField>
 
 <ParamField query="config_only" type="boolean" default="false">
@@ -151,4 +151,3 @@ console.log(`Deployment ${data.deployment_id} created`);
 }
 ```
 </ResponseExample>
-

--- a/docs/open-source/cli/deploy.mdx
+++ b/docs/open-source/cli/deploy.mdx
@@ -21,7 +21,7 @@ runtm deploy [path]
 
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--tier TIER` | | Machine tier: `starter`, `standard`, `performance` |
+| `--tier TIER` | | Machine tier: `starter`, `performance`, `pro` |
 | `--wait/--no-wait` | | Wait for deployment to complete (default: wait) |
 | `--timeout N` | `-t` | Timeout in seconds (default: 500) |
 | `--yes` | `-y` | Auto-fix lockfile issues without prompting |
@@ -46,11 +46,11 @@ runtm deploy ./my-project
 ### Machine Tiers
 
 ```bash
-# Deploy with standard tier (512MB RAM)
-runtm deploy --tier standard
-
-# Deploy with performance tier (1GB RAM)
+# Deploy with performance tier (4GB RAM)
 runtm deploy --tier performance
+
+# Deploy with pro tier (8GB RAM)
+runtm deploy --tier pro
 ```
 
 ### Auto-Fix Issues
@@ -150,14 +150,14 @@ runtm deploy --new
 
 | Tier | Memory | CPUs | Best for |
 |------|--------|------|----------|
-| `starter` | 256 MB | 1 shared | Simple APIs, webhooks |
-| `standard` | 512 MB | 1 shared | Web apps, fullstack |
-| `performance` | 1 GB | 2 shared | AI/ML, heavy workloads |
+| `starter` | 2 GB | 2 shared | APIs, webhooks, starter fullstack apps |
+| `performance` | 4 GB | 4 shared | Web apps, background work, moderate traffic |
+| `pro` | 8 GB | 4 shared | Memory-intensive apps, heavy workloads |
 
 All tiers use **suspended state** - machines pause when idle and resume quickly on requests.
 
 <Note>
-The `web-app` template requires `standard` or higher.
+The `starter` tier is the default. Use `performance` or `pro` when your app needs more CPU or memory.
 </Note>
 
 ## Config-Only Deploys

--- a/docs/open-source/cli/status.mdx
+++ b/docs/open-source/cli/status.mdx
@@ -36,7 +36,7 @@ Deployment: dep_abc123xyz
   Version:  3
   Template: backend-service
   Runtime:  python
-  Tier:     standard
+  Tier:     performance
 
   Created:  2024-01-15 10:30:00 UTC
   Ready:    2024-01-15 10:32:15 UTC (2m 15s)
@@ -107,4 +107,3 @@ runtm status dep_abc123xyz --json
 - [`runtm logs`](/cli/logs) - View deployment logs
 - [`runtm list`](/cli/list) - List all deployments
 - [`runtm destroy`](/cli/destroy) - Remove a deployment
-

--- a/docs/open-source/cli/validate.mdx
+++ b/docs/open-source/cli/validate.mdx
@@ -28,11 +28,11 @@ runtm validate [path] [options]
 ### 1. Manifest (runtm.yaml)
 
 - Required fields present (`name`, `template`)
-- `runtime` required for standard templates (not for `docker` template)
+- `runtime` required for non-Docker templates
 - Valid template type (`backend-service`, `static-site`, `web-app`, `docker`)
 - Valid runtime type (`python`, `node`, `fullstack`)
 - Valid port number
-- Tier requirements (fullstack needs standard+)
+- Valid machine tier (`starter`, `performance`, or `pro`)
 - Feature requirements (auth needs database)
 
 ### 2. Lockfile
@@ -109,7 +109,7 @@ Ready to deploy!
 ✗ Validation failed
 
 Errors:
-  • Manifest: tier must be 'standard' or higher for fullstack runtime
+  • Manifest: tier must be one of: performance, pro, starter
   • Lockfile: bun.lockb is out of sync. Run 'runtm fix' or 'bun install'
   • Import: Cannot import 'httpx' - add to [project] dependencies
 ```
@@ -144,11 +144,11 @@ Errors:
     ]
     ```
   </Accordion>
-  <Accordion title="Fullstack tier error">
-    Web apps need at least `standard` tier:
+  <Accordion title="Invalid tier">
+    Use one of the supported machine tiers:
     ```yaml
     # runtm.yaml
-    tier: standard  # Not starter
+    tier: performance
     ```
   </Accordion>
   <Accordion title="Auth without database">

--- a/docs/open-source/features/machine-tiers.mdx
+++ b/docs/open-source/features/machine-tiers.mdx
@@ -9,37 +9,33 @@ Runtime offers three machine tiers. All deployments use **suspended state** by d
 
 <Tabs>
   <Tab title="starter">
-    **256 MB RAM • 1 shared CPU**
-    
-    The default for most workloads. Good for simple APIs, webhooks, and tools.
-    
+    **2 GB RAM • 2 shared CPUs**
+
+    The default for most workloads. Good for APIs, webhooks, static sites, and fullstack starter apps.
+
     ```yaml
     # runtm.yaml
     tier: starter
     ```
   </Tab>
-  <Tab title="standard">
-    **512 MB RAM • 1 shared CPU**
-    
-    Required for fullstack apps. Good for web apps with moderate memory usage.
-    
-    ```yaml
-    # runtm.yaml
-    tier: standard
-    ```
-    
-    <Note>
-    The `web-app` template requires at least `standard` because it runs Node.js and Python simultaneously.
-    </Note>
-  </Tab>
   <Tab title="performance">
-    **1 GB RAM • 2 shared CPUs**
-    
-    For heavy workloads like AI/ML processing or high-traffic services.
-    
+    **4 GB RAM • 4 shared CPUs**
+
+    Good for heavier web apps, background work, and moderate traffic.
+
     ```yaml
     # runtm.yaml
     tier: performance
+    ```
+  </Tab>
+  <Tab title="pro">
+    **8 GB RAM • 4 shared CPUs**
+
+    For memory-intensive apps and larger workloads.
+
+    ```yaml
+    # runtm.yaml
+    tier: pro
     ```
   </Tab>
 </Tabs>
@@ -64,7 +60,7 @@ This gives you the cost benefits of serverless with near-instant response times.
 name: my-service
 template: backend-service
 runtime: python
-tier: standard
+tier: performance
 ```
 
 ### At deploy time
@@ -80,7 +76,7 @@ runtm deploy --tier performance
 Use config-only deploys to change tier instantly:
 
 ```bash
-runtm deploy --tier standard --config-only
+runtm deploy --tier performance --config-only
 ```
 
 ## Template requirements
@@ -89,7 +85,7 @@ runtm deploy --tier standard --config-only
 |----------|--------------|
 | `backend-service` | starter |
 | `static-site` | starter |
-| `web-app` | standard |
+| `web-app` | starter |
 
 ## When to upgrade
 

--- a/docs/open-source/guides/logs-debugging.mdx
+++ b/docs/open-source/guides/logs-debugging.mdx
@@ -267,7 +267,7 @@ runtm logs dep_abc123xyz --search "memory,oom,killed"
 If you see out-of-memory errors, upgrade to a higher tier:
 
 ```bash
-runtm deploy --tier standard
+runtm deploy --tier performance
 ```
 
 ## Best Practices
@@ -278,7 +278,7 @@ runtm deploy --tier standard
     ```python
     import logging
     import json
-    
+
     logging.info(json.dumps({
         "event": "request",
         "path": "/api/items",
@@ -307,4 +307,3 @@ runtm deploy --tier standard
 
 - [`runtm logs`](/cli/logs) - CLI reference
 - [Logs API](/api/logs) - API reference
-

--- a/docs/open-source/guides/troubleshooting.mdx
+++ b/docs/open-source/guides/troubleshooting.mdx
@@ -18,7 +18,7 @@ Quick solutions to common problems.
     pipx install runtm --force
     ```
   </Accordion>
-  
+
   <Accordion title="Authentication failed">
     Check your setup:
     ```bash
@@ -30,11 +30,11 @@ Quick solutions to common problems.
     runtm login
     ```
   </Accordion>
-  
+
   <Accordion title="Invalid API key format">
     Keys should start with `runtm_`. Get a new key from [app.runtm.com](https://app.runtm.com).
   </Accordion>
-  
+
   <Accordion title="Connection refused">
     If self-hosting, check your API URL:
     ```bash
@@ -58,7 +58,7 @@ Quick solutions to common problems.
     runtm deploy --yes
     ```
   </Accordion>
-  
+
   <Accordion title="Missing required environment variable">
     Set the missing secret:
     ```bash
@@ -67,7 +67,7 @@ Quick solutions to common problems.
     runtm deploy
     ```
   </Accordion>
-  
+
   <Accordion title="Artifact too large">
     Check what's being included:
     ```bash
@@ -75,28 +75,28 @@ Quick solutions to common problems.
     ```
     Add large files to `.gitignore`. Max artifact size is 20MB.
   </Accordion>
-  
+
   <Accordion title="Build timeout">
     Builds have a 10-minute limit. Common causes:
     - Too many dependencies
     - Large assets being processed
     - Network issues during package install
-    
+
     Try a higher tier:
     ```bash
-    runtm deploy --tier standard
+    runtm deploy --tier performance
     ```
   </Accordion>
-  
+
   <Accordion title="Health check failed">
     Your app must respond HTTP 200 at `/health` (or custom `health_path`).
-    
+
     Test locally:
     ```bash
     runtm run
     curl http://localhost:8080/health
     ```
-    
+
     Check logs:
     ```bash
     runtm logs <id> --type deploy
@@ -117,22 +117,22 @@ Quick solutions to common problems.
     - Wrong port (should match manifest)
     - Unhandled exceptions during init
   </Accordion>
-  
+
   <Accordion title="Out of memory">
     Upgrade to a higher tier:
     ```bash
-    runtm deploy --tier standard   # 512MB
-    runtm deploy --tier performance # 1GB
+    runtm deploy --tier performance # 4GB
+    runtm deploy --tier pro         # 8GB
     ```
   </Accordion>
-  
+
   <Accordion title="Database connection errors">
     If using `features.database: true`:
     - Ensure your app connects to `sqlite:///data/app.db`
     - The `/data` directory is mounted automatically
     - Check for file permission issues in logs
   </Accordion>
-  
+
   <Accordion title="Slow cold starts">
     Apps in suspended state take ~1-2 seconds to wake. To reduce this:
     - Minimize startup work
@@ -152,7 +152,7 @@ Quick solutions to common problems.
     ```
     Stop the conflicting process or use a `docker-compose.override.yml` to change ports.
   </Accordion>
-  
+
   <Accordion title="Database connection failed">
     Check PostgreSQL is running:
     ```bash
@@ -160,7 +160,7 @@ Quick solutions to common problems.
     docker compose -f infra/docker-compose.yml logs postgres
     ```
   </Accordion>
-  
+
   <Accordion title="Worker not processing jobs">
     Check worker logs:
     ```bash
@@ -171,7 +171,7 @@ Quick solutions to common problems.
     - Redis is running
     - API is healthy
   </Accordion>
-  
+
   <Accordion title="Migrations not running">
     Migrations run on API startup. To run manually:
     ```bash
@@ -182,7 +182,7 @@ Quick solutions to common problems.
     docker compose -f infra/docker-compose.yml exec api alembic upgrade head
     ```
   </Accordion>
-  
+
   <Accordion title="FLY_API_TOKEN errors">
     Use a Personal Access Token, not a deploy token:
     ```bash
@@ -205,7 +205,7 @@ Quick solutions to common problems.
     - Invalid template name
     - Malformed YAML
   </Accordion>
-  
+
   <Accordion title="Secret with default value">
     Secrets can't have defaults. Fix in `runtm.yaml`:
     ```yaml
@@ -213,14 +213,14 @@ Quick solutions to common problems.
     - name: API_KEY
       secret: true
       default: "xxx"
-    
+
     # Correct
     - name: API_KEY
       secret: true
       required: true
     ```
   </Accordion>
-  
+
   <Accordion title="Missing Dockerfile">
     Each template requires a `Dockerfile`. If missing:
     ```bash
@@ -250,4 +250,3 @@ If you're still stuck:
 3. **Search the docs** - Use the search bar above
 
 4. **Open an issue** - [github.com/runtm-ai/runtm/issues](https://github.com/runtm-ai/runtm/issues)
-

--- a/docs/open-source/templates/docker.mdx
+++ b/docs/open-source/templates/docker.mdx
@@ -182,14 +182,14 @@ runtm secrets list
 
 | Tier | Memory | CPUs | Best for |
 |------|--------|------|----------|
-| `starter` | 256 MB | 1 shared | Simple APIs, low traffic |
-| `standard` | 512 MB | 1 shared | Most workloads |
-| `performance` | 1 GB | 2 shared | Heavy processing |
+| `starter` | 2 GB | 2 shared | Simple APIs, low traffic |
+| `performance` | 4 GB | 4 shared | Most workloads |
+| `pro` | 8 GB | 4 shared | Memory-intensive apps |
 
 Set in your manifest:
 
 ```yaml runtm.yaml
-tier: standard
+tier: performance
 ```
 
 ## Deployment checklist

--- a/docs/open-source/templates/overview.mdx
+++ b/docs/open-source/templates/overview.mdx
@@ -76,10 +76,10 @@ Auth requires database to be enabled. Only available on `web-app` template.
 |----------|----------|------|---------|
 | `backend-service` | starter | 8080 | `python` |
 | `static-site` | starter | 3000 | `node` |
-| `web-app` | standard | 3000 | `fullstack` |
+| `web-app` | starter | 3000 | `fullstack` |
 | `docker` | starter | your choice | not required |
 
-The `web-app` template requires `standard` tier because it runs both Node.js and Python.
+Use `performance` or `pro` for web apps that need more CPU or memory.
 
 <Note>
 The `docker` template doesn't require a `runtime` field in `runtm.yaml` since you provide your own Dockerfile.

--- a/docs/open-source/templates/web-app.mdx
+++ b/docs/open-source/templates/web-app.mdx
@@ -24,12 +24,12 @@ Visit `http://localhost:3000` for the frontend and `http://localhost:8080/docs` 
 | Frontend | Next.js 14 (App Router) |
 | Backend | Python FastAPI |
 | Port | 3000 (frontend proxies to backend) |
-| **Minimum Tier** | **standard** (512MB required) |
+| **Minimum Tier** | **starter** |
 | Health Endpoint | `/health` |
 
-<Warning>
-  This template requires at least `standard` tier because it runs both Node.js and Python simultaneously. The `starter` tier (256MB) is insufficient.
-</Warning>
+<Note>
+  The `starter` tier works for the generated template. Use `performance` or `pro` for heavier fullstack apps.
+</Note>
 
 ## Project Structure
 
@@ -235,8 +235,7 @@ The frontend proxies `/api/*` requests to the backend.
 ## Deployment
 
 ```bash
-# Set tier to standard (required)
-# This is already set in runtm.yaml
+# The starter tier is already set in runtm.yaml
 
 # Deploy
 runtm deploy
@@ -309,7 +308,7 @@ env_schema:
     required: true
     secret: true
     description: "Session signing secret"
-  
+
   - name: DATABASE_URL
     type: url
     required: false
@@ -322,4 +321,3 @@ Set locally:
 ```bash
 runtm secrets set AUTH_SECRET=$(openssl rand -base64 32)
 ```
-

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -20,7 +20,7 @@ Creates a new deployment or redeploys an existing one (based on manifest name).
 
 **Query Parameters:**
 - `new=true` - Force creation of new deployment instead of redeploying existing
-- `tier=starter|standard|performance` - Override machine tier from manifest
+- `tier=starter|performance|pro` - Override machine tier from manifest
 
 **Request:**
 - `manifest` (file) - `runtm.yaml` manifest file
@@ -44,9 +44,9 @@ All deployments use **auto-stop** for cost savings (machines stop when idle and 
 
 | Tier | CPUs | Memory | Est. Cost |
 |------|------|--------|-----------|
-| `starter` (default) | 1 shared | 256MB | ~$2/month* |
-| `standard` | 1 shared | 512MB | ~$5/month* |
-| `performance` | 2 shared | 1GB | ~$10/month* |
+| `starter` (default) | 2 shared | 2GB | ~$15/month* |
+| `performance` | 4 shared | 4GB | ~$30/month* |
+| `pro` | 4 shared | 8GB | ~$55/month* |
 
 *Costs are estimates for 24/7 operation. With auto-stop, costs are much lower for low-traffic services.
 
@@ -78,4 +78,3 @@ pytest
 | `BUCKET_NAME` | S3/Tigris bucket name (when backend=s3) | - |
 | `AWS_ENDPOINT_URL_S3` | S3 endpoint URL (e.g. `https://fly.storage.tigris.dev`) | - |
 | `AUTH_MODE` | Auth mode: `single_tenant` or `multi_tenant` | `single_tenant` |
-

--- a/packages/api/runtm_api/core/config.py
+++ b/packages/api/runtm_api/core/config.py
@@ -155,7 +155,7 @@ class Settings(BaseSettings):
     default_deploys_per_day: int | None = None
     default_concurrent_deploys: int | None = None
 
-    # Comma-separated list of allowed machine tiers (e.g., "starter,standard")
+    # Comma-separated list of allowed machine tiers (e.g., "starter,performance")
     # None/empty = all tiers allowed
     default_allowed_tiers: str | None = None
 

--- a/packages/api/runtm_api/routes/deployments.py
+++ b/packages/api/runtm_api/routes/deployments.py
@@ -522,7 +522,7 @@ async def create_deployment(
         False, alias="new", description="Force new deployment instead of redeploying"
     ),
     tier: str | None = Query(
-        None, description="Machine tier override: starter, standard, or performance"
+        None, description="Machine tier override: starter, performance, or pro"
     ),
     config_only: bool = Query(
         False, description="Skip Docker build - reuse previous image (for env/tier changes only)"

--- a/packages/api/runtm_api/services/policy.py
+++ b/packages/api/runtm_api/services/policy.py
@@ -10,7 +10,7 @@ Usage:
     from runtm_api.services.policy import get_policy_provider
 
     provider = get_policy_provider()
-    result = provider.check_deploy(tenant_id, db, requested_tier="standard")
+    result = provider.check_deploy(tenant_id, db, requested_tier="performance")
 
     if not result.allowed:
         raise HTTPException(403, detail=result.reason)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -241,9 +241,9 @@ All deployments use **auto-stop** for cost savings (machines stop when idle and 
 
 | Tier | CPUs | Memory | Est. Cost | Use Case |
 |------|------|--------|-----------|----------|
-| **starter** (default) | 1 shared | 256MB | ~$2/month* | Simple tools, APIs |
-| **standard** | 1 shared | 512MB | ~$5/month* | Most workloads |
-| **performance** | 2 shared | 1GB | ~$10/month* | Full-stack apps |
+| **starter** (default) | 2 shared | 2GB | ~$15/month* | Simple tools, APIs |
+| **performance** | 4 shared | 4GB | ~$30/month* | Full-stack apps |
+| **pro** | 4 shared | 8GB | ~$55/month* | Memory-intensive apps |
 
 *Costs are estimates for 24/7 operation. With auto-stop, costs are much lower for low-traffic services.
 
@@ -254,8 +254,8 @@ All deployments use **auto-stop** for cost savings (machines stop when idle and 
 runtm deploy
 
 # Deploy with a specific tier
-runtm deploy --tier standard
 runtm deploy --tier performance
+runtm deploy --tier pro
 
 # Check deployment status
 runtm status dep_abc123

--- a/packages/cli/runtm_cli/api_client.py
+++ b/packages/cli/runtm_cli/api_client.py
@@ -384,7 +384,7 @@ class APIClient:
             artifact_path: Path to artifact.zip
             idempotency_key: Optional idempotency key (generated if not provided)
             force_new: Force creation of new deployment instead of redeploying
-            tier: Optional machine tier override (starter, standard, performance)
+            tier: Optional machine tier override (starter, performance, pro)
             secrets: Optional secrets to inject (passed through to provider, never stored)
             src_hash: Source hash for tracking and config-only validation
             config_only: Skip Docker build and reuse previous image (for config-only changes)

--- a/packages/cli/runtm_cli/commands/deploy.py
+++ b/packages/cli/runtm_cli/commands/deploy.py
@@ -59,9 +59,9 @@ def deploy_command(
     Use --json for NDJSON output for AI agents (one JSON object per line).
 
     Machine tiers (all use auto-stop for cost savings):
-      - starter: 1 shared CPU, 256MB RAM (~$2/month, much less with auto-stop)
-      - standard: 1 shared CPU, 512MB RAM (~$5/month, much less with auto-stop)
-      - performance: 2 shared CPUs, 1GB RAM (~$10/month, much less with auto-stop)
+      - starter: 2 shared CPUs, 2GB RAM (~$15/month, much less with auto-stop)
+      - performance: 4 shared CPUs, 4GB RAM (~$30/month, much less with auto-stop)
+      - pro: 4 shared CPUs, 8GB RAM (~$55/month, much less with auto-stop)
 
     Examples:
         runtm deploy                    # Deploy current directory

--- a/packages/cli/runtm_cli/main.py
+++ b/packages/cli/runtm_cli/main.py
@@ -232,7 +232,7 @@ def deploy(
         "--new",
         help="DANGEROUS: Create new Fly app instead of redeploying. Loses custom domains and secrets!",
     ),
-    tier: str = typer.Option(None, "--tier", help="Machine tier: starter, standard, performance"),
+    tier: str = typer.Option(None, "--tier", help="Machine tier: starter, performance, pro"),
     yes: bool = typer.Option(
         False, "--yes", "-y", help="Auto-fix lockfile issues without prompting"
     ),

--- a/packages/shared/runtm_shared/telemetry/metrics.py
+++ b/packages/shared/runtm_shared/telemetry/metrics.py
@@ -18,7 +18,7 @@ ALLOWED_METRIC_LABELS = frozenset(
         "outcome",  # success, failure, timeout
         "error_type",  # validation, auth, network, etc.
         "template",  # backend-service, static-site, web-app
-        "tier",  # starter, standard, performance
+        "tier",  # starter, performance, pro
         "runtime",  # python, node, fullstack
     }
 )

--- a/packages/shared/runtm_shared/types.py
+++ b/packages/shared/runtm_shared/types.py
@@ -320,7 +320,7 @@ class MachineConfig:
         """Create a MachineConfig from a tier specification.
 
         Args:
-            tier: Machine tier (starter, standard, performance)
+            tier: Machine tier (starter, performance, pro)
             image: Docker image to deploy
             health_check_path: Health check endpoint
             internal_port: Internal container port
@@ -468,7 +468,7 @@ def validate_tier_name(tier: str) -> str:
     """Validate and normalize a machine tier name.
 
     Args:
-        tier: Tier name to validate (e.g., "starter", "STANDARD")
+        tier: Tier name to validate (e.g., "starter", "PERFORMANCE")
 
     Returns:
         Normalized lowercase tier name

--- a/packages/worker/runtm_worker/builder/docker.py
+++ b/packages/worker/runtm_worker/builder/docker.py
@@ -176,8 +176,8 @@ class DockerBuilder:
 
         # Map memory to Fly VM size and memory strings
         # Fly.io requires explicit memory setting; size only controls CPU
-        # shared-cpu-1x: 1 shared CPU (starter 512MB)
-        # shared-cpu-2x: 2 shared CPUs (standard 2GB)
+        # shared-cpu-1x: 1 shared CPU (custom/sub-1GB memory)
+        # shared-cpu-2x: 2 shared CPUs (starter 2GB)
         # shared-cpu-4x: 4 shared CPUs (performance 4GB, pro 8GB)
         if memory_mb >= 4096:
             vm_size = "shared-cpu-4x"

--- a/templates/backend-service/runtm.yaml
+++ b/templates/backend-service/runtm.yaml
@@ -3,5 +3,4 @@ template: backend-service
 runtime: python
 health_path: /health
 port: 8080
-tier: starter  # Options: starter (cheapest), standard, performance
-
+tier: starter  # Options: starter (cheapest), performance, pro

--- a/templates/docker/AGENT.md
+++ b/templates/docker/AGENT.md
@@ -251,12 +251,12 @@ runtm deploy    # Deploy to production
 
 | Tier | Memory | CPUs | Best for |
 |------|--------|------|----------|
-| `starter` | 256 MB | 1 shared | Simple APIs, low traffic |
-| `standard` | 512 MB | 1 shared | Most workloads |
-| `performance` | 1 GB | 2 shared | Heavy processing, AI/ML |
+| `starter` | 2 GB | 2 shared | Simple APIs, low traffic |
+| `performance` | 4 GB | 4 shared | Most workloads |
+| `pro` | 8 GB | 4 shared | Memory-intensive apps |
 
 Set in `runtm.yaml`:
 
 ```yaml
-tier: standard
+tier: performance
 ```

--- a/templates/docker/CLAUDE.md
+++ b/templates/docker/CLAUDE.md
@@ -149,12 +149,12 @@ runtm deploy    # Deploy
 
 | Tier | Memory | CPUs |
 |------|--------|------|
-| `starter` | 256 MB | 1 shared |
-| `standard` | 512 MB | 1 shared |
-| `performance` | 1 GB | 2 shared |
+| `starter` | 2 GB | 2 shared |
+| `performance` | 4 GB | 4 shared |
+| `pro` | 8 GB | 4 shared |
 
 Set in `runtm.yaml`:
 
 ```yaml
-tier: standard
+tier: performance
 ```

--- a/templates/docker/README.md
+++ b/templates/docker/README.md
@@ -165,14 +165,14 @@ runtm secrets list
 
 | Tier | Memory | CPUs | Best for |
 |------|--------|------|----------|
-| `starter` | 256 MB | 1 shared | Simple APIs |
-| `standard` | 512 MB | 1 shared | Most workloads |
-| `performance` | 1 GB | 2 shared | Heavy processing |
+| `starter` | 2 GB | 2 shared | Simple APIs |
+| `performance` | 4 GB | 4 shared | Most workloads |
+| `pro` | 8 GB | 4 shared | Memory-intensive apps |
 
 Set in `runtm.yaml`:
 
 ```yaml
-tier: standard
+tier: performance
 ```
 
 ## Constraints

--- a/templates/static-site/README.md
+++ b/templates/static-site/README.md
@@ -47,7 +47,7 @@ You can set the tier in `runtm.yaml`:
 name: my-site
 template: static-site
 runtime: node
-tier: starter  # starter, standard, performance
+tier: starter  # starter, performance, pro
 ```
 
 ## Project Structure

--- a/templates/static-site/runtm.yaml
+++ b/templates/static-site/runtm.yaml
@@ -3,5 +3,4 @@ template: static-site
 runtime: node
 health_path: /health
 port: 3000
-tier: starter  # Options: starter (cheapest), standard, performance
-
+tier: starter  # Options: starter (cheapest), performance, pro

--- a/templates/web-app/AGENT.md
+++ b/templates/web-app/AGENT.md
@@ -39,7 +39,7 @@ Interactive UI + backend for real user workflows. Combines a Next.js frontend wi
 2. **DO NOT remove health endpoints** - `/health` must exist
 3. **DO NOT remove runtm.yaml** - Required for deployment
 4. **KEEP types in sync** - Pydantic models ↔ TypeScript types
-5. **MINIMUM tier: standard** - Fullstack apps need 512MB+ RAM (starter tier is rejected)
+5. **Machine tier** - `starter` is valid by default; use `performance` or `pro` for heavier workloads
 6. **ADD dependencies to PRODUCTION deps** - See "Adding Python Dependencies" below
 
 ## Project Structure
@@ -425,7 +425,7 @@ runtm deploy    # Deploy to production
 - ❌ Change frontend port from 3000
 - ❌ Change backend port from 8080
 - ❌ Remove `/health` endpoint
-- ❌ Use `tier: starter` in runtm.yaml (needs 512MB+ for both Node.js and Python)
+- ❌ Use old tier names such as `standard` in runtm.yaml
 - ❌ **Add Python imports without adding to `[project] dependencies`** (NOT dev deps!)
 - ❌ Store files locally at runtime (use `/data` volume with `features.database`)
 - ❌ Use sync blocking calls in async endpoints
@@ -611,7 +611,7 @@ import { headers } from "next/headers";
 export default async function ProfilePage() {
   const session = await getSession({ headers: headers() });
   if (!session?.user) redirect("/login");
-  
+
   return <h1>Hello, {session.user.name}</h1>;
 }
 ```

--- a/templates/web-app/CLAUDE.md
+++ b/templates/web-app/CLAUDE.md
@@ -31,7 +31,7 @@ Interactive UI + backend for real user workflows.
 2. **Health endpoint required**: `/health` must return 200
 3. **Keep types in sync**: Pydantic models ↔ TypeScript types
 4. **No database**: In-memory storage only for V0
-5. **Minimum tier: standard**: Fullstack needs 512MB+ RAM (starter tier rejected)
+5. **Machine tier**: `starter` is valid by default; use `performance` or `pro` for heavier workloads
 6. **Dependencies in `[project] dependencies`**: NOT in `dev` (see below)
 
 ## Project Structure
@@ -198,11 +198,11 @@ Then run `runtm approve` to merge into manifest.
 - ✅ Each page folder has its own `actions.ts` for data fetching
 - ✅ Reusable UI goes in `components/ui/`
 - ✅ Sync Pydantic and TypeScript types
-- ✅ Use `tier: standard` or higher in runtm.yaml
+- ✅ Use a valid tier in runtm.yaml: `starter`, `performance`, or `pro`
 - ✅ Add new imports to `[project] dependencies` in pyproject.toml
 - ❌ Don't put logic in API endpoints
 - ❌ Don't mix page-specific and reusable components
-- ❌ Don't use `tier: starter` (256MB is not enough for Node.js + Python)
+- ❌ Don't use old tier names such as `standard` in runtm.yaml
 - ❌ Don't add production deps to `[project.optional-dependencies] dev`
 - ❌ Don't scale SQLite to multiple machines (use Postgres instead)
 

--- a/templates/web-app/README.md
+++ b/templates/web-app/README.md
@@ -255,7 +255,7 @@ runtm deploy
 
 ### Resource Requirements
 
-Fullstack apps run both Next.js and FastAPI simultaneously, requiring at least the standard tier (512MB RAM). The `runtm.yaml` is pre-configured with `tier: standard`.
+The generated template uses the `starter` tier by default. Use `performance` or `pro` for fullstack apps that need more CPU or memory.
 
 ## Customization
 

--- a/templates/web-app/runtm.yaml
+++ b/templates/web-app/runtm.yaml
@@ -3,5 +3,4 @@ template: web-app
 runtime: fullstack
 health_path: /health
 port: 3000
-tier: standard  # Fullstack apps need 512MB+ RAM for Node.js + Python
-
+tier: starter  # Options: starter, performance, pro


### PR DESCRIPTION
## Summary
- align OSS deployment tier docs and examples with the current `MachineTier` enum: `starter`, `performance`, `pro`
- update generated template manifests and agent instructions so new projects no longer copy the removed `standard` tier
- refresh CLI/API help text, comments, and policy notes that still advertised stale tier names/specs

## Why
The current manifest validator rejects `standard` and accepts only `starter`, `performance`, and `pro`. Several OSS docs and templates still referenced `standard`, which can lead users or agents to generate a `runtm.yaml` that fails validation.

## Validation
- `.venv/bin/pytest packages/shared/tests/test_types_volume.py packages/shared/tests/test_policy_types.py packages/shared/tests/test_manifest.py -q`
- `.venv/bin/pytest packages/cli/tests/test_validate.py packages/cli/tests/test_template.py -q`
- `.venv/bin/ruff check . && .venv/bin/ruff format --check .`
- `git diff --check`
- verified backend-service/static-site/web-app/docker template manifests parse with supported tiers
- targeted `rg` check for stale OSS `standard` tier examples
