### PR TITLE
fix(agent): resolve org context from /v1/me so org-scoped keys work

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -66,7 +66,7 @@ Requires Go 1.23+ and `goreleaser` installed locally (only for the snapshot path
 | `runtm session prompt <id> <text>` | Stream a prompt as SSE -> JSON lines. |
 | `runtm session destroy <id>` | Tear down a sandbox. |
 | `runtm session git <id> <op>` | Run a git operation (commit, push, create_branch_and_pr, ...). |
-| `runtm template list` | List org templates (requires `--org` / `RUNTM_ORG_ID`). |
+| `runtm template list` | List org templates (requires an org-scoped API key). |
 | `runtm template get <id>` | Inspect one template. |
 | `runtm deploy list` | List deployments. |
 | `runtm deploy get <id>` | Inspect one deployment. |
@@ -80,6 +80,12 @@ Run `runtm --help` or `runtm <command> --help` for full flag reference.
 | API key | `RUNTM_API_KEY` | `~/.runtm/credentials` (written by `runtm login` in the pip CLI) |
 | API URL | `RUNTM_API_URL` | `~/.runtm/config.yaml` then `https://app.runtm.com/api/cloud` |
 | Org ID  | `RUNTM_ORG_ID`  | `--org` flag, otherwise auto-resolved from the API key when it's org-scoped |
+
+The org is bound to the API key at creation. `RUNTM_ORG_ID` / `--org` can only
+restate that binding — the API returns `403` if they name a different org, or
+name any org at all on a personal key. To use org-scoped commands (templates,
+team telemetry, team secrets, org instructions, guardrails, skills/MCP), create
+an org-scoped key in the dashboard.
 
 API keys are managed in the dashboard at https://app.runtm.com. The same key works for both the pip CLI and this Go CLI.
 

--- a/packages/agent/internal/cmd/activity.go
+++ b/packages/agent/internal/cmd/activity.go
@@ -11,7 +11,7 @@ import (
 //
 // All routes mount under /api/sessions/telemetry/* and require the
 // `activity:read` scope. Team endpoints additionally require an organization
-// context (--org or RUNTM_ORG_ID).
+// context, which comes from an org-scoped API key.
 func NewActivityCommand(rt *Runtime) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "activity",
@@ -128,7 +128,7 @@ func newActivitySessionUsage(rt *Runtime) *cobra.Command {
 func newActivityTeamSummary(rt *Runtime) *cobra.Command {
 	return &cobra.Command{
 		Use:   "team-summary",
-		Short: "Team-wide summary (GET /api/sessions/telemetry/team/summary, requires --org)",
+		Short: "Team-wide summary (GET /api/sessions/telemetry/team/summary, requires an org-scoped key)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, _, err := requireOrgClient(rt, "team telemetry")
 			if err != nil {
@@ -148,7 +148,7 @@ func newActivityTeamActivity(rt *Runtime) *cobra.Command {
 	var days int
 	cmd := &cobra.Command{
 		Use:   "team-activity",
-		Short: "Team activity over time (GET /api/sessions/telemetry/team/activity, requires --org)",
+		Short: "Team activity over time (GET /api/sessions/telemetry/team/activity, requires an org-scoped key)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, _, err := requireOrgClient(rt, "team telemetry")
 			if err != nil {
@@ -173,7 +173,7 @@ func newActivityTeamActivity(rt *Runtime) *cobra.Command {
 func newActivityTeamMembers(rt *Runtime) *cobra.Command {
 	return &cobra.Command{
 		Use:   "team-members",
-		Short: "Per-member team usage (GET /api/sessions/telemetry/team/members, requires --org)",
+		Short: "Per-member team usage (GET /api/sessions/telemetry/team/members, requires an org-scoped key)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, _, err := requireOrgClient(rt, "team telemetry")
 			if err != nil {

--- a/packages/agent/internal/cmd/agents_cmd.go
+++ b/packages/agent/internal/cmd/agents_cmd.go
@@ -29,8 +29,8 @@ connected platform — a Slack mention, a GitHub issue/PR.
 
 The final install step happens in your browser (you authorize the app into your
 workspace/account), so 'create' hands back a URL or page to open. Org-scoped:
-pass --org or RUNTM_ORG_ID, or use an org-scoped key with admin/owner role and
-the integrations:write scope.
+requires an org-scoped API key with admin/owner role and the integrations:write
+scope (--org cannot substitute for one).
 
   Slack:  needs the org's Slack app config token set once in the dashboard,
           then 'create --type slack --name X' returns an authorize URL.

--- a/packages/agent/internal/cmd/auth.go
+++ b/packages/agent/internal/cmd/auth.go
@@ -54,16 +54,27 @@ func newAuthStatusCommand(rt *Runtime) *cobra.Command {
 				"api_url":       creds.APIURL,
 				"source":        creds.Source,
 			}
-			// Surface the effective org context: explicit (--org / env)
-			// first, otherwise whatever is embedded in the key (returned
-			// by /v1/me as tenant_id when the key is org-scoped).
-			if creds.OrganizationID != "" {
-				out["organization_id"] = creds.OrganizationID
-			} else if t, ok := me["tenant_id"].(string); ok && t != "" {
-				out["organization_id"] = t
-			}
 			for k, v := range me {
 				out[k] = v
+			}
+
+			// Surface the effective org context: explicit (--org / env)
+			// first, otherwise whatever the key itself is bound to. Resolved
+			// after copying `me` so a null organization_id in the payload
+			// cannot clobber it, and reported identically to the bootstrap
+			// that org-scoped commands rely on.
+			str := func(key string) string {
+				s, _ := me[key].(string)
+				return s
+			}
+			orgID := creds.OrganizationID
+			if orgID == "" {
+				orgID = orgFromIdentity(str("organization_id"), str("tenant_id"), str("principal_id"))
+			}
+			if orgID != "" {
+				out["organization_id"] = orgID
+			} else {
+				delete(out, "organization_id")
 			}
 			rt.WriteObject(out)
 			return nil

--- a/packages/agent/internal/cmd/directives_cmd.go
+++ b/packages/agent/internal/cmd/directives_cmd.go
@@ -30,8 +30,8 @@ func NewMcpCommand(rt *Runtime) *cobra.Command {
 		Long: `Manage MCP servers that sessions can load. Two transports:
 stdio (a local command) and http/sse (a remote URL).
 
-Org-scoped: pass --org or RUNTM_ORG_ID, or use an org-scoped key. Writes need
-the context:write scope on the key.`,
+Org-scoped: requires an org-scoped API key (--org cannot substitute for one).
+Writes need the context:write scope on the key.`,
 	}
 	cmd.AddCommand(
 		newDirectiveList(rt, "MCP server", "mcp_server"),
@@ -56,8 +56,8 @@ func NewToolsCommand(rt *Runtime) *cobra.Command {
 sessions use. This command handles static-credential providers (service
 accounts, API keys); OAuth providers are connected through the dashboard.
 
-Org-scoped: pass --org or RUNTM_ORG_ID, or use an org-scoped key. Writes need
-the integrations:write scope on the key.`,
+Org-scoped: requires an org-scoped API key (--org cannot substitute for one).
+Writes need the integrations:write scope on the key.`,
 	}
 	cmd.AddCommand(
 		newToolList(rt),

--- a/packages/agent/internal/cmd/guardrails_cmd.go
+++ b/packages/agent/internal/cmd/guardrails_cmd.go
@@ -26,7 +26,7 @@ func NewGuardrailsCommand(rt *Runtime) *cobra.Command {
 		Use:   "guardrails",
 		Short: "Org spend limits, allowlist policy, and deploy permissions",
 		Long: `Inspect and set org-scoped policies that gate session and deploy spend.
-Most commands require --org or RUNTM_ORG_ID. Writes require admin/owner role.
+Most commands require an org-scoped API key. Writes require admin/owner role.
 
 See https://docs.runtm.com/cloud-api/guardrails for the full schemas.`,
 	}
@@ -122,8 +122,8 @@ func newGuardrailsAllowlist(rt *Runtime) *cobra.Command {
 
 func newGuardrailsAllowlistSet(rt *Runtime) *cobra.Command {
 	var (
-		mode         string
-		patternsCSV  string
+		mode          string
+		patternsCSV   string
 		allowPersonal bool
 	)
 	cmd := &cobra.Command{

--- a/packages/agent/internal/cmd/instructions_cmd.go
+++ b/packages/agent/internal/cmd/instructions_cmd.go
@@ -25,7 +25,7 @@ func NewInstructionsCommand(rt *Runtime) *cobra.Command {
 agent always reads them at boot. User instructions apply to your sessions;
 org instructions apply to every session inside the org.
 
-Use --org or RUNTM_ORG_ID to scope to an organization.
+Use --org-scope with an org-scoped API key to target org instructions.
 See https://docs.runtm.com/cloud-api/context for the full schema.`,
 	}
 	cmd.AddCommand(newInstructionsGet(rt), newInstructionsSet(rt))
@@ -50,7 +50,7 @@ func newInstructionsGet(rt *Runtime) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&orgScope, "org-scope", false, "Read org instructions (requires --org)")
+	cmd.Flags().BoolVar(&orgScope, "org-scope", false, "Read org instructions (requires an org-scoped key)")
 	return cmd
 }
 
@@ -85,7 +85,7 @@ func newInstructionsSet(rt *Runtime) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&orgScope, "org-scope", false, "Write org instructions (requires --org and admin role)")
+	cmd.Flags().BoolVar(&orgScope, "org-scope", false, "Write org instructions (requires an org-scoped key and admin role)")
 	cmd.Flags().StringVarP(&text, "text", "t", "", "Instructions content")
 	cmd.Flags().BoolVar(&clear, "clear", false, "Clear instructions (set to null)")
 	return cmd

--- a/packages/agent/internal/cmd/providers_cmd.go
+++ b/packages/agent/internal/cmd/providers_cmd.go
@@ -39,7 +39,8 @@ func NewProvidersCommand(rt *Runtime) *cobra.Command {
 		Use:   "providers",
 		Short: "Manage Anthropic / OpenAI LLM provider keys (user + org scope)",
 		Long: `Stores encrypted LLM provider API keys used by sessions when no per-session
-override is set. Use --org to manage org-wide keys (admin/owner role required).
+override is set. Use --org-scope with an org-scoped API key to manage org-wide
+keys (admin/owner role required).
 
 This is separate from external integrations (MCP servers, skills, tools, CLIs,
 APIs) — for those, see the 'runtm-integrations' skill. GitHub/Slack/Linear OAuth
@@ -85,7 +86,7 @@ func newProviderGet(rt *Runtime, provider string) *cobra.Command {
 			return runJSON(rt, resp, err)
 		},
 	}
-	cmd.Flags().BoolVar(&orgScope, "org-scope", false, "Read org-level key (requires --org)")
+	cmd.Flags().BoolVar(&orgScope, "org-scope", false, "Read org-level key (requires an org-scoped key)")
 	return cmd
 }
 
@@ -114,7 +115,7 @@ func newProviderSet(rt *Runtime, provider string) *cobra.Command {
 			return runJSON(rt, resp, err)
 		},
 	}
-	cmd.Flags().BoolVar(&orgScope, "org-scope", false, "Write to org-level key (requires --org and admin role)")
+	cmd.Flags().BoolVar(&orgScope, "org-scope", false, "Write to org-level key (requires an org-scoped key and admin role)")
 	cmd.Flags().StringVar(&apiKey, "api-key", "", "Raw provider API key (required)")
 	cmd.Flags().StringVar(&policy, "policy", "", "Org policy: 'allow_user_override' or 'require_team_key' (org only)")
 	_ = cmd.MarkFlagRequired("api-key")
@@ -135,7 +136,7 @@ func newProviderDelete(rt *Runtime, provider string) *cobra.Command {
 			return runJSON(rt, resp, err)
 		},
 	}
-	cmd.Flags().BoolVar(&orgScope, "org-scope", false, "Delete org-level key (requires --org and admin role)")
+	cmd.Flags().BoolVar(&orgScope, "org-scope", false, "Delete org-level key (requires an org-scoped key and admin role)")
 	return cmd
 }
 

--- a/packages/agent/internal/cmd/root.go
+++ b/packages/agent/internal/cmd/root.go
@@ -40,7 +40,7 @@ Docs: https://docs.runtm.com`,
 		SilenceUsage:  true,
 	}
 	root.PersistentFlags().StringVar(&flags.APIURL, "api-url", "", "Override API base URL (also RUNTM_API_URL)")
-	root.PersistentFlags().StringVar(&flags.Org, "org", "", "Organization ID for org-scoped operations (also RUNTM_ORG_ID)")
+	root.PersistentFlags().StringVar(&flags.Org, "org", "", "Organization ID for org-scoped operations (also RUNTM_ORG_ID); must match the API key's own org")
 
 	sessionCmd := NewSessionCommand(rt)
 	AddSessionExtras(sessionCmd, rt)

--- a/packages/agent/internal/cmd/runtime.go
+++ b/packages/agent/internal/cmd/runtime.go
@@ -62,36 +62,62 @@ func (r *Runtime) Client() (*client.Client, *auth.Credentials, error) {
 }
 
 // resolveKeyOrgID asks the backend (once) which org this API key is bound to.
-// Returns "" when the key is personal or when verify fails (in which case the
-// caller's subsequent request will surface the real error). Memoized so a
+// Returns "" when the key is personal or when the lookup fails (in which case
+// the caller's subsequent request will surface the real error). Memoized so a
 // single CLI invocation pays at most one extra round-trip.
+//
+// This reads /v1/me, not /auth/verify. The backend mounts /auth/verify at its
+// root, while the CLI speaks to the /api/cloud proxy which only forwards to
+// /api/* -- so /auth/verify is a 404 over this transport.
 func (r *Runtime) resolveKeyOrgID(c *client.Client) (string, error) {
 	r.keyOrgOnce.Do(func() {
-		body, err := c.Get("/auth/verify", nil)
+		body, err := c.Get("/v1/me", nil)
 		if err != nil {
 			r.keyOrgErr = err
 			return
 		}
 		var v struct {
 			OrganizationID string `json:"organization_id"`
+			TenantID       string `json:"tenant_id"`
+			PrincipalID    string `json:"principal_id"`
 		}
 		if err := json.Unmarshal(body, &v); err != nil {
 			r.keyOrgErr = err
 			return
 		}
-		r.keyOrgID = v.OrganizationID
+		r.keyOrgID = orgFromIdentity(v.OrganizationID, v.TenantID, v.PrincipalID)
 	})
 	return r.keyOrgID, r.keyOrgErr
+}
+
+// orgFromIdentity extracts the org binding from a /v1/me payload.
+// organization_id is authoritative when the backend supplies it. Older
+// backends only return the legacy tenant_id, which holds the org for org keys
+// but the user_id for personal ones -- so it only counts as an org when it
+// differs from the principal.
+func orgFromIdentity(orgID, tenantID, principalID string) string {
+	if orgID != "" {
+		return orgID
+	}
+	if tenantID != "" && tenantID != principalID {
+		return tenantID
+	}
+	return ""
 }
 
 // requireOrgClient resolves the API client and ensures an org context is
 // available for routes that require X-Organization-Id (team telemetry, org
 // instructions, guardrails, team secrets, templates, etc.).
 //
+// The org is a property of the API key, not a caller-supplied parameter: the
+// backend 403s a personal key that sends X-Organization-Id, and 403s an org key
+// whose header names a different org. So --org / RUNTM_ORG_ID can only restate
+// the key's own binding -- it can never grant access to an org the key lacks.
+//
 // Resolution order:
 //  1. --org flag / RUNTM_ORG_ID env var (already populated on creds).
-//  2. The org embedded in the API key, fetched once via /auth/verify.
-//  3. Surface a friendly silent error pointing the agent at the fix.
+//  2. The org embedded in the API key, fetched once via /v1/me.
+//  3. Surface a friendly silent error pointing the agent at the only real fix.
 func requireOrgClient(rt *Runtime, what string) (*client.Client, *auth.Credentials, error) {
 	c, creds, err := rt.Client()
 	if err != nil {
@@ -111,8 +137,8 @@ func requireOrgClient(rt *Runtime, what string) (*client.Client, *auth.Credentia
 	}
 
 	rt.WriteObject(map[string]any{
-		"error": what + " is org-scoped, but the API key has no org. Pass --org <id> or set RUNTM_ORG_ID, or create an org-scoped key in the dashboard.",
-		"hint":  "Run `runtm-api auth status` to inspect the active key and its org.",
+		"error": what + " is org-scoped, but this API key is personal (it has no org). Create an org-scoped key at https://app.runtm.com > Settings > API Keys and use it instead.",
+		"hint":  "The org is fixed when the key is created; --org / RUNTM_ORG_ID cannot grant access to one (the API rejects a personal key that sends an org with 403). Run `runtm-api auth status` to inspect the active key.",
 	})
 	return nil, nil, errSilent
 }

--- a/packages/agent/internal/cmd/runtime_test.go
+++ b/packages/agent/internal/cmd/runtime_test.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -31,16 +33,32 @@ func newTestClient(serverURL string) *client.Client {
 	})
 }
 
-func TestResolveKeyOrgIDReturnsOrgFromVerify(t *testing.T) {
-	var calls int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&calls, 1)
-		if r.URL.Path != "/auth/verify" {
-			t.Errorf("unexpected path %q", r.URL.Path)
+// identityServer serves the supplied JSON at /v1/me and 404s everything else,
+// mirroring the real /api/cloud proxy — which only forwards to /api/*, so a
+// root-mounted route like /auth/verify is unreachable.
+//
+// The leading /cloud is stripped the way the proxy does, so this stub works
+// both for clients built directly and for those whose base URL went through
+// auth.Load (which appends the /cloud suffix).
+func identityServer(t *testing.T, payload string, calls *int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls != nil {
+			atomic.AddInt32(calls, 1)
+		}
+		if strings.TrimPrefix(r.URL.Path, "/cloud") != "/v1/me" {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"detail":"Not Found"}`)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"organization_id":"org_abc"}`)
+		fmt.Fprint(w, payload)
 	}))
+}
+
+func TestResolveKeyOrgIDReturnsOrgFromMe(t *testing.T) {
+	var calls int32
+	srv := identityServer(t, `{"organization_id":"org_abc","tenant_id":"org_abc","principal_id":"user_xyz"}`, &calls)
 	defer srv.Close()
 
 	rt := newTestRuntime()
@@ -59,22 +77,51 @@ func TestResolveKeyOrgIDReturnsOrgFromVerify(t *testing.T) {
 		t.Fatalf("second call error: %v", err)
 	}
 	if calls != 1 {
-		t.Errorf("verify hit %d times, want 1 (memoized)", calls)
+		t.Errorf("identity endpoint hit %d times, want 1 (memoized)", calls)
+	}
+}
+
+// Regression guard: the bootstrap used to call /auth/verify, which the cloud
+// proxy 404s, so every org-scoped command wrongly reported "no org".
+func TestResolveKeyOrgIDUsesProxyReachableEndpoint(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"organization_id":"org_abc"}`)
+	}))
+	defer srv.Close()
+
+	if _, err := newTestRuntime().resolveKeyOrgID(newTestClient(srv.URL)); err != nil {
+		t.Fatalf("resolveKeyOrgID error: %v", err)
+	}
+	if gotPath != "/v1/me" {
+		t.Errorf("requested %q, want /v1/me", gotPath)
+	}
+}
+
+// Backends that predate organization_id on /v1/me only expose the legacy
+// tenant_id, which equals the org for org-scoped keys.
+func TestResolveKeyOrgIDFallsBackToTenantID(t *testing.T) {
+	srv := identityServer(t, `{"tenant_id":"org_abc","principal_id":"user_xyz"}`, nil)
+	defer srv.Close()
+
+	got, err := rtResolve(t, srv.URL)
+	if err != nil {
+		t.Fatalf("resolveKeyOrgID error: %v", err)
+	}
+	if got != "org_abc" {
+		t.Errorf("orgID = %q, want org_abc", got)
 	}
 }
 
 func TestResolveKeyOrgIDReturnsEmptyForPersonalKey(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		// Personal keys come back with organization_id missing/null.
-		fmt.Fprint(w, `{"organization_id":null,"tenant_id":"user_xyz"}`)
-	}))
+	// Personal keys carry a null organization_id and a tenant_id that is just
+	// the user_id — it must not be mistaken for an org.
+	srv := identityServer(t, `{"organization_id":null,"tenant_id":"user_xyz","principal_id":"user_xyz"}`, nil)
 	defer srv.Close()
 
-	rt := newTestRuntime()
-	c := newTestClient(srv.URL)
-
-	got, err := rt.resolveKeyOrgID(c)
+	got, err := rtResolve(t, srv.URL)
 	if err != nil {
 		t.Fatalf("resolveKeyOrgID error: %v", err)
 	}
@@ -83,21 +130,112 @@ func TestResolveKeyOrgIDReturnsEmptyForPersonalKey(t *testing.T) {
 	}
 }
 
-func TestResolveKeyOrgIDPropagatesVerifyError(t *testing.T) {
+func TestResolveKeyOrgIDPropagatesLookupError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		fmt.Fprint(w, `{"detail":"Invalid API key"}`)
 	}))
 	defer srv.Close()
 
-	rt := newTestRuntime()
-	c := newTestClient(srv.URL)
-
-	got, err := rt.resolveKeyOrgID(c)
+	got, err := rtResolve(t, srv.URL)
 	if err == nil {
 		t.Fatalf("expected error, got nil (orgID=%q)", got)
 	}
 	if got != "" {
 		t.Errorf("orgID on error = %q, want empty", got)
+	}
+}
+
+func TestOrgFromIdentity(t *testing.T) {
+	cases := []struct {
+		name                         string
+		orgID, tenantID, principalID string
+		want                         string
+	}{
+		{"explicit org wins", "org_abc", "user_xyz", "user_xyz", "org_abc"},
+		{"tenant differs from principal", "", "org_abc", "user_xyz", "org_abc"},
+		{"tenant equals principal", "", "user_xyz", "user_xyz", ""},
+		{"all empty", "", "", "", ""},
+		{"tenant only, no principal", "", "org_abc", "", "org_abc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := orgFromIdentity(tc.orgID, tc.tenantID, tc.principalID); got != tc.want {
+				t.Errorf("orgFromIdentity(%q, %q, %q) = %q, want %q",
+					tc.orgID, tc.tenantID, tc.principalID, got, tc.want)
+			}
+		})
+	}
+}
+
+func rtResolve(t *testing.T, serverURL string) (string, error) {
+	t.Helper()
+	return newTestRuntime().resolveKeyOrgID(newTestClient(serverURL))
+}
+
+// orgRuntime wires a Runtime to a stub identity server the way a real
+// invocation would: key from the env, base URL from the --api-url flag. The
+// returned counter lets callers assert the identity endpoint was actually
+// reached, so a routing regression can't masquerade as a personal key.
+func orgRuntime(t *testing.T, payload string) (*Runtime, *bytes.Buffer, *int32) {
+	t.Helper()
+	var calls int32
+	srv := identityServer(t, payload, &calls)
+	t.Cleanup(srv.Close)
+	t.Setenv("RUNTM_API_KEY", "runtm_sk_test")
+	t.Setenv("RUNTM_ORG_ID", "")
+
+	stdout := &bytes.Buffer{}
+	return &Runtime{
+		Flags:  &GlobalFlags{APIURL: srv.URL},
+		Stdout: stdout,
+		Stderr: &bytes.Buffer{},
+	}, stdout, &calls
+}
+
+func TestRequireOrgClientAdoptsOrgFromKey(t *testing.T) {
+	rt, _, _ := orgRuntime(t, `{"organization_id":"org_abc","tenant_id":"org_abc","principal_id":"user_xyz"}`)
+
+	_, creds, err := requireOrgClient(rt, "org templates")
+	if err != nil {
+		t.Fatalf("requireOrgClient error: %v", err)
+	}
+	if creds.OrganizationID != "org_abc" {
+		t.Errorf("OrganizationID = %q, want org_abc", creds.OrganizationID)
+	}
+}
+
+// A personal key genuinely cannot reach an org, so the guidance must point at
+// creating an org-scoped key rather than at --org / RUNTM_ORG_ID, which the API
+// rejects with 403.
+func TestRequireOrgClientPersonalKeyGuidance(t *testing.T) {
+	rt, stdout, calls := orgRuntime(t, `{"organization_id":null,"tenant_id":"user_xyz","principal_id":"user_xyz"}`)
+
+	if _, _, err := requireOrgClient(rt, "org templates"); err != errSilent {
+		t.Fatalf("err = %v, want errSilent", err)
+	}
+	if *calls != 1 {
+		t.Fatalf("identity endpoint hit %d times, want 1 — the lookup must succeed "+
+			"and report a personal key, not fail to route", *calls)
+	}
+
+	var payload struct {
+		Error string `json:"error"`
+		Hint  string `json:"hint"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal output %q: %v", stdout.String(), err)
+	}
+	if !strings.Contains(payload.Error, "org-scoped key") {
+		t.Errorf("error should point at creating an org-scoped key, got %q", payload.Error)
+	}
+	// Guard against regressing to the old advice, which does not work.
+	for _, banned := range []string{"Pass --org", "set RUNTM_ORG_ID"} {
+		if strings.Contains(payload.Error, banned) {
+			t.Errorf("error recommends %q, which the API rejects with 403: %q", banned, payload.Error)
+		}
+	}
+	if !strings.Contains(payload.Hint, "403") {
+		t.Errorf("hint should explain the 403, got %q", payload.Hint)
 	}
 }

--- a/packages/agent/internal/cmd/secrets_cmd.go
+++ b/packages/agent/internal/cmd/secrets_cmd.go
@@ -29,7 +29,7 @@ func NewSecretsCommand(rt *Runtime) *cobra.Command {
 		Long: `Personal secrets belong to the API key owner. Team secrets are org-scoped
 and require admin/owner role on the key for writes.
 
-Set --team to operate on team secrets (requires --org or RUNTM_ORG_ID).
+Set --team to operate on team secrets (requires an org-scoped API key).
 See https://docs.runtm.com/cloud-api/secrets for the full schemas.`,
 	}
 	cmd.AddCommand(
@@ -59,7 +59,7 @@ func newSecretsList(rt *Runtime) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&team, "team", false, "List team secrets (requires --org)")
+	cmd.Flags().BoolVar(&team, "team", false, "List team secrets (requires an org-scoped key)")
 	return cmd
 }
 
@@ -97,7 +97,7 @@ func newSecretsSet(rt *Runtime) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&team, "team", false, "Write to team secrets (requires --org and admin role)")
+	cmd.Flags().BoolVar(&team, "team", false, "Write to team secrets (requires an org-scoped key and admin role)")
 	return cmd
 }
 
@@ -120,7 +120,7 @@ func newSecretsDelete(rt *Runtime) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&team, "team", false, "Delete from team secrets (requires --org and admin role)")
+	cmd.Flags().BoolVar(&team, "team", false, "Delete from team secrets (requires an org-scoped key and admin role)")
 	return cmd
 }
 

--- a/packages/agent/internal/cmd/skills_cmd.go
+++ b/packages/agent/internal/cmd/skills_cmd.go
@@ -23,8 +23,9 @@ func NewSkillsCommand(rt *Runtime) *cobra.Command {
 		Long: `Create, list, update, and delete your org's skills, and install this
 CLI's own bundled skill files locally.
 
-Cloud commands (create/get/list/update/delete) are org-scoped: pass --org or
-RUNTM_ORG_ID, or use an org-scoped key. Writes need the context:write scope.
+Cloud commands (create/get/list/update/delete) are org-scoped: they require an
+org-scoped API key, which --org / RUNTM_ORG_ID cannot substitute for. Writes
+need the context:write scope.
 
 'skills install' is a local operation (no API call) that copies the skill files
 embedded in this binary into the detected agent's skills directory.`,

--- a/packages/agent/internal/cmd/skills_pull_cmd.go
+++ b/packages/agent/internal/cmd/skills_pull_cmd.go
@@ -73,8 +73,8 @@ for ~/.agents/skills, --agent all for both (repeat --agent to combine), or
 --target to write to one explicit directory instead. Existing skill directories
 are skipped unless --force is passed.
 
-Org-scoped: pass --org or RUNTM_ORG_ID, or use an org-scoped key. Needs the
-context:read scope.
+Org-scoped: requires an org-scoped API key. The org is read from the key, so
+--org / RUNTM_ORG_ID cannot substitute for one. Needs the context:read scope.
 
 Example:
   runtm-api skills pull <template_id>

--- a/packages/agent/internal/cmd/template.go
+++ b/packages/agent/internal/cmd/template.go
@@ -127,7 +127,7 @@ func parseSessionArgs(specs []string) ([]map[string]any, error) {
 // boot instantly with the environment ready.
 //
 // All routes are dual-auth and live under /api/org-templates/*. Templates are
-// org-scoped (--org or RUNTM_ORG_ID required).
+// org-scoped (an org-scoped API key is required).
 //
 // Surface covered:
 //
@@ -153,7 +153,8 @@ func NewTemplateCommand(rt *Runtime) *cobra.Command {
 and agent instructions configured. Sessions launched from a template boot
 instantly with the environment ready.
 
-All template commands require --org or RUNTM_ORG_ID. Writes (create, build,
+All template commands require an org-scoped API key; the org is read from the
+key, and --org / RUNTM_ORG_ID cannot substitute for one. Writes (create, build,
 delete) require admin/owner role on the API key.
 
 See https://docs.runtm.com/cloud-api/templates for the full schemas.`,

--- a/packages/agent/internal/skills/files/SKILL.md
+++ b/packages/agent/internal/skills/files/SKILL.md
@@ -163,12 +163,23 @@ go install github.com/runtm-ai/runtm/packages/agent/cmd/runtm-api@latest
 runtm-api skills install
 ```
 
-Org context for org-scoped operations (templates, team telemetry, team secrets, org instructions, guardrails) is auto-discovered from the API key, so org keys "just work" with no extra setup. Only set this when using a personal key against an org you belong to, or when switching between orgs:
+### Org context
+
+Org-scoped operations (templates, team telemetry, team secrets, org instructions, guardrails, skills/MCP) need an **org-scoped API key**. Nothing else is required — the org is auto-discovered from the key, so org keys work with no extra setup.
+
+The org is bound to the key when it is created and cannot be overridden at call time:
+
+| Key | What you pass | Result |
+|-----|---------------|--------|
+| Org-scoped | nothing | Works — org read from the key |
+| Org-scoped | `--org` matching the key | Works, redundant |
+| Org-scoped | `--org` for another org | `403` |
+| Personal | anything | `403` — a personal key can never reach an org |
+
+So `--org` / `RUNTM_ORG_ID` can only restate the key's own binding; they cannot grant access. If an org-scoped command reports the key is personal, the fix is to create an org-scoped key at https://app.runtm.com > Settings > API Keys — not to set the env var.
 
 ```bash
-export RUNTM_ORG_ID=org_abc123   # optional; usually only personal keys need this
-# or pass per command:
-runtm-api template list --org org_abc123
+runtm-api auth status | jq .organization_id   # null => personal key
 ```
 
 ## Required Input Resolution
@@ -200,7 +211,7 @@ If `authenticated: false`, ask the user to set `RUNTM_API_KEY` (or run `runtm-ap
 | Status | Cause | Fix |
 |--------|-------|-----|
 | 401 | API key invalid or missing | `RUNTM_API_KEY` or rotate in dashboard |
-| 403 | Missing scope or wrong org | `runtm-api auth status` to inspect; key may need `templates:write`, `secrets:write`, `guardrails:write`, etc. |
+| 403 | Missing scope, or the key's org doesn't match the request | `runtm-api auth status` to inspect; key may need `templates:write`, `secrets:write`, `guardrails:write`, etc. Also returned when a personal key targets an org, or `--org` names a different org than the key — use an org-scoped key instead. |
 | 404 | Wrong ID | Run the matching `list` command first |
 | 409 | Conflict (e.g. duplicate name) | Use a different name / --name flag |
 | 422 | Body validation failed | Check the canonical endpoint schema at https://docs.runtm.com/cloud-api |

--- a/packages/agent/internal/skills/files/runtm-agents.md
+++ b/packages/agent/internal/skills/files/runtm-agents.md
@@ -25,9 +25,10 @@ supported from the CLI yet** — manage Linear agents in the dashboard.
 
 ## Org context + scope
 
-All commands are org-scoped: pass `--org` / `RUNTM_ORG_ID`, or use an org-scoped
-key. Writes (create/update/delete) need an **admin/owner** key with the
-`integrations:write` scope; reads need `integrations:read`.
+All commands are org-scoped, so they need an **org-scoped API key** — the org is
+read from the key, and `--org` / `RUNTM_ORG_ID` cannot substitute for one. Writes
+(create/update/delete) need an **admin/owner** key with the `integrations:write`
+scope; reads need `integrations:read`.
 
 ## Create
 

--- a/packages/agent/internal/skills/files/runtm-integrations.md
+++ b/packages/agent/internal/skills/files/runtm-integrations.md
@@ -23,10 +23,14 @@ Each command exposes the same verbs: `create`, `get`, `list`, `update`,
 endpoint. That mapping is an implementation detail — just use `skills`, `mcp`,
 and `tools`.
 
-## All commands require org context
+## All commands require an org-scoped API key
+
+The org is read from the key; `--org` / `RUNTM_ORG_ID` cannot stand in for one,
+and a personal key targeting an org is rejected with `403`.
 
 ```bash
-export RUNTM_ORG_ID=org_abc123    # or pass --org org_abc123 each time
+export RUNTM_API_KEY=runtm_sk_live_...        # must be an org-scoped key
+runtm-api auth status | jq .organization_id   # null => personal key
 ```
 
 Writes need the right API-key scope: `context:write` for skills/MCP, and
@@ -303,13 +307,13 @@ Scopes & semantics:
 - `detach` removes the named `--template`/`--repo`, `--all` removes the
   all-repos attachment, and `--clear` removes everything. It leaves untouched
   attachments in place.
-- Only **org-owned** skills/MCP servers can be attached (use `--org` /
-  `RUNTM_ORG_ID`); personal directives cannot.
+- Only **org-owned** skills/MCP servers can be attached (they come from an
+  org-scoped key); personal directives cannot.
 
 The full flow to wire a skill into a template:
 
 ```bash
-export RUNTM_ORG_ID=org_abc123
+export RUNTM_API_KEY=runtm_sk_live_...   # org-scoped key
 SKILL_ID=$(runtm-api skills create --name deploy-checks --md ./SKILL.md | jq -r .directive.id)
 runtm-api skills attach "$SKILL_ID" --template <template_id>
 runtm-api template skills <template_id>          # verify it's listed

--- a/packages/agent/internal/skills/files/runtm-templates.md
+++ b/packages/agent/internal/skills/files/runtm-templates.md
@@ -24,13 +24,16 @@ Org templates are **snapshots of fully configured sandbox environments**. Each t
 
 A session created from a template boots instantly with the environment ready -- no install commands, no waiting on dependency builds.
 
-## All template commands require org context
+## All template commands require an org-scoped API key
+
+The org is read from the key itself, so no extra setup is needed:
 
 ```bash
-export RUNTM_ORG_ID=org_abc123    # or pass --org org_abc123 each time
+export RUNTM_API_KEY=runtm_sk_live_...   # must be an org-scoped key
+runtm-api auth status | jq .organization_id   # null => personal key, templates unavailable
 ```
 
-Without org context, every `runtm-api template` command surfaces a clear error.
+With a personal key every `runtm-api template` command surfaces a clear error. Setting `RUNTM_ORG_ID` or passing `--org` does **not** help — the org is fixed when the key is created, and the API rejects a personal key that names an org. Create an org-scoped key at https://app.runtm.com > Settings > API Keys.
 
 ## Recipe: discover what exists
 

--- a/packages/agent/skills/SKILL.md
+++ b/packages/agent/skills/SKILL.md
@@ -163,12 +163,23 @@ go install github.com/runtm-ai/runtm/packages/agent/cmd/runtm-api@latest
 runtm-api skills install
 ```
 
-Org context for org-scoped operations (templates, team telemetry, team secrets, org instructions, guardrails) is auto-discovered from the API key, so org keys "just work" with no extra setup. Only set this when using a personal key against an org you belong to, or when switching between orgs:
+### Org context
+
+Org-scoped operations (templates, team telemetry, team secrets, org instructions, guardrails, skills/MCP) need an **org-scoped API key**. Nothing else is required — the org is auto-discovered from the key, so org keys work with no extra setup.
+
+The org is bound to the key when it is created and cannot be overridden at call time:
+
+| Key | What you pass | Result |
+|-----|---------------|--------|
+| Org-scoped | nothing | Works — org read from the key |
+| Org-scoped | `--org` matching the key | Works, redundant |
+| Org-scoped | `--org` for another org | `403` |
+| Personal | anything | `403` — a personal key can never reach an org |
+
+So `--org` / `RUNTM_ORG_ID` can only restate the key's own binding; they cannot grant access. If an org-scoped command reports the key is personal, the fix is to create an org-scoped key at https://app.runtm.com > Settings > API Keys — not to set the env var.
 
 ```bash
-export RUNTM_ORG_ID=org_abc123   # optional; usually only personal keys need this
-# or pass per command:
-runtm-api template list --org org_abc123
+runtm-api auth status | jq .organization_id   # null => personal key
 ```
 
 ## Required Input Resolution
@@ -200,7 +211,7 @@ If `authenticated: false`, ask the user to set `RUNTM_API_KEY` (or run `runtm-ap
 | Status | Cause | Fix |
 |--------|-------|-----|
 | 401 | API key invalid or missing | `RUNTM_API_KEY` or rotate in dashboard |
-| 403 | Missing scope or wrong org | `runtm-api auth status` to inspect; key may need `templates:write`, `secrets:write`, `guardrails:write`, etc. |
+| 403 | Missing scope, or the key's org doesn't match the request | `runtm-api auth status` to inspect; key may need `templates:write`, `secrets:write`, `guardrails:write`, etc. Also returned when a personal key targets an org, or `--org` names a different org than the key — use an org-scoped key instead. |
 | 404 | Wrong ID | Run the matching `list` command first |
 | 409 | Conflict (e.g. duplicate name) | Use a different name / --name flag |
 | 422 | Body validation failed | Check the canonical endpoint schema at https://docs.runtm.com/cloud-api |

--- a/packages/agent/skills/runtm-agents.md
+++ b/packages/agent/skills/runtm-agents.md
@@ -25,9 +25,10 @@ supported from the CLI yet** — manage Linear agents in the dashboard.
 
 ## Org context + scope
 
-All commands are org-scoped: pass `--org` / `RUNTM_ORG_ID`, or use an org-scoped
-key. Writes (create/update/delete) need an **admin/owner** key with the
-`integrations:write` scope; reads need `integrations:read`.
+All commands are org-scoped, so they need an **org-scoped API key** — the org is
+read from the key, and `--org` / `RUNTM_ORG_ID` cannot substitute for one. Writes
+(create/update/delete) need an **admin/owner** key with the `integrations:write`
+scope; reads need `integrations:read`.
 
 ## Create
 

--- a/packages/agent/skills/runtm-integrations.md
+++ b/packages/agent/skills/runtm-integrations.md
@@ -23,10 +23,14 @@ Each command exposes the same verbs: `create`, `get`, `list`, `update`,
 endpoint. That mapping is an implementation detail — just use `skills`, `mcp`,
 and `tools`.
 
-## All commands require org context
+## All commands require an org-scoped API key
+
+The org is read from the key; `--org` / `RUNTM_ORG_ID` cannot stand in for one,
+and a personal key targeting an org is rejected with `403`.
 
 ```bash
-export RUNTM_ORG_ID=org_abc123    # or pass --org org_abc123 each time
+export RUNTM_API_KEY=runtm_sk_live_...        # must be an org-scoped key
+runtm-api auth status | jq .organization_id   # null => personal key
 ```
 
 Writes need the right API-key scope: `context:write` for skills/MCP, and
@@ -303,13 +307,13 @@ Scopes & semantics:
 - `detach` removes the named `--template`/`--repo`, `--all` removes the
   all-repos attachment, and `--clear` removes everything. It leaves untouched
   attachments in place.
-- Only **org-owned** skills/MCP servers can be attached (use `--org` /
-  `RUNTM_ORG_ID`); personal directives cannot.
+- Only **org-owned** skills/MCP servers can be attached (they come from an
+  org-scoped key); personal directives cannot.
 
 The full flow to wire a skill into a template:
 
 ```bash
-export RUNTM_ORG_ID=org_abc123
+export RUNTM_API_KEY=runtm_sk_live_...   # org-scoped key
 SKILL_ID=$(runtm-api skills create --name deploy-checks --md ./SKILL.md | jq -r .directive.id)
 runtm-api skills attach "$SKILL_ID" --template <template_id>
 runtm-api template skills <template_id>          # verify it's listed

--- a/packages/agent/skills/runtm-templates.md
+++ b/packages/agent/skills/runtm-templates.md
@@ -24,13 +24,16 @@ Org templates are **snapshots of fully configured sandbox environments**. Each t
 
 A session created from a template boots instantly with the environment ready -- no install commands, no waiting on dependency builds.
 
-## All template commands require org context
+## All template commands require an org-scoped API key
+
+The org is read from the key itself, so no extra setup is needed:
 
 ```bash
-export RUNTM_ORG_ID=org_abc123    # or pass --org org_abc123 each time
+export RUNTM_API_KEY=runtm_sk_live_...   # must be an org-scoped key
+runtm-api auth status | jq .organization_id   # null => personal key, templates unavailable
 ```
 
-Without org context, every `runtm-api template` command surfaces a clear error.
+With a personal key every `runtm-api template` command surfaces a clear error. Setting `RUNTM_ORG_ID` or passing `--org` does **not** help — the org is fixed when the key is created, and the API rejects a personal key that names an org. Create an org-scoped key at https://app.runtm.com > Settings > API Keys.
 
 ## Recipe: discover what exists
 


### PR DESCRIPTION
## Summary

Every org-scoped command (`template`, `skills`, `mcp`, `guardrails`, `activity team-*`) reported **"the API key has no org"** even when the key was org-bound, forcing users to set `RUNTM_ORG_ID` by hand.

**Root cause.** The org bootstrap in `requireOrgClient` called `GET /auth/verify`. That route is mounted at the backend *root*, but the CLI speaks to the `/api/cloud` proxy, which only rewrites to `/api/*`. So the request resolved to `/api/auth/verify` and returned `404` on every single invocation — the org never resolved, and every org command fell through to the error branch. Confirmed directly against production.

The existing unit tests mocked `/auth/verify` on a stub server that served *any* path, which is exactly why the broken transport was never caught.

**Fix.** Read `/v1/me`, which is reachable through the proxy. Prefer its `organization_id`, falling back to `tenant_id` when it differs from `principal_id` — `tenant_id` is legacy and holds the `user_id` on personal keys, so it only denotes an org when the two diverge. That fallback means this works against the current production backend today, before the companion change lands.

> Companion (not required for this to work): `runtm-cloud` adds `organization_id` to `/api/v1/me` so the heuristic becomes an exact read.

## Docs corrected

The org is fixed when a key is created. The API `403`s a personal key that sends an org, and `403`s an org key naming a different one — so `--org` / `RUNTM_ORG_ID` can **never** grant access, and the old advice to set them was a dead end. Error text, command help, README, and the bundled skills now point at creating an org-scoped key instead.

`auth status` also derived the org from `tenant_id` alone, which would report a `user_id` as an `organization_id` on personal keys. It now shares the same resolution, applied after the payload copy so a null `organization_id` can't clobber it.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test -race ./internal/...` passes
- [x] Regression guard asserts the bootstrap requests `/v1/me`, with the stub 404ing everything else to mirror the proxy
- [x] Table test covers org vs personal resolution (`tenant_id` == `principal_id`)
- [x] Personal-key test asserts the corrected guidance and that the endpoint was actually reached, so a routing regression can't masquerade as a personal key
- [x] Verified against live production with `RUNTM_ORG_ID` unset: `template list`, `skills list`, `mcp list`, `guardrails limits get`, `activity team-summary` all succeed where they previously errored

Note: `ci.yml` runs only the Python suites, so the Go tests here don't execute in CI.

Made with [Cursor](https://cursor.com)