### PR TITLE
fix(agent): skills install creates the agent skills dir instead of failing

### DIFF
--- a/packages/agent/internal/cmd/skills_cmd.go
+++ b/packages/agent/internal/cmd/skills_cmd.go
@@ -56,12 +56,19 @@ Pass --target to override the destination directory.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			targets := resolveSkillTargets(target)
 			if len(targets) == 0 {
-				rt.WriteObject(map[string]any{
-					"installed": false,
-					"error":     "No AI agent skills directory found (~/.claude or ~/.cursor).",
-					"hint":      "Pass --target <dir> to install manually, or create ~/.claude/skills/ first.",
-				})
-				return errSilent
+				// No agent config dir detected. `skills install` is an explicit
+				// setup command, so don't bail — default to Claude Code's location
+				// and create it (the install loop's MkdirAll does the `mkdir -p`).
+				home, err := os.UserHomeDir()
+				if err != nil {
+					rt.WriteObject(map[string]any{
+						"installed": false,
+						"error":     "Could not resolve home directory.",
+						"hint":      "Pass --target <dir> to install manually.",
+					})
+					return errSilent
+				}
+				targets = []string{filepath.Join(home, ".claude/skills/runtm")}
 			}
 
 			files, err := listEmbeddedSkills()
@@ -155,15 +162,18 @@ func resolveSkillTargets(override string) []string {
 		return nil
 	}
 
+	// Detect each agent by its ROOT config dir (~/.claude, ~/.cursor) — if the
+	// agent is present, install into <root>/skills/runtm (created on demand by
+	// MkdirAll at install time). Checking for <root>/skills to pre-exist was too
+	// strict: a fresh agent has ~/.claude (settings.json/CLAUDE.md) but no
+	// skills/ subdir yet, so `skills install` wrongly reported "no agent found".
 	var targets []string
-	for _, rel := range []string{
-		".claude/skills/runtm",
-		".cursor/skills/runtm",
+	for _, a := range []struct{ root, target string }{
+		{".claude", ".claude/skills/runtm"},
+		{".cursor", ".cursor/skills/runtm"},
 	} {
-		dir := filepath.Join(home, rel)
-		parent := filepath.Dir(dir)
-		if info, err := os.Stat(parent); err == nil && info.IsDir() {
-			targets = append(targets, dir)
+		if info, err := os.Stat(filepath.Join(home, a.root)); err == nil && info.IsDir() {
+			targets = append(targets, filepath.Join(home, a.target))
 		}
 	}
 	return targets

--- a/packages/agent/internal/cmd/skills_resolve_targets_test.go
+++ b/packages/agent/internal/cmd/skills_resolve_targets_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// resolveSkillTargets must detect an agent by its ROOT config dir (~/.claude),
+// even when the skills/ subdir does not exist yet — MkdirAll creates it at
+// install time. Regression: it previously required ~/.claude/skills to pre-exist,
+// so `skills install` failed on a fresh agent that only had ~/.claude.
+func TestResolveSkillTargetsDetectsAgentRootWithoutSkillsDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Agent present (settings/CLAUDE.md) but NO skills/ subdir.
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveSkillTargets("")
+	want := filepath.Join(home, ".claude/skills/runtm")
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("expected [%s], got %v", want, got)
+	}
+}
+
+func TestResolveSkillTargetsEmptyWhenNoAgent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if got := resolveSkillTargets(""); len(got) != 0 {
+		t.Fatalf("expected no targets, got %v", got)
+	}
+}
+
+func TestResolveSkillTargetsOverride(t *testing.T) {
+	if got := resolveSkillTargets("/tmp/custom"); len(got) != 1 || got[0] != "/tmp/custom" {
+		t.Fatalf("override not honored, got %v", got)
+	}
+}


### PR DESCRIPTION
## Problem

`runtm-api skills install` reported:

```
{
  "error": "No AI agent skills directory found (~/.claude or ~/.cursor).",
  "hint": "Pass --target <dir> to install manually, or create ~/.claude/skills/ first.",
  "installed": false
}
```

…even when `~/.claude` exists. The detection (`resolveSkillTargets`) stat'd the **`~/.claude/skills`** subdir — the *parent of the runtm target* — instead of the agent **root** (`~/.claude`). A fresh agent has `~/.claude` (`settings.json` / `CLAUDE.md`) but **no `skills/` subdir yet**, so install wrongly bailed. Hit in Runtm Cloud GKE sandbox sessions.

## Fix

- **`resolveSkillTargets`**: detect each agent by its **root** config dir (`~/.claude`, `~/.cursor`). `os.MkdirAll` already creates `skills/runtm` at install time, so the pre-existing-`skills/` requirement was unnecessary and wrong.
- **`skills install`**: if **no** agent dir is detected at all, default to `~/.claude/skills/runtm` and create it (`mkdir -p`) instead of erroring — an explicit install command should set things up.

Net: `skills install` now always creates the dir and succeeds.

## Verification

Built the binary and ran it against temp homes:

| Case | Result |
|------|--------|
| Empty `HOME` (no `~/.claude`) | creates `~/.claude/skills/runtm`, installs 6 files ✅ |
| `~/.claude` exists, no `skills/` (reported bug) | creates `~/.claude/skills/runtm`, installs ✅ |

Added tests (`skills_resolve_targets_test.go`): root-dir detection without a pre-existing `skills/`, no-agent → empty, and `--target` override. `go test ./internal/cmd/` + `go vet` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)