### PR TITLE
feat(cli): add dev-environment checks to `doctor` + harden setup (#4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@ Open-source sandboxes where coding agents build and deploy. Spin up isolated env
 
 ```bash
 # Setup
-./scripts/dev.sh setup              # Install all packages in dev mode
+./scripts/dev.sh setup              # Install all packages in dev mode (creates .env if missing)
+./scripts/dev.sh doctor             # Verify setup (Python, .env, Docker, services)
 cp infra/local.env.example .env     # Configure environment (add FLY_API_TOKEN)
 
 # Development CLI (use runtm-dev, not runtm)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ These files are automatically loaded by Cursor and provide essential context for
 
 ### Prerequisites
 
-- Python 3.9+
+- Python 3.11+ (the `api` and `worker` packages require >= 3.11)
 - Docker & Docker Compose
 - Git
 - Fly.io account + API token (for deployment testing)
@@ -81,6 +81,16 @@ These files are automatically loaded by Cursor and provide essential context for
    pip install pre-commit
    pre-commit install
    ```
+
+6. Verify your setup:
+   ```bash
+   ./scripts/dev.sh doctor
+   ```
+
+   The doctor checks your Python version, `.env` configuration,
+   `FLY_API_TOKEN`, Docker, sandbox dependencies, and whether local
+   services are healthy — with a hint for fixing anything that fails.
+   Use `runtm-dev doctor --json` for machine-readable output.
 
 ### Development CLI (`runtm-dev`)
 

--- a/packages/cli/runtm_cli/commands/__init__.py
+++ b/packages/cli/runtm_cli/commands/__init__.py
@@ -3,6 +3,7 @@
 from runtm_cli.commands.approve import approve_command
 from runtm_cli.commands.deploy import deploy_command
 from runtm_cli.commands.destroy import destroy_command
+from runtm_cli.commands.doctor import doctor_command
 from runtm_cli.commands.domain import (
     domain_add_command,
     domain_remove_command,
@@ -34,6 +35,7 @@ __all__ = [
     "approve_command",
     "deploy_command",
     "destroy_command",
+    "doctor_command",
     "domain_add_command",
     "domain_remove_command",
     "domain_status_command",

--- a/packages/cli/runtm_cli/commands/doctor.py
+++ b/packages/cli/runtm_cli/commands/doctor.py
@@ -1,0 +1,496 @@
+"""Doctor command - diagnose CLI setup and the local development environment.
+
+Runs three groups of checks:
+
+1. CLI          - version, API URL, auth storage/status, API connectivity.
+2. Local sandbox - sandbox dependencies (bun, sandbox-runtime, Claude CLI,
+                   bubblewrap). Only shown when the sandbox extras are
+                   installed (``runtm-dev`` or ``pip install runtm[sandbox]``).
+3. Dev environment - monorepo contributor checks (Python version, .env,
+                   FLY_API_TOKEN, Docker, local services). Only shown when
+                   run from inside the runtm repository.
+
+Exit code is 0 when no check fails, 1 otherwise, so it can gate scripts:
+
+    runtm doctor && runtm deploy
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import platform
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+console = Console()
+
+# Check statuses
+OK = "ok"
+WARN = "warn"
+FAIL = "fail"
+INFO = "info"
+
+# api/worker packages require >= 3.11, so local development does too
+DEV_MIN_PYTHON = (3, 11)
+
+# Placeholder values from infra/local.env.example that must be replaced
+ENV_PLACEHOLDER_VALUES = {
+    "your-fly-personal-access-token-here",
+    "your-cloudflare-api-token-here",
+    "your-zone-id-here",
+}
+
+LOCAL_API_URL = "http://localhost:8000"
+
+
+@dataclass
+class CheckResult:
+    """Outcome of a single doctor check."""
+
+    section: str
+    name: str
+    status: str  # ok | warn | fail | info
+    message: str
+    hint: str | None = None
+
+
+def _find_repo_root(start: Path) -> Path | None:
+    """Walk up from `start` looking for the runtm monorepo root.
+
+    The root is identified by the presence of both `scripts/dev.sh`
+    and `infra/docker-compose.yml`.
+
+    Args:
+        start: Directory to start searching from.
+
+    Returns:
+        The repo root path, or None if not inside the monorepo.
+    """
+    for candidate in [start, *start.parents]:
+        if (candidate / "scripts" / "dev.sh").is_file() and (
+            candidate / "infra" / "docker-compose.yml"
+        ).is_file():
+            return candidate
+    return None
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    """Parse a .env file into a dict (comments and blank lines ignored).
+
+    Args:
+        path: Path to the .env file.
+
+    Returns:
+        Mapping of KEY -> value with surrounding quotes stripped.
+    """
+    values: dict[str, str] = {}
+    try:
+        content = path.read_text()
+    except OSError:
+        return values
+
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip("'\"")
+        if key:
+            values[key] = value
+    return values
+
+
+def _sandbox_extras_installed() -> bool:
+    """Check if the sandbox extras (runtm-sandbox + runtm-agents) are installed."""
+    return (
+        importlib.util.find_spec("runtm_sandbox") is not None
+        and importlib.util.find_spec("runtm_agents") is not None
+    )
+
+
+def _docker_daemon_running() -> bool:
+    """Check if the Docker daemon responds (docker CLI must be present)."""
+    try:
+        result = subprocess.run(
+            ["docker", "info", "--format", "{{.ServerVersion}}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _check_cli() -> list[CheckResult]:
+    """Core CLI checks: API URL, auth storage, auth status, connectivity."""
+    import httpx
+
+    from runtm_cli.auth import (
+        check_credentials_permissions,
+        get_keyring_key,
+        get_token,
+        get_token_source,
+    )
+    from runtm_cli.config import get_api_url
+
+    section = "cli"
+    results: list[CheckResult] = []
+
+    api_url = get_api_url()
+    results.append(CheckResult(section, "API URL", INFO, api_url))
+
+    # Auth storage source
+    source = get_token_source()
+    if source == "env":
+        results.append(CheckResult(section, "Auth storage", OK, "env (RUNTM_API_KEY)"))
+    elif source == "keychain":
+        results.append(CheckResult(section, "Auth storage", OK, f"keychain ({get_keyring_key()})"))
+    elif source == "file":
+        results.append(CheckResult(section, "Auth storage", OK, "file (~/.runtm/credentials)"))
+    else:
+        results.append(
+            CheckResult(
+                section,
+                "Auth storage",
+                WARN,
+                "no credentials configured",
+                hint="Run `runtm login` (or set RUNTM_API_KEY for self-hosted setups)",
+            )
+        )
+
+    # Auth status - validate token via /v1/me if we have one
+    token = get_token()
+    if token:
+        try:
+            response = httpx.get(
+                f"{api_url}/v1/me",
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=5.0,
+            )
+            if response.status_code == 200:
+                email = response.json().get("email", "unknown")
+                results.append(CheckResult(section, "Auth status", OK, f"authenticated as {email}"))
+            elif response.status_code == 401:
+                results.append(
+                    CheckResult(
+                        section,
+                        "Auth status",
+                        FAIL,
+                        "token invalid or expired",
+                        hint="Run `runtm login` to authenticate again",
+                    )
+                )
+            elif response.status_code == 404:
+                # /v1/me not available (older self-hosted API) - token presence is all we know
+                results.append(CheckResult(section, "Auth status", OK, "token configured"))
+            else:
+                results.append(
+                    CheckResult(
+                        section,
+                        "Auth status",
+                        WARN,
+                        f"could not verify (HTTP {response.status_code})",
+                    )
+                )
+        except httpx.TimeoutException:
+            results.append(CheckResult(section, "Auth status", WARN, "verification timed out"))
+        except Exception as e:
+            results.append(CheckResult(section, "Auth status", WARN, f"could not verify: {e}"))
+    else:
+        results.append(
+            CheckResult(
+                section,
+                "Auth status",
+                FAIL,
+                "not authenticated",
+                hint="Run `runtm login` to authenticate",
+            )
+        )
+
+    # Credentials file permissions (only relevant for file storage)
+    if source == "file":
+        perm_ok, perm_msg = check_credentials_permissions()
+        results.append(CheckResult(section, "Credentials", OK if perm_ok else WARN, perm_msg))
+
+    # Connectivity check (unauthenticated ping)
+    try:
+        start = time.time()
+        response = httpx.get(f"{api_url}/health", timeout=5.0)
+        latency_ms = int((time.time() - start) * 1000)
+        if response.status_code == 200:
+            results.append(
+                CheckResult(section, "Connectivity", OK, f"API reachable ({latency_ms}ms)")
+            )
+        else:
+            results.append(
+                CheckResult(
+                    section, "Connectivity", WARN, f"API returned HTTP {response.status_code}"
+                )
+            )
+    except httpx.TimeoutException:
+        results.append(
+            CheckResult(
+                section,
+                "Connectivity",
+                FAIL,
+                "API request timed out",
+                hint="Check your network, or `runtm config get api_url`",
+            )
+        )
+    except Exception:
+        hint = (
+            "Run `./scripts/dev.sh up` to start local services"
+            if LOCAL_API_URL in api_url
+            else "Check your network, or `runtm config get api_url`"
+        )
+        results.append(
+            CheckResult(section, "Connectivity", FAIL, "could not connect to API", hint=hint)
+        )
+
+    return results
+
+
+def _check_sandbox() -> list[CheckResult]:
+    """Local sandbox dependency checks (bun, srt, claude, bwrap)."""
+    from runtm_sandbox.deps import check_bun, check_bwrap, check_claude, check_srt
+
+    section = "sandbox"
+    results: list[CheckResult] = []
+    setup_hint = "Run `./scripts/dev.sh setup` (auto-installed on first `runtm start` too)"
+
+    if check_bun():
+        runtime = "bun" if shutil.which("bun") else "node"
+        results.append(CheckResult(section, "JS runtime", OK, f"{runtime} found"))
+    else:
+        results.append(
+            CheckResult(section, "JS runtime", WARN, "bun/node not found", hint=setup_hint)
+        )
+
+    if check_srt():
+        results.append(CheckResult(section, "sandbox-runtime", OK, "srt found"))
+    else:
+        results.append(
+            CheckResult(section, "sandbox-runtime", WARN, "srt not found", hint=setup_hint)
+        )
+
+    if check_claude():
+        results.append(CheckResult(section, "Claude Code CLI", OK, "claude found"))
+    else:
+        results.append(
+            CheckResult(section, "Claude Code CLI", WARN, "claude not found", hint=setup_hint)
+        )
+
+    if platform.system() == "Linux":
+        if check_bwrap():
+            results.append(CheckResult(section, "bubblewrap", OK, "bwrap found"))
+        else:
+            results.append(
+                CheckResult(
+                    section,
+                    "bubblewrap",
+                    WARN,
+                    "bwrap not found (required for sandbox isolation on Linux)",
+                    hint="Install with your package manager, e.g. `sudo apt install bubblewrap`",
+                )
+            )
+
+    return results
+
+
+def _check_dev_env(repo_root: Path) -> list[CheckResult]:
+    """Monorepo contributor checks: Python, .env, Docker, local services."""
+    import httpx
+
+    section = "dev"
+    results: list[CheckResult] = []
+
+    # Python version (api/worker packages require >= 3.11)
+    py_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    min_version = ".".join(str(p) for p in DEV_MIN_PYTHON)
+    if sys.version_info >= DEV_MIN_PYTHON:
+        results.append(CheckResult(section, "Python", OK, py_version))
+    else:
+        results.append(
+            CheckResult(
+                section,
+                "Python",
+                FAIL,
+                f"{py_version} (>= {min_version} required for api/worker packages)",
+                hint=f"Recreate the venv with Python {min_version}+ and re-run `./scripts/dev.sh setup`",
+            )
+        )
+
+    # .env file + FLY_API_TOKEN
+    env_file = repo_root / ".env"
+    if env_file.is_file():
+        results.append(CheckResult(section, ".env", OK, "found"))
+        env_values = _parse_env_file(env_file)
+        fly_token = env_values.get("FLY_API_TOKEN", "")
+        if not fly_token or fly_token in ENV_PLACEHOLDER_VALUES:
+            results.append(
+                CheckResult(
+                    section,
+                    "FLY_API_TOKEN",
+                    WARN,
+                    "not set (deploys will fail)",
+                    hint="Run `fly auth token` and set FLY_API_TOKEN in .env",
+                )
+            )
+        else:
+            results.append(CheckResult(section, "FLY_API_TOKEN", OK, "set"))
+    else:
+        results.append(
+            CheckResult(
+                section,
+                ".env",
+                WARN,
+                "not found (required for local services)",
+                hint="Run `cp infra/local.env.example .env` and add your FLY_API_TOKEN",
+            )
+        )
+
+    # Docker CLI + daemon
+    if shutil.which("docker"):
+        if _docker_daemon_running():
+            results.append(CheckResult(section, "Docker", OK, "daemon running"))
+        else:
+            results.append(
+                CheckResult(
+                    section,
+                    "Docker",
+                    WARN,
+                    "CLI found but daemon not responding",
+                    hint="Start Docker Desktop (or the docker service) to run local services",
+                )
+            )
+    else:
+        results.append(
+            CheckResult(
+                section,
+                "Docker",
+                WARN,
+                "not found (required for local services)",
+                hint="Install Docker: https://docs.docker.com/get-docker/",
+            )
+        )
+
+    # Local API health (only meaningful if services are expected to run)
+    try:
+        response = httpx.get(f"{LOCAL_API_URL}/health", timeout=3.0)
+        if response.status_code == 200:
+            results.append(
+                CheckResult(section, "Local services", OK, f"API healthy at {LOCAL_API_URL}")
+            )
+        else:
+            results.append(
+                CheckResult(
+                    section,
+                    "Local services",
+                    WARN,
+                    f"API returned HTTP {response.status_code}",
+                    hint="Check `./scripts/dev.sh logs api`",
+                )
+            )
+    except Exception:
+        results.append(
+            CheckResult(
+                section,
+                "Local services",
+                WARN,
+                f"API not reachable at {LOCAL_API_URL}",
+                hint="Run `./scripts/dev.sh up` to start API + worker + DB + Redis",
+            )
+        )
+
+    return results
+
+
+_SECTION_TITLES = {
+    "cli": "CLI",
+    "sandbox": "Local sandbox",
+    "dev": "Dev environment",
+}
+
+_STATUS_ICONS = {
+    OK: "[green]✓[/green]",
+    WARN: "[yellow]⚠[/yellow]",
+    FAIL: "[red]✗[/red]",
+    INFO: "[dim]·[/dim]",
+}
+
+
+def _render_human(version: str, results: list[CheckResult]) -> None:
+    """Render check results grouped by section."""
+    console.print()
+    console.print(f"[bold]runtm[/bold] v{version}")
+
+    for section_key, title in _SECTION_TITLES.items():
+        section_results = [r for r in results if r.section == section_key]
+        if not section_results:
+            continue
+        console.print()
+        console.print(f"[bold]{title}[/bold]")
+        width = max(len(r.name) for r in section_results)
+        for r in section_results:
+            icon = _STATUS_ICONS.get(r.status, " ")
+            console.print(f"  {icon} {r.name.ljust(width)}  {r.message}")
+            if r.hint and r.status in (WARN, FAIL):
+                console.print(f"    [dim]↳ {r.hint}[/dim]")
+
+    failures = [r for r in results if r.status == FAIL]
+    warnings = [r for r in results if r.status == WARN]
+    console.print()
+    if failures:
+        console.print(f"[red]✗ {len(failures)} problem(s) found[/red]")
+    elif warnings:
+        console.print(f"[yellow]⚠ Setup OK with {len(warnings)} warning(s)[/yellow]")
+    else:
+        console.print("[green]✓ All checks passed[/green]")
+    console.print()
+
+
+def doctor_command(json_output: bool = False) -> None:
+    """Run all applicable doctor checks and report results.
+
+    Args:
+        json_output: Emit results as a single JSON object for AI agents.
+
+    Raises:
+        typer.Exit: Exit code 1 if any check fails.
+    """
+    from runtm_cli import __version__
+
+    results = _check_cli()
+
+    if _sandbox_extras_installed():
+        results.extend(_check_sandbox())
+
+    repo_root = _find_repo_root(Path.cwd())
+    if repo_root is not None:
+        results.extend(_check_dev_env(repo_root))
+
+    ok = not any(r.status == FAIL for r in results)
+
+    if json_output:
+        payload = {
+            "version": __version__,
+            "ok": ok,
+            "checks": [asdict(r) for r in results],
+        }
+        # Plain print: JSON must be parseable, not wrapped by rich
+        print(json.dumps(payload, indent=2))
+    else:
+        _render_human(__version__, results)
+
+    if not ok:
+        raise typer.Exit(1)

--- a/packages/cli/runtm_cli/main.py
+++ b/packages/cli/runtm_cli/main.py
@@ -66,6 +66,7 @@ from runtm_cli.commands import (
     approve_command,
     deploy_command,
     destroy_command,
+    doctor_command,
     domain_add_command,
     domain_remove_command,
     domain_status_command,
@@ -795,116 +796,24 @@ def config_reset(
 
 
 @app.command("doctor")
-def doctor() -> None:
+def doctor(
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON for AI agents"),
+) -> None:
     """Check CLI setup and diagnose issues.
 
-    Displays version, configuration, authentication status,
-    and API connectivity. Useful for troubleshooting.
+    Displays version, configuration, authentication status, and API
+    connectivity. When the sandbox extras are installed (runtm-dev),
+    also checks sandbox dependencies. When run from inside the runtm
+    repository, also validates the local dev environment (Python
+    version, .env, FLY_API_TOKEN, Docker, local services).
 
-    Example:
-        runtm doctor
+    Exits with code 1 if any check fails, so it can gate scripts.
+
+    Examples:
+        runtm doctor           # Human-readable report
+        runtm doctor --json    # Machine-readable report for agents
     """
-    import time
-
-    import httpx
-
-    from runtm_cli import __version__
-    from runtm_cli.auth import (
-        check_credentials_permissions,
-        get_keyring_key,
-        get_token,
-        get_token_source,
-    )
-    from runtm_cli.config import get_api_url
-
-    console.print()
-    console.print(f"[bold]runtm[/bold] v{__version__}")
-    console.print()
-
-    # API URL
-    api_url = get_api_url()
-    console.print(f"  API URL:      {api_url}")
-
-    # Auth storage source
-    source = get_token_source()
-    if source == "env":
-        console.print("  Auth storage: env (RUNTM_API_KEY)")
-    elif source == "keychain":
-        key = get_keyring_key()
-        console.print(f"  Auth storage: keychain ({key})")
-    elif source == "file":
-        console.print("  Auth storage: file (~/.runtm/credentials)")
-    else:
-        console.print("  Auth storage: [yellow]none[/yellow]")
-
-    # Auth status - try to validate token via /v1/me if we have one
-    token = get_token()
-    if token:
-        try:
-            start = time.time()
-            response = httpx.get(
-                f"{api_url}/v1/me",
-                headers={"Authorization": f"Bearer {token}"},
-                timeout=5.0,
-            )
-            latency_ms = int((time.time() - start) * 1000)
-
-            if response.status_code == 200:
-                data = response.json()
-                email = data.get("email", "unknown")
-                console.print(f"  Auth status:  [green]✓[/green] Authenticated as {email}")
-            elif response.status_code == 401:
-                console.print("  Auth status:  [red]✗[/red] Token invalid or expired")
-            elif response.status_code == 404:
-                # /v1/me endpoint doesn't exist yet, fall back to showing token is configured
-                console.print("  Auth status:  [green]✓[/green] Token configured")
-            else:
-                console.print(
-                    f"  Auth status:  [yellow]?[/yellow] Could not verify (HTTP {response.status_code})"
-                )
-        except httpx.TimeoutException:
-            console.print("  Auth status:  [yellow]?[/yellow] Verification timed out")
-        except Exception as e:
-            console.print(f"  Auth status:  [yellow]?[/yellow] Could not verify: {e}")
-    else:
-        console.print("  Auth status:  [red]✗[/red] Not authenticated")
-
-    # Credentials file permissions (only if using file storage)
-    if source == "file":
-        perm_ok, perm_msg = check_credentials_permissions()
-        if perm_ok:
-            console.print(f"  Credentials:  [green]✓[/green] {perm_msg}")
-        else:
-            console.print(f"  Credentials:  {perm_msg}")
-
-    # Connectivity check (unauthenticated ping)
-    try:
-        start = time.time()
-        response = httpx.get(f"{api_url}/health", timeout=5.0)
-        latency_ms = int((time.time() - start) * 1000)
-
-        if response.status_code == 200:
-            console.print(f"  Connectivity: [green]✓[/green] API reachable ({latency_ms}ms)")
-        else:
-            console.print(
-                f"  Connectivity: [yellow]?[/yellow] API returned HTTP {response.status_code}"
-            )
-    except httpx.TimeoutException:
-        console.print("  Connectivity: [red]✗[/red] API request timed out")
-    except httpx.ConnectError:
-        console.print("  Connectivity: [red]✗[/red] Could not connect to API")
-    except Exception as e:
-        console.print(f"  Connectivity: [red]✗[/red] {e}")
-
-    console.print()
-
-    # Suggested next step
-    if not token:
-        console.print("  Get started: [cyan]runtm login[/cyan]")
-    else:
-        console.print("  Ready to deploy! Run: [cyan]runtm init backend-service[/cyan]")
-
-    console.print()
+    doctor_command(json_output=json_output)
 
 
 @app.command("login")

--- a/packages/cli/tests/test_doctor.py
+++ b/packages/cli/tests/test_doctor.py
@@ -1,0 +1,277 @@
+"""Tests for the doctor command."""
+
+import json
+from collections import namedtuple
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import typer
+
+from runtm_cli.commands.doctor import (
+    FAIL,
+    OK,
+    WARN,
+    CheckResult,
+    _check_cli,
+    _check_dev_env,
+    _find_repo_root,
+    _parse_env_file,
+    doctor_command,
+)
+
+_VersionInfo = namedtuple("_VersionInfo", ["major", "minor", "micro"])
+
+
+def _results_by_name(results: list) -> dict:
+    return {r.name: r for r in results}
+
+
+# ---------------------------------------------------------------------------
+# _parse_env_file
+# ---------------------------------------------------------------------------
+
+
+def test_parse_env_file(tmp_path: Path):
+    """Comments, blank lines, and quotes should be handled."""
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "# a comment\n"
+        "\n"
+        "FLY_API_TOKEN=abc123\n"
+        'QUOTED="hello world"\n'
+        "SINGLE='quoted'\n"
+        "not-a-valid-line\n"
+        "EMPTY=\n"
+    )
+
+    values = _parse_env_file(env_file)
+
+    assert values["FLY_API_TOKEN"] == "abc123"
+    assert values["QUOTED"] == "hello world"
+    assert values["SINGLE"] == "quoted"
+    assert values["EMPTY"] == ""
+    assert "not-a-valid-line" not in values
+
+
+def test_parse_env_file_missing(tmp_path: Path):
+    """A missing file should return an empty dict, not raise."""
+    assert _parse_env_file(tmp_path / "nonexistent") == {}
+
+
+# ---------------------------------------------------------------------------
+# _find_repo_root
+# ---------------------------------------------------------------------------
+
+
+def _make_repo_root(tmp_path: Path) -> Path:
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "dev.sh").write_text("#!/bin/bash\n")
+    (tmp_path / "infra").mkdir()
+    (tmp_path / "infra" / "docker-compose.yml").write_text("services: {}\n")
+    return tmp_path
+
+
+def test_find_repo_root_from_nested_dir(tmp_path: Path):
+    """The root should be found from a nested subdirectory."""
+    root = _make_repo_root(tmp_path)
+    nested = root / "packages" / "cli"
+    nested.mkdir(parents=True)
+
+    assert _find_repo_root(nested) == root
+
+
+def test_find_repo_root_outside_repo(tmp_path: Path):
+    """Directories without the repo markers should return None."""
+    assert _find_repo_root(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# _check_dev_env
+# ---------------------------------------------------------------------------
+
+
+def _run_dev_env_checks(repo_root: Path, **overrides):
+    """Run _check_dev_env with external calls stubbed out."""
+    defaults = {
+        "version_info": _VersionInfo(3, 12, 0),
+        "docker_path": "/usr/bin/docker",
+        "daemon_running": True,
+        "api_up": True,
+    }
+    defaults.update(overrides)
+
+    class FakeResponse:
+        status_code = 200
+
+    def fake_httpx_get(*args, **kwargs):
+        if not defaults["api_up"]:
+            raise ConnectionError("down")
+        return FakeResponse()
+
+    with patch("runtm_cli.commands.doctor.sys") as mock_sys:
+        with patch("runtm_cli.commands.doctor.shutil.which", return_value=defaults["docker_path"]):
+            with patch(
+                "runtm_cli.commands.doctor._docker_daemon_running",
+                return_value=defaults["daemon_running"],
+            ):
+                with patch("httpx.get", side_effect=fake_httpx_get):
+                    mock_sys.version_info = defaults["version_info"]
+                    return _check_dev_env(repo_root)
+
+
+def test_dev_env_all_healthy(tmp_path: Path):
+    """A fully configured dev environment should report all OK."""
+    root = _make_repo_root(tmp_path)
+    (root / ".env").write_text("FLY_API_TOKEN=fly_real_token\n")
+
+    checks = _results_by_name(_run_dev_env_checks(root))
+
+    assert checks["Python"].status == OK
+    assert checks[".env"].status == OK
+    assert checks["FLY_API_TOKEN"].status == OK
+    assert checks["Docker"].status == OK
+    assert checks["Local services"].status == OK
+
+
+def test_dev_env_old_python_fails(tmp_path: Path):
+    """Python below 3.11 should be a hard failure (api/worker need it)."""
+    root = _make_repo_root(tmp_path)
+    (root / ".env").write_text("FLY_API_TOKEN=fly_real_token\n")
+
+    checks = _results_by_name(_run_dev_env_checks(root, version_info=_VersionInfo(3, 9, 6)))
+
+    assert checks["Python"].status == FAIL
+    assert "3.11" in checks["Python"].message
+
+
+def test_dev_env_missing_env_file_warns(tmp_path: Path):
+    """A missing .env should warn and point at the example file."""
+    root = _make_repo_root(tmp_path)
+
+    checks = _results_by_name(_run_dev_env_checks(root))
+
+    assert checks[".env"].status == WARN
+    assert "local.env.example" in checks[".env"].hint
+    # FLY_API_TOKEN check only runs when .env exists
+    assert "FLY_API_TOKEN" not in checks
+
+
+def test_dev_env_placeholder_fly_token_warns(tmp_path: Path):
+    """The example file's placeholder token should not count as configured."""
+    root = _make_repo_root(tmp_path)
+    (root / ".env").write_text("FLY_API_TOKEN=your-fly-personal-access-token-here\n")
+
+    checks = _results_by_name(_run_dev_env_checks(root))
+
+    assert checks["FLY_API_TOKEN"].status == WARN
+    assert "fly auth token" in checks["FLY_API_TOKEN"].hint
+
+
+def test_dev_env_docker_and_services_down(tmp_path: Path):
+    """Docker missing and API down should warn with recovery hints."""
+    root = _make_repo_root(tmp_path)
+    (root / ".env").write_text("FLY_API_TOKEN=fly_real_token\n")
+
+    checks = _results_by_name(_run_dev_env_checks(root, docker_path=None, api_up=False))
+
+    assert checks["Docker"].status == WARN
+    assert checks["Local services"].status == WARN
+    assert "dev.sh up" in checks["Local services"].hint
+
+
+# ---------------------------------------------------------------------------
+# _check_cli
+# ---------------------------------------------------------------------------
+
+
+def test_check_cli_not_authenticated():
+    """Missing credentials should fail the auth check with a login hint."""
+
+    class FakeResponse:
+        status_code = 200
+
+    with patch("runtm_cli.auth.get_token", return_value=None):
+        with patch("runtm_cli.auth.get_token_source", return_value="none"):
+            with patch("runtm_cli.config.get_api_url", return_value="https://api.example.com"):
+                with patch("httpx.get", return_value=FakeResponse()):
+                    checks = _results_by_name(_check_cli())
+
+    assert checks["Auth storage"].status == WARN
+    assert checks["Auth status"].status == FAIL
+    assert "runtm login" in checks["Auth status"].hint
+    assert checks["Connectivity"].status == OK
+
+
+def test_check_cli_authenticated():
+    """A valid token should report the authenticated email."""
+
+    class FakeResponse:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"email": "dev@example.com"}
+
+    with patch("runtm_cli.auth.get_token", return_value="runtm_token"):
+        with patch("runtm_cli.auth.get_token_source", return_value="env"):
+            with patch("runtm_cli.config.get_api_url", return_value="https://api.example.com"):
+                with patch("httpx.get", return_value=FakeResponse()):
+                    checks = _results_by_name(_check_cli())
+
+    assert checks["Auth storage"].status == OK
+    assert checks["Auth status"].status == OK
+    assert "dev@example.com" in checks["Auth status"].message
+
+
+# ---------------------------------------------------------------------------
+# doctor_command
+# ---------------------------------------------------------------------------
+
+
+def _patched_doctor(results: list, json_output: bool):
+    with patch("runtm_cli.commands.doctor._check_cli", return_value=results):
+        with patch("runtm_cli.commands.doctor._sandbox_extras_installed", return_value=False):
+            with patch("runtm_cli.commands.doctor._find_repo_root", return_value=None):
+                doctor_command(json_output=json_output)
+
+
+def test_doctor_json_output(capsys):
+    """--json should emit a parseable payload with all checks."""
+    results = [
+        CheckResult("cli", "Auth status", OK, "authenticated as dev@example.com"),
+        CheckResult("cli", "Connectivity", OK, "API reachable (10ms)"),
+    ]
+
+    _patched_doctor(results, json_output=True)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert len(payload["checks"]) == 2
+    assert payload["checks"][0]["name"] == "Auth status"
+    assert payload["checks"][0]["status"] == OK
+
+
+def test_doctor_exits_nonzero_on_failure():
+    """Any failing check should produce exit code 1 for scriptability."""
+    results = [
+        CheckResult("cli", "Auth status", FAIL, "not authenticated", hint="Run `runtm login`")
+    ]
+
+    with pytest.raises(typer.Exit) as exc_info:
+        _patched_doctor(results, json_output=True)
+
+    assert exc_info.value.exit_code == 1
+
+
+def test_doctor_warnings_do_not_fail(capsys):
+    """Warnings alone should keep ok=true and not raise an exit."""
+    results = [
+        CheckResult("cli", "Auth status", OK, "token configured"),
+        CheckResult("dev", "FLY_API_TOKEN", WARN, "not set"),
+    ]
+
+    _patched_doctor(results, json_output=True)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -18,40 +18,88 @@ load_env() {
     fi
 }
 
+# Fail fast with actionable messages before installing anything
+preflight() {
+    local failed=0
+
+    # Python >= 3.11 (required by the api and worker packages)
+    if ! command -v python3 &> /dev/null; then
+        echo "✗ python3 not found in PATH"
+        echo "  Install Python 3.11+ from https://www.python.org/downloads/"
+        failed=1
+    elif ! python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)'; then
+        echo "✗ Python 3.11+ required (found $(python3 --version 2>&1))"
+        echo "  The api and worker packages require Python >= 3.11."
+        echo "  Install a newer Python, then delete .venv and re-run setup."
+        failed=1
+    else
+        echo "✓ $(python3 --version 2>&1)"
+    fi
+
+    # Docker (needed for local services, not for package installs)
+    if command -v docker &> /dev/null; then
+        echo "✓ Docker found"
+    else
+        echo "⚠ Docker not found - './scripts/dev.sh up' will not work"
+        echo "  Install from https://docs.docker.com/get-docker/"
+    fi
+
+    if [ "$failed" -ne 0 ]; then
+        echo ""
+        echo "Setup aborted. Fix the issues above and re-run: ./scripts/dev.sh setup"
+        exit 1
+    fi
+}
+
 case "$1" in
     setup)
         echo "Setting up development environment..."
         cd "$PROJECT_ROOT"
 
