### PR TITLE
ci: pin Ruff to 0.15.22 so a new release can't red every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   PYTHON_VERSION: "3.12"
+  # Pinned so a new Ruff release can't turn every open PR red on its own.
+  # Bump deliberately, in a PR that also applies the resulting reformat.
+  RUFF_VERSION: "0.15.22"
 
 jobs:
   lint:
@@ -22,7 +25,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Ruff
-        run: pip install ruff
+        run: pip install "ruff==${{ env.RUFF_VERSION }}"
 
       - name: Run Ruff check
         run: ruff check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  # Pinned so a new Ruff release can't turn every open PR red on its own.
+  # Bump deliberately, in a PR that also applies the resulting reformat.
+  RUFF_VERSION: "0.15.22"
+
 jobs:
   lint:
     name: Lint
@@ -15,7 +20,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Run Ruff check
-        run: uvx ruff check .
+        run: uvx ruff@${{ env.RUFF_VERSION }} check .
 
       - name: Run Ruff format check
-        run: uvx ruff format --check .
+        run: uvx ruff@${{ env.RUFF_VERSION }} format --check .


### PR DESCRIPTION
## Summary

`Lint` has failed on **every** open PR since 2026-07-23, with no code change to explain it. Both workflows installed Ruff unpinned — `uvx ruff` in `lint.yml`, `pip install ruff` in `ci.yml` — so CI silently adopted a new major the moment it shipped.

The timeline is unambiguous:

| When | What |
|---|---|
| 2026-07-09 | Ruff 0.15.21 released |
| 2026-07-11 | last green `Lint` run |
| **2026-07-23 19:10 UTC** | **Ruff 0.16.0 released** |
| 2026-07-23 19:40 UTC | first failing `Lint` run, 30 min later |

0.16.0 formats Python embedded in Markdown code blocks differently, so `ruff format --check` now fails on nine documentation files nobody has touched, spread across `packages/agents/`, `packages/shared/`, and `templates/`.

## Fix

Pin to **0.15.22**, the newest release before the break, via a `RUFF_VERSION` env var in both workflows. Verified locally against this repo:

| Ruff | `check` | `format --check` |
|---|---|---|
| 0.15.21 | pass | pass |
| **0.15.22** | **pass** | **pass** ← pinned |
| 0.16.0 | pass | **fail** |

This restores green without reformatting anything. Adopting 0.16.0 should be its own PR that applies the reformat alongside the version bump, so the churn is reviewable instead of arriving unannounced.

## Test plan

- [x] Both workflow files parse as valid YAML
- [x] `uvx ruff@0.15.22 check .` passes on this branch
- [x] `uvx ruff@0.15.22 format --check .` passes on this branch
- [x] Reproduced the failure with `uvx ruff@0.16.0 format --check .` and confirmed the failing files are all untouched Markdown
- [ ] `Lint` goes green on this PR

Unblocks #44 and #45, which are both red purely for this reason.

Made with [Cursor](https://cursor.com)