-        # 1. Create/activate virtual environment
-        if [ ! -d ".venv" ]; then
-            echo "Creating virtual environment..."
-            python3 -m venv .venv
+        echo ""
+        echo "[1/6] Checking prerequisites..."
+        preflight
+
+        # Create .env from the example so services can start out of the box
+        if [ ! -f ".env" ]; then
+            echo "  Creating .env from infra/local.env.example..."
+            cp infra/local.env.example .env
+            echo "  ⚠ Edit .env and set FLY_API_TOKEN (run 'fly auth token') to enable deploys"
         fi
 
-        echo "Activating virtual environment..."
+        echo ""
+        echo "[2/6] Creating virtual environment..."
+        if [ ! -d ".venv" ]; then
+            python3 -m venv .venv
+        else
+            echo "  ✓ .venv already exists"
+        fi
         source .venv/bin/activate
 
-        # 2. Upgrade pip
-        pip install --upgrade pip
-
-        # 3. Install Python packages in development mode
         echo ""
-        echo "Installing Python packages..."
-        pip install -e packages/shared[dev]
-        pip install -e packages/sandbox[dev]
-        pip install -e packages/agents[dev]
-        pip install -e packages/api[dev]
-        pip install -e packages/worker[dev]
-        pip install -e "packages/cli[dev,sandbox]"
+        echo "[3/6] Upgrading pip..."
+        pip install --quiet --upgrade pip
 
-        # 4. Install pre-commit hooks
-        pip install pre-commit
+        echo ""
+        echo "[4/6] Installing Python packages..."
+        for pkg in "packages/shared[dev]" "packages/sandbox[dev]" "packages/agents[dev]" \
+                   "packages/api[dev]" "packages/worker[dev]" "packages/cli[dev,sandbox]"; do
+            echo "  Installing $pkg..."
+            if ! pip install --quiet -e "$pkg"; then
+                echo ""
+                echo "✗ Failed to install $pkg"
+                echo "  Re-run with full output: pip install -e '$pkg'"
+                exit 1
+            fi
+        done
+
+        echo ""
+        echo "[5/6] Installing pre-commit hooks..."
+        pip install --quiet pre-commit
         pre-commit install
 
-        # 5. Install sandbox dependencies (bun, sandbox-runtime, claude)
         echo ""
-        echo "Installing sandbox dependencies..."
+        echo "[6/6] Installing sandbox dependencies..."
 
         # Install Bun if not present
         if ! command -v bun &> /dev/null; then
@@ -92,10 +140,24 @@ case "$1" in
         echo "If this is your first time, reload your shell:"
         echo "  source ~/.zshrc   # or restart terminal"
         echo ""
-        echo "Then run:"
+        echo "Then verify your setup:"
+        echo "  ./scripts/dev.sh doctor"
+        echo ""
+        echo "And start building:"
         echo "  source .venv/bin/activate"
         echo "  runtm-dev start"
         echo "============================================"
+        ;;
+
+    doctor)
+        cd "$PROJECT_ROOT"
+        if [ ! -x ".venv/bin/runtm-dev" ]; then
+            echo "✗ runtm-dev is not installed."
+            echo "  Run './scripts/dev.sh setup' first."
+            exit 1
+        fi
+        load_env
+        .venv/bin/runtm-dev doctor "${@:2}"
         ;;
 
     up)
@@ -177,10 +239,11 @@ case "$1" in
         ;;
 
     *)
-        echo "Usage: $0 {setup|up|down|restart|rebuild|reset-db|logs|migrate|test|lint|format|check}"
+        echo "Usage: $0 {setup|doctor|up|down|restart|rebuild|reset-db|logs|migrate|test|lint|format|check}"
         echo ""
         echo "Commands:"
         echo "  setup    - Install packages in development mode"
+        echo "  doctor   - Verify the dev environment (Python, .env, Docker, services)"
         echo "  up       - Start local services (auto-loads .env, runs migrations)"
         echo "  down     - Stop local services"
         echo "  restart  - Restart services (auto-loads .env)"


### PR DESCRIPTION
## Summary

Closes #4 — improves the first-run developer experience by turning `runtm doctor` into a real setup-validation tool and hardening `scripts/dev.sh setup` so contributors catch and fix environment problems before they cause confusing failures.

Issue #4 asked for a "doctor" command that checks Python version, Docker, `.env`/`FLY_API_TOKEN`, package install, and whether local services start — plus a friendlier setup script. This PR delivers that, reusing existing primitives (`runtm_sandbox.deps`, the auth/config helpers) rather than duplicating logic.

## What changed

### `runtm doctor` / `runtm-dev doctor`
The old inline doctor in `main.py` (~110 lines) is extracted into `commands/doctor.py` and expanded. Checks are now structured `CheckResult` records grouped into three sections, each shown only when relevant:

- **CLI** (always): API URL, auth storage, auth status (`/v1/me`), API connectivity.
- **Local sandbox** (only when the sandbox extras are installed, i.e. `runtm-dev`): bun/node, sandbox-runtime, Claude CLI, and bubblewrap on Linux — via `runtm_sandbox.deps`.
- **Dev environment** (only when run inside the monorepo): Python ≥ 3.11, `.env` presence, `FLY_API_TOKEN` (placeholder-aware), Docker daemon, and local API health.

Additions:
- `--json` for agent-first, machine-readable output.
- **Exit code 1 on any failed check**, so it composes in scripts: `runtm doctor && runtm deploy`.
- Every warning/failure carries a concrete recovery hint.

### `scripts/dev.sh`
- **Preflight**: fails fast on missing/old Python (< 3.11) with clear recovery steps, warns on missing Docker — before installing anything.
- **Auto-creates `.env`** from `infra/local.env.example` when missing.
- Numbered step-by-step progress and per-package install error reporting (no more silent failures).
- New `./scripts/dev.sh doctor` subcommand that loads `.env` and runs the CLI doctor.

### Docs
- `CONTRIBUTING.md`: prerequisite bumped to **Python 3.11+** (the `api`/`worker` packages already require it), plus a "verify your setup" step.
- `CLAUDE.md`: documents the doctor command in the dev-commands list.

## Example

```
$ ./scripts/dev.sh doctor

CLI
  ⚠ Auth storage  no credentials configured
    ↳ Run `runtm login` (or set RUNTM_API_KEY for self-hosted setups)
  ✓ Connectivity  API reachable (912ms)

Dev environment
  ✓ Python          3.12.4
  ⚠ .env            not found (required for local services)
    ↳ Run `cp infra/local.env.example .env` and add your FLY_API_TOKEN
  ✓ Docker          daemon running
  ⚠ Local services  API not reachable at http://localhost:8000
    ↳ Run `./scripts/dev.sh up` to start API + worker + DB + Redis
```

## Testing

- New `packages/cli/tests/test_doctor.py` — 14 cases covering `.env` parsing, repo-root discovery, each check group, JSON output, and exit codes.
- Full CLI suite green: `104 passed`.
- `ruff check .` and `ruff format --check .` both pass.
- Verified end-to-end: human output, `--json` (valid parseable payload), and exit codes all confirmed on a real machine.

## Notes

- The design principle "Design for agents first" is honored via `--json` and script-friendly exit codes.
- No new dependencies. Sandbox checks reuse `runtm_sandbox.deps`; auth/connectivity reuse existing CLI helpers.
- Backward compatible: `runtm doctor` with no flags still prints a human report (now richer).
