### PR TITLE
feat(agent): scheduled-agents command, exec --json, and skill discoverability

### DIFF
--- a/docs/cloud-api/agent-cli.mdx
+++ b/docs/cloud-api/agent-cli.mdx
@@ -78,15 +78,33 @@ The same API key works for both this CLI and the pip CLI.
 | `runtm-api session list` | List sessions for the API key. |
 | `runtm-api session status <id>` | Get state + `last_prompt` polling fields. |
 | `runtm-api session prompt <id> <text>` | Stream a prompt as SSE → JSON lines. |
+| `runtm-api session exec <id> -- <cmd>` | Run one command in the sandbox. Add `--json` for `{stdout, stderr, exit_code}`. |
+| `runtm-api session connect <id>` | Attach an interactive PTY (needs a TTY on stdin). |
 | `runtm-api session destroy <id>` | Tear down a sandbox. |
 | `runtm-api session git <id> <op>` | Run a git operation (commit, push, create_branch_and_pr, ...). |
 | `runtm-api template list` | List org templates (requires `--org` / `RUNTM_ORG_ID`). |
-| `runtm-api template get <id>` | Inspect one template. |
+| `runtm-api template get <id>` | Inspect one template, including its attached skills and build staleness. |
+| `runtm-api skills list --template <id>` | Skills a session from that template loads. |
+| `runtm-api scheduled-agents list` | Cron-driven agents, with `next_run_at`. |
+| `runtm-api scheduled-agents run-now <id>` | Fire one run immediately (works on disabled agents). |
 | `runtm-api deploy list` | List deployments. |
 | `runtm-api deploy get <id>` | Inspect one deployment. |
 | `runtm-api skills install` | Install the agent skill files into `~/.claude/skills/runtm/` and/or `~/.cursor/skills/runtm/`. |
 
 Run `runtm-api --help` or `runtm-api <command> --help` for full flag reference.
+
+### Running commands in a sandbox
+
+`session exec` prints the raw PTY stream by default, which merges stderr into stdout and carries the sandbox shell's startup banners. Pass `--json` whenever the output will be parsed:
+
+```bash
+runtm-api session exec <id> --json -- npm test
+# {"stdout": "...", "stderr": "...", "exit_code": 1}
+```
+
+The two streams are captured separately and PTY carriage returns are stripped. The process still exits with the remote exit code, so under `set -e` capture the output with `|| true` and read `exit_code` instead.
+
+Bash history expansion is disabled for the command in both modes, so a literal `!` in a heredoc, commit message, or regex reaches the sandbox intact. A paused sandbox is resumed automatically by `exec`, `connect`, and the file commands.
 
 ## Output and exit codes
 
@@ -103,11 +121,15 @@ Run `runtm-api --help` or `runtm-api <command> --help` for full flag reference.
 
 ## Agent skills
 
-The CLI ships with three SKILL.md files **embedded into the binary** ([`packages/agent/skills/`](https://github.com/runtm-ai/runtm/tree/main/packages/agent/skills)):
+The CLI ships with a set of SKILL.md files **embedded into the binary** ([`packages/agent/skills/`](https://github.com/runtm-ai/runtm/tree/main/packages/agent/skills)):
 
 - `SKILL.md` — command cheat sheet, auth, error recovery, trigger words (`runtm`, `runtime`).
 - `runtm-sessions.md` — multi-step workflows (launch from template, iterate, poll, open PR).
-- `runtm-templates.md` — discovering and inspecting org templates.
+- `runtm-templates.md` — discovering, inspecting, and verifying org templates.
+- `runtm-automation.md` — scheduled agents: cron syntax, `run-now`, debugging a schedule that didn't fire.
+- `runtm-integrations.md` — skills, MCP servers, tools, and how attachments reach a template.
+- `runtm-agents.md` — Slack/GitHub event-driven agents.
+- `runtm-debug.md` — inspecting a session when something is wrong.
 
 These are workflow recipes that teach the agent how to use the CLI. They are auto-installed by the one-liner installer when `~/.claude` or `~/.cursor` exists, and can be re-installed any time with:
 

--- a/docs/cloud-api/scheduled-agents/overview.mdx
+++ b/docs/cloud-api/scheduled-agents/overview.mdx
@@ -1,0 +1,167 @@
+---
+title: "Scheduled Agents"
+description: "Run an agent prompt on a cron schedule, and trigger a run on demand"
+---
+
+A scheduled agent pairs a cron expression with a prompt, an optional org template, and an optional Slack channel. Every tick launches a fresh session in autopilot mode and runs the prompt to completion.
+
+This is the *time*-driven automation primitive. For *event*-driven agents (a Slack mention, a GitHub issue), see [Slack](/cloud-api/integrations/slack/list-integrations) and [GitHub](/cloud-api/integrations/github-app/list-installations) integrations.
+
+## Endpoints
+
+| Method | Path | Scope |
+|--------|------|-------|
+| `GET` | `/api/v1/scheduled-agents` | `sessions:read` |
+| `GET` | `/api/v1/scheduled-agents/{agent_id}` | `sessions:read` |
+| `POST` | `/api/v1/scheduled-agents` | `sessions:write` + admin |
+| `PATCH` | `/api/v1/scheduled-agents/{agent_id}` | `sessions:write` + admin |
+| `POST` | `/api/v1/scheduled-agents/{agent_id}:run` | `sessions:write` + admin |
+| `DELETE` | `/api/v1/scheduled-agents/{agent_id}` | `sessions:write` + admin |
+
+All endpoints are organization-scoped and require the `X-Organization-Id` header. Mutations additionally require an **admin or owner** role, because a run costs compute and can post to a shared channel.
+
+## Validate before you enable
+
+`POST /{agent_id}:run` executes the identical code path the scheduled tick takes — same template resolution, same Slack target, same orchestrator call. A misconfigured agent fails there, synchronously, with the reason in the response, instead of silently at its scheduled hour.
+
+It works on **disabled** agents, which makes this the recommended order:
+
+```bash
+# 1. Create it switched off
+curl -X POST "https://app.runtm.com/api/cloud/v1/scheduled-agents" \
+  -H "Authorization: Bearer runtm_xxx" \
+  -H "X-Organization-Id: org_abc123" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "weekly-outbound",
+    "cron": "0 18 * * 1",
+    "prompt": "Build this week'"'"'s outbound lists and post them for approval",
+    "org_template_id": "tmpl_abc123",
+    "enabled": false
+  }'
+
+# 2. Prove it runs
+curl -X POST "https://app.runtm.com/api/cloud/v1/scheduled-agents/sa_9f3c/:run" \
+  -H "Authorization: Bearer runtm_xxx" \
+  -H "X-Organization-Id: org_abc123"
+
+# 3. Only then enable the schedule
+curl -X PATCH "https://app.runtm.com/api/cloud/v1/scheduled-agents/sa_9f3c" \
+  -H "Authorization: Bearer runtm_xxx" \
+  -H "X-Organization-Id: org_abc123" \
+  -H "Content-Type: application/json" \
+  -d '{"enabled": true}'
+```
+
+## Cron is 5 fields, in UTC
+
+Schedules run in `Etc/UTC`. There is no per-agent time zone, so a local time has to be converted by hand and revisited when daylight saving shifts.
+
+| Intent | Winter (UTC-8) | Summer (UTC-7) |
+|--------|---------------|----------------|
+| Daily 11:00 Pacific | `0 19 * * *` | `0 18 * * *` |
+| Mondays 11:00 Pacific | `0 19 * * 1` | `0 18 * * 1` |
+| Weekdays 09:00 Pacific | `0 17 * * 1-5` | `0 16 * * 1-5` |
+| Every hour | `0 * * * *` | `0 * * * *` |
+
+The `next_run_at` field on every response is derived from the cron, so it is the fastest way to confirm a schedule reads the way you meant. It is `null` for disabled agents, which have no scheduler job at all.
+
+<Note>
+`next_run_at` is advisory. Cloud Scheduler owns the real timing; this is a convenience so you don't need a separate lookup.
+</Note>
+
+## The scheduled agent object
+
+<ResponseField name="id" type="string">
+  Scheduled agent ID.
+</ResponseField>
+
+<ResponseField name="name" type="string">
+  Display name (1–128 characters).
+</ResponseField>
+
+<ResponseField name="cron" type="string">
+  5-field cron expression, evaluated in UTC.
+</ResponseField>
+
+<ResponseField name="prompt" type="string">
+  Prompt run on every tick.
+</ResponseField>
+
+<ResponseField name="org_template_id" type="string | null">
+  Org template the session launches from.
+</ResponseField>
+
+<ResponseField name="template_name" type="string | null">
+  Display name of that template.
+</ResponseField>
+
+<ResponseField name="agent" type="string">
+  Coding agent to run (default `claude-code`).
+</ResponseField>
+
+<ResponseField name="model" type="string | null">
+  Model override for the launched session.
+</ResponseField>
+
+<ResponseField name="enabled" type="boolean">
+  Whether the schedule is live. Disabling removes the scheduler job but keeps the agent.
+</ResponseField>
+
+<ResponseField name="slack_integration_id" type="string | null">
+  Slack integration posting the result. Travels with `slack_channel_id`; setting one without the other is a `400`.
+</ResponseField>
+
+<ResponseField name="slack_integration_name" type="string | null">
+  Display name of that integration.
+</ResponseField>
+
+<ResponseField name="slack_channel_id" type="string | null">
+  Channel the result is posted to.
+</ResponseField>
+
+<ResponseField name="last_run_at" type="string | null">
+  When the agent last ran, scheduled or manual.
+</ResponseField>
+
+<ResponseField name="last_session_id" type="string | null">
+  Session created by that run. Inspect it with [Get Session](/cloud-api/sessions/get).
+</ResponseField>
+
+<ResponseField name="next_run_at" type="string | null">
+  Next UTC fire time derived from the cron. `null` when disabled or when the expression can't be parsed.
+</ResponseField>
+
+<ResponseField name="created_at" type="string">
+  Creation timestamp.
+</ResponseField>
+
+<ResponseField name="updated_at" type="string | null">
+  Last modification timestamp.
+</ResponseField>
+
+## Errors
+
+| Status | Cause |
+|--------|-------|
+| `400` | Missing organization context, or `slack_integration_id` / `slack_channel_id` set without the other |
+| `403` | Caller is not an org admin or owner |
+| `404` | No such agent in this organization |
+| `422` | `cron` is not a 5-field expression |
+| `502` | `:run` — the launch itself failed; `detail` carries the reason |
+| `503` | Cloud Scheduler is not configured in this environment |
+
+<Tip>
+A `503` on create or update means the environment has no scheduler wired up. You can still create the agent with `"enabled": false` and drive it entirely with `:run`.
+</Tip>
+
+## CLI
+
+```bash
+runtm-api scheduled-agents list
+runtm-api scheduled-agents create --name weekly --cron '0 18 * * 1' --prompt '...' --disabled
+runtm-api scheduled-agents run-now <id>
+runtm-api scheduled-agents update <id> --enabled
+```
+
+See the [agent CLI reference](/cloud-api/agent-cli).

--- a/docs/cloud-api/scheduled-agents/run.mdx
+++ b/docs/cloud-api/scheduled-agents/run.mdx
@@ -1,0 +1,127 @@
+---
+title: "Run Scheduled Agent Now"
+api: "POST /api/v1/scheduled-agents/{agent_id}:run"
+description: "Fire one run immediately instead of waiting for the next cron tick"
+---
+
+Launches one run of a scheduled agent right now. Returns the created session ID.
+
+**Required scope:** `sessions:write` — the caller must also be an organization **admin or owner**.
+
+This executes the identical code path Cloud Scheduler triggers: same template resolution, same Slack target, same orchestrator call. That is the point — a broken agent fails here, synchronously, with the reason in the response, rather than silently at its scheduled hour.
+
+<Note>
+**Disabled agents run too.** Validating an agent before turning its schedule on is the main reason to use this endpoint, so `enabled` is not checked. The response echoes the agent's `enabled` state so you know which you triggered.
+</Note>
+
+The run stamps `last_run_at` and `last_session_id` exactly like a scheduled tick. It is recorded with a `manual` trigger for telemetry, but is otherwise indistinguishable from a scheduled run.
+
+## Path Parameters
+
+<ParamField path="agent_id" type="string" required>
+  The scheduled agent ID.
+</ParamField>
+
+## Headers
+
+<ParamField header="Authorization" type="string" required>
+  Bearer token. Example: `Bearer runtm_xxx`
+</ParamField>
+
+<ParamField header="X-Organization-Id" type="string" required>
+  Organization ID.
+</ParamField>
+
+## Response
+
+<ResponseField name="scheduled_agent_id" type="string">
+  The agent that was run.
+</ResponseField>
+
+<ResponseField name="session_id" type="string">
+  Session created by this run. Follow it with [Get Session](/cloud-api/sessions/get) or [Prompt History](/cloud-api/sessions/history).
+</ResponseField>
+
+<ResponseField name="enabled" type="boolean">
+  The agent's schedule state. A manual run works either way.
+</ResponseField>
+
+<ResponseField name="trigger" type="string">
+  Always `manual` for this endpoint.
+</ResponseField>
+
+<ResponseField name="triggered_at" type="string">
+  When the run was triggered.
+</ResponseField>
+
+## Errors
+
+| Status | Cause |
+|--------|-------|
+| `403` | Caller is not an org admin or owner |
+| `404` | No such agent in this organization |
+| `502` | The launch failed — `detail` carries the reason (unknown template, deleted Slack integration, sandbox capacity) |
+
+<RequestExample>
+```bash cURL
+curl -X POST "https://app.runtm.com/api/cloud/v1/scheduled-agents/sa_9f3c1a/:run" \
+  -H "Authorization: Bearer runtm_xxx" \
+  -H "X-Organization-Id: org_abc123"
+```
+
+```bash CLI
+runtm-api scheduled-agents run-now sa_9f3c1a
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://app.runtm.com/api/cloud/v1/scheduled-agents/sa_9f3c1a:run",
+    headers={
+        "Authorization": "Bearer runtm_xxx",
+        "X-Organization-Id": "org_abc123",
+    },
+)
+
+if response.status_code == 502:
+    # The scheduled tick would have failed the same way.
+    raise RuntimeError(response.json()["detail"])
+
+print(response.json()["session_id"])
+```
+
+```javascript JavaScript
+const response = await fetch(
+  "https://app.runtm.com/api/cloud/v1/scheduled-agents/sa_9f3c1a:run",
+  {
+    method: "POST",
+    headers: {
+      "Authorization": "Bearer runtm_xxx",
+      "X-Organization-Id": "org_abc123",
+    },
+  }
+);
+
+const data = await response.json();
+console.log(data.session_id);
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200
+{
+  "scheduled_agent_id": "sa_9f3c1a",
+  "session_id": "a6414511-4430-4e1f-8c51-8ea8824dadec",
+  "enabled": false,
+  "trigger": "manual",
+  "triggered_at": "2026-07-27T18:04:11Z"
+}
+```
+
+```json 502
+{
+  "detail": "Failed to launch scheduled agent: template 'gtm-machine' not found"
+}
+```
+</ResponseExample>

--- a/docs/cloud-api/sessions/lifecycle.mdx
+++ b/docs/cloud-api/sessions/lifecycle.mdx
@@ -13,6 +13,22 @@ single atomic call.
   Required scope for all four endpoints: `sessions:write`.
 </Info>
 
+<Note>
+**You usually don't need to resume explicitly.** Sessions auto-pause after
+roughly 20 minutes idle, and the endpoints you'd reach for next resume in
+place rather than rejecting:
+
+- the [file endpoints](/cloud-api/sessions/files-read) (read, write, list, search, upload, download, mkdir, rename, delete) and `run-server`
+- the terminal WebSocket, which backs `runtm-api session exec` and `session connect`
+- the prompt WebSocket
+- `POST /api/v2/sessions/{id}/start`
+
+The first call after a resume takes a few extra seconds. If the resume itself
+fails, those endpoints return `400` with the reason rather than a bare
+"not running". Call `resume` explicitly when you want to warm a sandbox ahead
+of time, or `pause` when you deliberately want to stop the clock.
+</Note>
+
 ---
 
 ## Pause Session

--- a/docs/cloud-api/templates/get.mdx
+++ b/docs/cloud-api/templates/get.mdx
@@ -4,9 +4,16 @@ api: "GET /api/org-templates/{template_id}"
 description: "Get detailed information about a specific template"
 ---
 
-Returns the full detail of an organization template including its configuration, build status, linked repos, and secret requirements.
+Returns the full detail of an organization template including its configuration, build status, linked repos, secret requirements, and the skills and MCP servers a session launched from it will load.
 
 **Required scope:** `templates:read`
+
+<Note>
+Two fields answer the questions that are easy to get silently wrong:
+
+- **`skills` / `mcp_servers`** — what sessions from this template actually load. An empty `skills` array means nothing is attached, however many skills exist in the org.
+- **`attachments_changed_since_build`** — `true` when those attachments changed after the snapshot was built, so the running image is behind the configuration. Trigger [a build](/cloud-api/templates/build) to catch it up.
+</Note>
 
 ## Path Parameters
 
@@ -68,6 +75,50 @@ Returns the full detail of an organization template including its configuration,
 
 <ResponseField name="build_status" type="string | null">
   Current build status (`pending`, `building`, `completed`, `failed`).
+</ResponseField>
+
+<ResponseField name="skills" type="array">
+  Skills a session launched from this template loads. Includes skills attached to the template directly, to one of its repos, and org-wide.
+
+  <Expandable title="properties">
+    <ResponseField name="id" type="string">
+      Directive ID. Fetch the body with `GET /api/agent-directives/{id}?include_content=true`.
+    </ResponseField>
+    <ResponseField name="type" type="string">
+      Always `skill_v0`.
+    </ResponseField>
+    <ResponseField name="name" type="string">
+      Skill slug.
+    </ResponseField>
+    <ResponseField name="display_name" type="string | null">
+      Human-readable name.
+    </ResponseField>
+    <ResponseField name="description" type="string | null">
+      Short description.
+    </ResponseField>
+    <ResponseField name="content_hash" type="string">
+      Hash of the skill body, so you can tell whether the content changed.
+    </ResponseField>
+    <ResponseField name="attached_via" type="string">
+      The narrowest scope through which the skill reaches this template — `template`, `repo`, or `all`. This is the scope to change if you want to detach it.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="mcp_servers" type="array">
+  MCP servers a session launched from this template loads. Same shape as `skills`, with `type` set to `mcp_server_v0`.
+</ResponseField>
+
+<ResponseField name="attachments_changed_since_build" type="boolean">
+  `true` when the attached skills / MCP servers changed after the snapshot was built, so sessions still boot with the previously baked set. Rebuild with `POST /api/org-templates/{template_id}/build`.
+</ResponseField>
+
+<ResponseField name="directive_manifest_hash" type="string | null">
+  Hash of the currently-attached directive set.
+</ResponseField>
+
+<ResponseField name="last_built_directive_manifest_hash" type="string | null">
+  Directive manifest hash baked into the current snapshot. `attachments_changed_since_build` is the comparison of these two.
 </ResponseField>
 
 <RequestExample>
@@ -139,7 +190,22 @@ console.log(`${data.display_name} (build: ${data.build_status})`);
     }
   ],
   "build_spec": null,
-  "workdir": "/home/user/project"
+  "workdir": "/home/user/project",
+  "skills": [
+    {
+      "id": "dir_9f3c1a",
+      "type": "skill_v0",
+      "name": "deploy-checks",
+      "display_name": "Pre-deploy checks",
+      "description": "Run the release checklist before shipping",
+      "content_hash": "9c1185a5c5e9fc54612808977ee8f548b2258d31",
+      "attached_via": "template"
+    }
+  ],
+  "mcp_servers": [],
+  "attachments_changed_since_build": true,
+  "directive_manifest_hash": "b1946ac92492d2347c6235b4d2611184",
+  "last_built_directive_manifest_hash": "5d41402abc4b2a76b9719d911017c592"
 }
 ```
 </ResponseExample>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -217,6 +217,13 @@
       ]
     },
     {
+      "group": "Scheduled Agents",
+      "pages": [
+        "cloud-api/scheduled-agents/overview",
+        "cloud-api/scheduled-agents/run"
+      ]
+    },
+    {
       "group": "Secrets",
       "pages": [
         "cloud-api/secrets/resolved",

--- a/packages/agent/internal/cmd/directives_cmd.go
+++ b/packages/agent/internal/cmd/directives_cmd.go
@@ -34,7 +34,10 @@ Org-scoped: requires an org-scoped API key (--org cannot substitute for one).
 Writes need the context:write scope on the key.`,
 	}
 	cmd.AddCommand(
-		newDirectiveList(rt, "MCP server", "mcp_server"),
+		// "mcp" is the backend's type_family. Sending the type name instead
+		// ("mcp_server") falls through to no type filter at all, which quietly
+		// mixes skills into the results.
+		newDirectiveList(rt, "MCP server", "mcp"),
 		newDirectiveGet(rt, "MCP server"),
 		newMcpCreate(rt),
 		newMcpUpdate(rt),
@@ -680,13 +683,23 @@ func newToolDelete(rt *Runtime) *cobra.Command {
 // backend query value ("skill", "mcp_server").
 func newDirectiveList(rt *Runtime, singular, typeFamily string) *cobra.Command {
 	var (
+		templateID     string
+		repo           string
 		pageSize       int
 		pageToken      string
 		includeContent bool
 	)
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: fmt.Sprintf("List %ss", singular),
+		Short: fmt.Sprintf("List %ss (--template to scope to one template)", singular),
+		Long: fmt.Sprintf(`List the %ss in your org.
+
+  --template <id>   only the %ss a session from that template loads.
+                    Equivalent to 'runtm-api template mcp <id>'.
+  --repo owner/name only the %ss attached to that repo.
+
+Both scoped forms include org-wide items (those attached with --all).`,
+			singular, singular, singular),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, _, err := requireOrgClient(rt, singular+"s")
 			if err != nil {
@@ -694,6 +707,12 @@ func newDirectiveList(rt *Runtime, singular, typeFamily string) *cobra.Command {
 			}
 			q := listQuery(pageSize, pageToken)
 			q.Set("type_family", typeFamily)
+			if templateID != "" {
+				q.Set("template_id", templateID)
+			}
+			if repo != "" {
+				q.Set("repo_full_name", repo)
+			}
 			if includeContent {
 				q.Set("include_content", "true")
 			}
@@ -701,6 +720,8 @@ func newDirectiveList(rt *Runtime, singular, typeFamily string) *cobra.Command {
 			return runJSON(rt, resp, err)
 		},
 	}
+	cmd.Flags().StringVar(&templateID, "template", "", fmt.Sprintf("Only %ss a session from this template loads", singular))
+	cmd.Flags().StringVar(&repo, "repo", "", fmt.Sprintf("Only %ss attached to this repo (owner/name)", singular))
 	cmd.Flags().IntVar(&pageSize, "page-size", 0, "Results per page (1-100)")
 	cmd.Flags().StringVar(&pageToken, "page-token", "", "Pagination cursor")
 	cmd.Flags().BoolVar(&includeContent, "include-content", false, "Include each item's content payload")

--- a/packages/agent/internal/cmd/root.go
+++ b/packages/agent/internal/cmd/root.go
@@ -60,6 +60,7 @@ Docs: https://docs.runtm.com`,
 		NewMcpCommand(rt),
 		NewToolsCommand(rt),
 		NewAgentsCommand(rt),
+		NewScheduledAgentsCommand(rt),
 	)
 	return rootBuild{cmd: root, rt: rt}
 }

--- a/packages/agent/internal/cmd/scheduled_agents_cmd.go
+++ b/packages/agent/internal/cmd/scheduled_agents_cmd.go
@@ -1,0 +1,327 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/spf13/cobra"
+)
+
+// NewScheduledAgentsCommand returns `runtm-api scheduled-agents` — cron-driven
+// agents, the automation primitive.
+//
+// Distinct from `runtm-api agents`, which manages Slack/GitHub integration
+// agents that fire on an *event*. These fire on a *schedule*.
+//
+// Routes (all org-scoped, under /api/v1/scheduled-agents):
+//
+//	GET    ""                sessions:read    (list)
+//	GET    "/{id}"           sessions:read    (get)
+//	POST   ""                sessions:write   (create, admin)
+//	PATCH  "/{id}"           sessions:write   (update, admin)
+//	POST   "/{id}:run"       sessions:write   (run now, admin)
+//	DELETE "/{id}"           sessions:write   (delete, admin)
+//
+// `run-now` exists so a schedule can be validated on demand: it executes the
+// identical path the cron tick takes, so a bad template or missing Slack
+// target fails in front of you instead of silently at the scheduled hour.
+func NewScheduledAgentsCommand(rt *Runtime) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "scheduled-agents",
+		Aliases: []string{"scheduled-agent", "schedules", "cron"},
+		Short:   "Cron-driven agents: run a prompt on a schedule",
+		Long: `Manage agents that launch a session and run a prompt on a cron schedule.
+
+Each agent pairs a 5-field UTC cron with a prompt, an optional org template,
+and an optional Slack channel to post the result to. Enabling one creates the
+schedule; disabling removes it.
+
+Always validate with 'run-now' before enabling. It runs the same code path the
+scheduled tick does — same template resolution, same Slack target — so a
+misconfiguration surfaces immediately rather than at 11am in a shared channel.
+Disabled agents can be run this way too, which is the recommended order:
+create disabled, run-now, then enable.
+
+Cron is 5 fields in UTC (minute hour day-of-month month day-of-week). 11am
+Pacific is '0 18 * * *' in winter and '0 17 * * *' during daylight time --
+there is no per-agent time zone, so pick the one that matches now and revisit
+at the DST boundary.
+
+Org-scoped: requires an org-scoped API key. Writes (create/update/delete/
+run-now) need admin or owner role.
+
+See https://docs.runtm.com/cloud-api/scheduled-agents for the full schemas.`,
+	}
+	cmd.AddCommand(
+		newScheduledAgentList(rt),
+		newScheduledAgentGet(rt),
+		newScheduledAgentCreate(rt),
+		newScheduledAgentUpdate(rt),
+		newScheduledAgentRunNow(rt),
+		newScheduledAgentDelete(rt),
+	)
+	return cmd
+}
+
+const scheduledAgentsPath = "/v1/scheduled-agents"
+
+func scheduledAgentPath(id string) string {
+	return scheduledAgentsPath + "/" + url.PathEscape(id)
+}
+
+// --- list / get -----------------------------------------------------------
+
+func newScheduledAgentList(rt *Runtime) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List scheduled agents (GET /api/v1/scheduled-agents)",
+		Long: `Lists every scheduled agent in the org. Each entry carries 'next_run_at'
+(the next UTC fire time, null when disabled) alongside 'last_run_at' and
+'last_session_id', so you can tell at a glance whether a schedule is live and
+when it last did anything.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _, err := requireOrgClient(rt, "scheduled agents")
+			if err != nil {
+				return err
+			}
+			resp, err := c.Get(scheduledAgentsPath, nil)
+			return runJSON(rt, resp, err)
+		},
+	}
+}
+
+func newScheduledAgentGet(rt *Runtime) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <agent_id>",
+		Short: "Get one scheduled agent (GET /api/v1/scheduled-agents/{id})",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _, err := requireOrgClient(rt, "scheduled agents")
+			if err != nil {
+				return err
+			}
+			resp, err := c.Get(scheduledAgentPath(args[0]), nil)
+			return runJSON(rt, resp, err)
+		},
+	}
+}
+
+// --- create / update ------------------------------------------------------
+
+// scheduledAgentFlags is the shared flag set for create and update. Update
+// only sends the flags that were explicitly passed, so a partial edit never
+// clobbers fields it didn't mention.
+type scheduledAgentFlags struct {
+	name             string
+	cron             string
+	prompt           string
+	template         string
+	agent            string
+	model            string
+	enabled          bool
+	disabled         bool
+	slackIntegration string
+	slackChannel     string
+}
+
+func (f *scheduledAgentFlags) register(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.name, "name", "", "Display name")
+	cmd.Flags().StringVar(&f.cron, "cron", "", "5-field UTC cron, e.g. '0 18 * * 1' (Mondays 11am PT in winter)")
+	cmd.Flags().StringVar(&f.prompt, "prompt", "", "Prompt run on every tick")
+	cmd.Flags().StringVar(&f.template, "template", "", "Org template id the session launches from")
+	cmd.Flags().StringVar(&f.agent, "agent", "", "Coding agent (claude-code, codex, …)")
+	cmd.Flags().StringVar(&f.model, "model", "", "Model for the launched session")
+	cmd.Flags().BoolVar(&f.enabled, "enabled", false, "Create/enable the schedule")
+	cmd.Flags().BoolVar(&f.disabled, "disabled", false, "Turn the schedule off (keeps the agent)")
+	cmd.Flags().StringVar(&f.slackIntegration, "slack-integration", "", "Slack integration id to post results as (requires --slack-channel)")
+	cmd.Flags().StringVar(&f.slackChannel, "slack-channel", "", "Slack channel id to post results to (requires --slack-integration)")
+}
+
+// body collects the flags the user actually set. When onlyChanged is true
+// (update) untouched flags are omitted entirely.
+func (f *scheduledAgentFlags) body(cmd *cobra.Command, onlyChanged bool) (map[string]any, error) {
+	if cmd.Flags().Changed("enabled") && cmd.Flags().Changed("disabled") {
+		return nil, fmt.Errorf("--enabled and --disabled are mutually exclusive")
+	}
+	// The Slack integration and channel travel together; the API rejects one
+	// without the other, so catch it here with a clearer message.
+	if cmd.Flags().Changed("slack-integration") != cmd.Flags().Changed("slack-channel") {
+		return nil, fmt.Errorf("--slack-integration and --slack-channel must be passed together")
+	}
+
+	body := map[string]any{}
+	set := func(flag, key string, value any) {
+		if !onlyChanged || cmd.Flags().Changed(flag) {
+			body[key] = value
+		}
+	}
+	set("name", "name", f.name)
+	set("cron", "cron", f.cron)
+	set("prompt", "prompt", f.prompt)
+
+	if cmd.Flags().Changed("template") {
+		body["org_template_id"] = f.template
+	}
+	if cmd.Flags().Changed("agent") {
+		body["agent"] = f.agent
+	}
+	if cmd.Flags().Changed("model") {
+		body["model"] = f.model
+	}
+	if cmd.Flags().Changed("enabled") {
+		body["enabled"] = f.enabled
+	}
+	if cmd.Flags().Changed("disabled") {
+		body["enabled"] = !f.disabled
+	}
+	if cmd.Flags().Changed("slack-integration") {
+		body["slack_integration_id"] = f.slackIntegration
+		body["slack_channel_id"] = f.slackChannel
+	}
+	return body, nil
+}
+
+func newScheduledAgentCreate(rt *Runtime) *cobra.Command {
+	f := &scheduledAgentFlags{}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a scheduled agent (POST /api/v1/scheduled-agents)",
+		Long: `Create a cron-driven agent. --name, --cron, and --prompt are required.
+
+Agents are created enabled unless you pass --disabled. The safer order is to
+create disabled, verify with 'run-now', then enable:
+
+  runtm-api scheduled-agents create --name weekly-outbound --disabled \
+    --cron '0 18 * * 1' --template <template_id> \
+    --prompt 'Build this week's outbound lists and post them for approval'
+  runtm-api scheduled-agents run-now <id>          # same path the tick takes
+  runtm-api scheduled-agents update <id> --enabled
+
+Pass --slack-integration and --slack-channel together to post each run's
+result to a channel. Requires admin or owner role.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if f.name == "" || f.cron == "" || f.prompt == "" {
+				return fmt.Errorf("--name, --cron, and --prompt are required")
+			}
+			body, err := f.body(cmd, false)
+			if err != nil {
+				return err
+			}
+			// Omit optional fields the user never set so the server defaults
+			// apply (agent defaults to claude-code, model to the org default).
+			for _, key := range []string{"org_template_id", "agent", "model"} {
+				if v, ok := body[key]; ok && v == "" {
+					delete(body, key)
+				}
+			}
+			c, _, err := requireOrgClient(rt, "scheduled agents")
+			if err != nil {
+				return err
+			}
+			resp, err := c.PostJSON(scheduledAgentsPath, body)
+			return runJSON(rt, resp, err)
+		},
+	}
+	f.register(cmd)
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("cron")
+	_ = cmd.MarkFlagRequired("prompt")
+	return cmd
+}
+
+func newScheduledAgentUpdate(rt *Runtime) *cobra.Command {
+	f := &scheduledAgentFlags{}
+	cmd := &cobra.Command{
+		Use:   "update <agent_id>",
+		Short: "Update a scheduled agent (PATCH /api/v1/scheduled-agents/{id})",
+		Long: `Update a scheduled agent. Only the flags you pass are changed.
+
+  runtm-api scheduled-agents update <id> --enabled
+  runtm-api scheduled-agents update <id> --cron '0 17 * * 1'   # DST shift
+  runtm-api scheduled-agents update <id> --disabled            # stop the schedule
+
+Requires admin or owner role.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			body, err := f.body(cmd, true)
+			if err != nil {
+				return err
+			}
+			if len(body) == 0 {
+				return fmt.Errorf("pass at least one field to update (--name, --cron, --prompt, --template, --agent, --model, --enabled/--disabled, --slack-integration + --slack-channel)")
+			}
+			c, _, err := requireOrgClient(rt, "scheduled agents")
+			if err != nil {
+				return err
+			}
+			resp, err := c.PatchJSON(scheduledAgentPath(args[0]), body)
+			return runJSON(rt, resp, err)
+		},
+	}
+	f.register(cmd)
+	return cmd
+}
+
+// --- run-now --------------------------------------------------------------
+
+func newScheduledAgentRunNow(rt *Runtime) *cobra.Command {
+	return &cobra.Command{
+		Use:     "run-now <agent_id>",
+		Aliases: []string{"run", "trigger"},
+		Short:   "Fire one run immediately (POST /api/v1/scheduled-agents/{id}:run)",
+		Long: `Run the agent now instead of waiting for the next tick.
+
+This is the same code path Cloud Scheduler triggers — same template lookup,
+same Slack target, same orchestrator call — so it is the way to prove a
+schedule works before trusting it. Disabled agents run too, which is what
+makes it useful for validating an agent before enabling it.
+
+Returns the launched session_id. Follow the run with:
+  runtm-api session get <session_id>
+  runtm-api session history <session_id>
+
+A run costs compute and can post to a shared channel, so this requires admin
+or owner role.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _, err := requireOrgClient(rt, "scheduled agents")
+			if err != nil {
+				return err
+			}
+			// Custom method (AIP-136): the colon suffix distinguishes an action
+			// from the resource itself.
+			resp, err := c.PostJSON(scheduledAgentPath(args[0])+":run", map[string]any{})
+			return runJSON(rt, resp, err)
+		},
+	}
+}
+
+// --- delete ---------------------------------------------------------------
+
+func newScheduledAgentDelete(rt *Runtime) *cobra.Command {
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "delete <agent_id>",
+		Short: "Delete a scheduled agent (DELETE /api/v1/scheduled-agents/{id})",
+		Long: `Permanently delete the agent and its schedule. To stop a schedule while
+keeping the agent, use 'update <id> --disabled' instead.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !yes {
+				rt.WriteObject(map[string]any{
+					"error": "Destructive operation requires --yes to confirm.",
+					"hint":  "To stop the schedule without deleting, run `scheduled-agents update <id> --disabled`.",
+				})
+				return errSilent
+			}
+			c, _, err := requireOrgClient(rt, "scheduled agents")
+			if err != nil {
+				return err
+			}
+			resp, err := c.Delete(scheduledAgentPath(args[0]))
+			return runJSON(rt, resp, err)
+		},
+	}
+	cmd.Flags().BoolVar(&yes, "yes", false, "Confirm deletion")
+	return cmd
+}

--- a/packages/agent/internal/cmd/scheduled_agents_cmd_test.go
+++ b/packages/agent/internal/cmd/scheduled_agents_cmd_test.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// findSub returns the named subcommand, or fails the test.
+func findSub(t *testing.T, parent *cobra.Command, name string) *cobra.Command {
+	t.Helper()
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	t.Fatalf("%s has no %q subcommand", parent.Name(), name)
+	return nil
+}
+
+func TestScheduledAgentsIsRegisteredOnRoot(t *testing.T) {
+	root := NewRootCommand()
+	cmd := findSub(t, root, "scheduled-agents")
+	// The automation primitive is easy to look for under several names.
+	for _, alias := range []string{"schedules", "cron"} {
+		if !cmd.HasAlias(alias) {
+			t.Errorf("scheduled-agents should answer to %q", alias)
+		}
+	}
+}
+
+func TestScheduledAgentsSubcommands(t *testing.T) {
+	cmd := NewScheduledAgentsCommand(newTestRuntime())
+	for _, name := range []string{"list", "get", "create", "update", "run-now", "delete"} {
+		findSub(t, cmd, name)
+	}
+}
+
+func TestRunNowAliases(t *testing.T) {
+	runNow := findSub(t, NewScheduledAgentsCommand(newTestRuntime()), "run-now")
+	for _, alias := range []string{"run", "trigger"} {
+		if !runNow.HasAlias(alias) {
+			t.Errorf("run-now should answer to %q", alias)
+		}
+	}
+}
+
+func TestScheduledAgentPath(t *testing.T) {
+	if got := scheduledAgentPath("abc-123"); got != "/v1/scheduled-agents/abc-123" {
+		t.Errorf("path = %q", got)
+	}
+	// Ids land in the URL path; they must be escaped.
+	if got := scheduledAgentPath("a b/c"); !strings.Contains(got, "a%20b%2Fc") {
+		t.Errorf("path = %q, want the id escaped", got)
+	}
+}
+
+// --- flag → request body --------------------------------------------------
+
+// bodyFor parses argv against a scheduled-agent flag set and returns the
+// request body it would send.
+func bodyFor(t *testing.T, argv []string, onlyChanged bool) map[string]any {
+	t.Helper()
+	f := &scheduledAgentFlags{}
+	cmd := &cobra.Command{Use: "x", RunE: func(*cobra.Command, []string) error { return nil }}
+	f.register(cmd)
+	if err := cmd.Flags().Parse(argv); err != nil {
+		t.Fatalf("flag parse: %v", err)
+	}
+	body, err := f.body(cmd, onlyChanged)
+	if err != nil {
+		t.Fatalf("body: %v", err)
+	}
+	return body
+}
+
+func TestUpdateSendsOnlyChangedFields(t *testing.T) {
+	// A partial edit must not clobber the prompt or cron it never mentioned.
+	body := bodyFor(t, []string{"--enabled"}, true)
+	if len(body) != 1 {
+		t.Fatalf("body = %#v, want only enabled", body)
+	}
+	if body["enabled"] != true {
+		t.Errorf("enabled = %v, want true", body["enabled"])
+	}
+}
+
+func TestDisabledFlagSetsEnabledFalse(t *testing.T) {
+	body := bodyFor(t, []string{"--disabled"}, true)
+	if body["enabled"] != false {
+		t.Errorf("enabled = %v, want false", body["enabled"])
+	}
+}
+
+func TestTemplateFlagMapsToOrgTemplateID(t *testing.T) {
+	body := bodyFor(t, []string{"--template", "tpl-1"}, true)
+	if body["org_template_id"] != "tpl-1" {
+		t.Errorf("org_template_id = %v", body["org_template_id"])
+	}
+}
+
+func TestSlackTargetFlagsTravelTogether(t *testing.T) {
+	f := &scheduledAgentFlags{}
+	cmd := &cobra.Command{Use: "x"}
+	f.register(cmd)
+	if err := cmd.Flags().Parse([]string{"--slack-channel", "C123"}); err != nil {
+		t.Fatalf("flag parse: %v", err)
+	}
+	if _, err := f.body(cmd, true); err == nil {
+		t.Fatal("expected an error when only one half of the Slack target is set")
+	}
+}
+
+func TestSlackTargetBothSet(t *testing.T) {
+	body := bodyFor(t, []string{"--slack-integration", "i-1", "--slack-channel", "C123"}, true)
+	if body["slack_integration_id"] != "i-1" || body["slack_channel_id"] != "C123" {
+		t.Errorf("slack target = %#v", body)
+	}
+}
+
+func TestEnabledAndDisabledAreMutuallyExclusive(t *testing.T) {
+	f := &scheduledAgentFlags{}
+	cmd := &cobra.Command{Use: "x"}
+	f.register(cmd)
+	if err := cmd.Flags().Parse([]string{"--enabled", "--disabled"}); err != nil {
+		t.Fatalf("flag parse: %v", err)
+	}
+	if _, err := f.body(cmd, true); err == nil {
+		t.Fatal("expected an error for --enabled with --disabled")
+	}
+}
+
+func TestCreateSendsRequiredFieldsEvenWhenUnchanged(t *testing.T) {
+	body := bodyFor(t, []string{"--name", "weekly", "--cron", "0 18 * * 1", "--prompt", "go"}, false)
+	for _, key := range []string{"name", "cron", "prompt"} {
+		if _, ok := body[key]; !ok {
+			t.Errorf("create body missing %q: %#v", key, body)
+		}
+	}
+}
+
+// --- skills / mcp scoping -------------------------------------------------
+
+func TestSkillsListAcceptsTemplateScope(t *testing.T) {
+	// The whole point: someone reaching for `skills list` should be able to
+	// ask the template question without knowing `template skills` exists.
+	list := findSub(t, NewSkillsCommand(newTestRuntime()), "list")
+	if list.Flags().Lookup("template") == nil {
+		t.Fatal("skills list must accept --template")
+	}
+	if list.Flags().Lookup("repo") == nil {
+		t.Fatal("skills list must accept --repo")
+	}
+}
+
+func TestMcpListAcceptsTemplateScope(t *testing.T) {
+	list := findSub(t, NewMcpCommand(newTestRuntime()), "list")
+	if list.Flags().Lookup("template") == nil {
+		t.Fatal("mcp list must accept --template")
+	}
+}

--- a/packages/agent/internal/cmd/session_terminal_cmd.go
+++ b/packages/agent/internal/cmd/session_terminal_cmd.go
@@ -302,21 +302,95 @@ func findExecEnd(buf []byte, pid string) (output []byte, code int, ok bool) {
 	return buf[:m[0]], code, true
 }
 
+// splitExecStreams cuts captured output at the pid-bound mid sentinel that
+// --json mode prints between stdout and the replayed stderr file. Without the
+// marker (a shell too old to have run the split payload, or a command that
+// killed its own shell) everything is treated as stdout.
+func splitExecStreams(output []byte, pid string) (stdout, stderr []byte) {
+	midRe := regexp.MustCompile(`__RUNTM_` + regexp.QuoteMeta(pid) + `_M\r?\n`)
+	m := midRe.FindIndex(output)
+	if m == nil {
+		return output, nil
+	}
+	return output[:m[0]], output[m[1]:]
+}
+
+// execPayload builds the one-line shell program the PTY runs.
+//
+// Three things it has to get right:
+//
+//  1. `set +H` disables bash history expansion. E2B's pty.create() always
+//     starts bash, and an interactive bash expands `!` against history as the
+//     line is read — before the command ever runs. So a literal `!` in a
+//     heredoc, a commit message, or a regex silently rewrites the command.
+//     The option is probed in a subshell first because `set +H` is an
+//     *unrecoverable* error in shells that lack it (dash aborts on the spot,
+//     before a trailing `|| true` can run); the subshell contains that.
+//
+//  2. The command runs in a subshell, so `exit 3` (or anything that calls
+//     `exit`) yields an exit code instead of killing the wrapper before it can
+//     print the end marker — which surfaced as "connection closed before the
+//     command completed" with the output lost.
+//
+//  3. When splitStreams is set, stderr is redirected to a pid-scoped temp file
+//     and replayed after a mid sentinel, which is what lets --json hand back
+//     stdout and stderr separately. Otherwise the two interleave as before.
+func execPayload(cmdLine string, splitStreams bool) string {
+	const prelude = "if (set +H) 2>/dev/null; then set +H; fi; "
+
+	if !splitStreams {
+		return prelude + fmt.Sprintf(
+			"printf '__RUNTM_%%d_S\\n' \"$$\"; ( %s ); __rc=$?; printf '__RUNTM_%%d_E%%d\\n' \"$$\" \"$__rc\"; exit\n",
+			cmdLine,
+		)
+	}
+	// Order matters: print the start marker, run with stderr captured, then
+	// mid marker, then replay stderr, then the exit marker carrying $?.
+	return prelude + fmt.Sprintf(
+		"__errf=$(mktemp 2>/dev/null || echo /tmp/runtm-exec-$$.err); "+
+			"printf '__RUNTM_%%d_S\\n' \"$$\"; "+
+			"( %s ) 2>\"$__errf\"; __rc=$?; "+
+			"printf '__RUNTM_%%d_M\\n' \"$$\"; "+
+			"cat \"$__errf\" 2>/dev/null; rm -f \"$__errf\"; "+
+			"printf '__RUNTM_%%d_E%%d\\n' \"$$\" \"$__rc\"; exit\n",
+		cmdLine,
+	)
+}
+
+// normalizeExecOutput turns PTY line endings into plain newlines. The remote
+// shell runs on a PTY, so every "\n" arrives as "\r\n" — fine to print, but it
+// corrupts JSON string values and breaks callers that compare exact output.
+func normalizeExecOutput(b []byte) string {
+	return strings.ReplaceAll(string(stripLeadingNewline(b)), "\r\n", "\n")
+}
+
 func newSessionExec(rt *Runtime) *cobra.Command {
-	var timeoutSec int
+	var (
+		timeoutSec int
+		asJSON     bool
+	)
 	cmd := &cobra.Command{
 		Use:   "exec <session_id> -- <command> [args...]",
 		Short: "Run one command in a session over the terminal WebSocket",
 		Long: `Runs a single command inside the session's sandbox using the terminal
-WebSocket, streams its output to stdout, and exits with the command's exit
-code. A throwaway PTY is used so it never disturbs your interactive terminals.
+WebSocket, prints its output, and exits with the command's exit code. A
+throwaway PTY is used so it never disturbs your interactive terminals.
 
 Put the command after '--' so its flags are not parsed by runtm-api:
   runtm-api session exec <id> -- ls -la /workspace
   runtm-api session exec <id> -- "npm test"
 
-Output is the raw PTY stream and may contain minor terminal formatting. Scope
-required: sessions:terminal.`,
+--json emits {"stdout": "...", "stderr": "...", "exit_code": N} instead of the
+raw stream, with the two streams captured separately and PTY carriage returns
+stripped. Use it whenever the output is going to be parsed rather than read;
+the default merged stream also carries shell startup noise that otherwise has
+to be filtered out. The process still exits with the remote exit code, so
+check exit_code or the process status, not both.
+
+Bash history expansion is disabled for the command, so '!' is safe to use in
+heredocs, commit messages, and regexes.
+
+A paused sandbox is resumed automatically. Scope required: sessions:terminal.`,
 		Args: cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			sessionID := args[0]
@@ -349,10 +423,7 @@ required: sessions:terminal.`,
 			// One command line: print start marker, run, print end marker + $?,
 			// then exit so the server tears the PTY down. Markers use $$ so the
 			// echoed input can't collide with the printed values.
-			payload := fmt.Sprintf(
-				"printf '__RUNTM_%%d_S\\n' \"$$\"; %s; __rc=$?; printf '__RUNTM_%%d_E%%d\\n' \"$$\" \"$__rc\"; exit\n",
-				cmdLine,
-			)
+			payload := execPayload(cmdLine, asJSON)
 
 			var (
 				buf     []byte
@@ -409,7 +480,16 @@ required: sessions:terminal.`,
 				}
 				if started {
 					if output, code, ok := findExecEnd(buf, pid); ok {
-						os.Stdout.Write(stripLeadingNewline(output))
+						if asJSON {
+							stdout, stderr := splitExecStreams(output, pid)
+							rt.WriteObject(map[string]any{
+								"stdout":    normalizeExecOutput(stdout),
+								"stderr":    normalizeExecOutput(stderr),
+								"exit_code": code,
+							})
+						} else {
+							os.Stdout.Write(stripLeadingNewline(output))
+						}
 						if code != 0 {
 							return &exitCodeError{code: code}
 						}
@@ -420,6 +500,7 @@ required: sessions:terminal.`,
 		},
 	}
 	cmd.Flags().IntVar(&timeoutSec, "timeout", 0, "Abort if the command runs longer than N seconds (0 = no timeout)")
+	cmd.Flags().BoolVar(&asJSON, "json", false, `Emit {"stdout","stderr","exit_code"} with the streams captured separately`)
 	return cmd
 }
 

--- a/packages/agent/internal/cmd/session_terminal_cmd_test.go
+++ b/packages/agent/internal/cmd/session_terminal_cmd_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -123,5 +124,126 @@ func TestStripLeadingNewline(t *testing.T) {
 		if got := string(stripLeadingNewline([]byte(in))); got != want {
 			t.Errorf("stripLeadingNewline(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+// --- --json stream splitting ---------------------------------------------
+
+func TestSplitExecStreams(t *testing.T) {
+	out, errOut := splitExecStreams([]byte("on stdout\r\n__RUNTM_4242_M\r\non stderr\r\n"), "4242")
+	if got := string(out); got != "on stdout\r\n" {
+		t.Errorf("stdout = %q, want %q", got, "on stdout\r\n")
+	}
+	if got := string(errOut); got != "on stderr\r\n" {
+		t.Errorf("stderr = %q, want %q", got, "on stderr\r\n")
+	}
+}
+
+func TestSplitExecStreams_EmptyStderr(t *testing.T) {
+	out, errOut := splitExecStreams([]byte("only stdout\r\n__RUNTM_7_M\r\n"), "7")
+	if string(out) != "only stdout\r\n" {
+		t.Errorf("stdout = %q", string(out))
+	}
+	if len(errOut) != 0 {
+		t.Errorf("stderr = %q, want empty", string(errOut))
+	}
+}
+
+func TestSplitExecStreams_NoMarkerIsAllStdout(t *testing.T) {
+	// A shell that died before printing the mid marker: don't lose the output.
+	out, errOut := splitExecStreams([]byte("partial output\r\n"), "4242")
+	if string(out) != "partial output\r\n" {
+		t.Errorf("stdout = %q", string(out))
+	}
+	if errOut != nil {
+		t.Errorf("stderr = %q, want nil", string(errOut))
+	}
+}
+
+func TestSplitExecStreams_WrongPidIgnored(t *testing.T) {
+	out, errOut := splitExecStreams([]byte("a\r\n__RUNTM_999_M\r\nb\r\n"), "4242")
+	if string(out) != "a\r\n__RUNTM_999_M\r\nb\r\n" {
+		t.Errorf("stdout = %q, want the whole buffer", string(out))
+	}
+	if errOut != nil {
+		t.Errorf("stderr = %q, want nil", string(errOut))
+	}
+}
+
+func TestNormalizeExecOutput(t *testing.T) {
+	// PTY line endings must not leak into JSON string values.
+	cases := map[string]string{
+		"\r\nline one\r\nline two\r\n": "line one\nline two\n",
+		"no trailing":                  "no trailing",
+		"":                             "",
+	}
+	for in, want := range cases {
+		if got := normalizeExecOutput([]byte(in)); got != want {
+			t.Errorf("normalizeExecOutput(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// --- payload construction -------------------------------------------------
+
+func TestExecPayloadDisablesHistoryExpansion(t *testing.T) {
+	// Bash history expansion rewrites '!' before the command runs, which has
+	// silently corrupted heredocs and commit messages. The subshell probe
+	// matters: `set +H` aborts dash outright, so `set +H || true` would take
+	// the shell down before the fallback could run.
+	for _, split := range []bool{false, true} {
+		payload := execPayload("echo hi", split)
+		if !strings.HasPrefix(payload, "if (set +H) 2>/dev/null; then set +H; fi; ") {
+			t.Errorf("split=%v: payload must start by disabling history expansion, got %q", split, payload)
+		}
+	}
+}
+
+func TestExecPayloadRunsCommandInSubshell(t *testing.T) {
+	// A bare `exit 3` in the command used to kill the wrapper shell before it
+	// printed the end marker, losing both the output and the exit code.
+	for _, split := range []bool{false, true} {
+		payload := execPayload("exit 3", split)
+		if !strings.Contains(payload, "( exit 3 )") {
+			t.Errorf("split=%v: command must run in a subshell, got %q", split, payload)
+		}
+	}
+}
+
+func TestExecPayloadMergedStreamsByDefault(t *testing.T) {
+	payload := execPayload("npm test", false)
+	if strings.Contains(payload, "_M\\n") {
+		t.Error("default payload must not emit the stdout/stderr mid marker")
+	}
+	if strings.Contains(payload, "mktemp") {
+		t.Error("default payload must not redirect stderr to a file")
+	}
+	if !strings.Contains(payload, "npm test") {
+		t.Error("payload must contain the command")
+	}
+}
+
+func TestExecPayloadSplitStreams(t *testing.T) {
+	payload := execPayload("npm test", true)
+	for _, want := range []string{
+		`( npm test ) 2>"$__errf"`, // stderr captured, not interleaved
+		`_M\n`,                     // mid marker separates the streams
+		`cat "$__errf"`,            // stderr replayed after the marker
+		`rm -f "$__errf"`,          // and cleaned up
+	} {
+		if !strings.Contains(payload, want) {
+			t.Errorf("split payload missing %q\ngot: %s", want, payload)
+		}
+	}
+	// The exit code must be the command's, captured before the stderr replay.
+	if !strings.Contains(payload, `2>"$__errf"; __rc=$?;`) {
+		t.Errorf("exit code must be captured immediately after the command, got: %s", payload)
+	}
+}
+
+func TestSessionExecHasJSONFlag(t *testing.T) {
+	cmd := newSessionExec(NewRuntime(&GlobalFlags{}))
+	if cmd.Flags().Lookup("json") == nil {
+		t.Fatal("session exec must expose --json")
 	}
 }

--- a/packages/agent/internal/cmd/skills_cmd.go
+++ b/packages/agent/internal/cmd/skills_cmd.go
@@ -112,16 +112,32 @@ Pass --target to override the destination directory.`,
 func newSkillsList(rt *Runtime) *cobra.Command {
 	var (
 		bundled        bool
+		templateID     string
+		repo           string
 		pageSize       int
 		pageToken      string
 		includeContent bool
 	)
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List your org's skills (or --bundled for this CLI's own skills)",
+		Short: "List your org's skills (--template to scope to one template)",
+		Long: `List the skills in your org.
+
+  --template <id>   only the skills a session from that template loads.
+                    Equivalent to 'runtm-api template skills <id>' — the same
+                    answer from whichever command you reached for first.
+  --repo owner/name only the skills attached to that repo.
+  --bundled         the skill files embedded in this binary (local, no API).
+
+Both scoped forms include org-wide skills (those attached with --all), because
+those load too. 'runtm-api template get <id>' also carries the resolved list
+inline, along with whether it is stale relative to the last build.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// --bundled: list the skill files embedded in this binary (local).
 			if bundled {
+				if templateID != "" || repo != "" {
+					return fmt.Errorf("--bundled lists this binary's own files; it cannot be combined with --template or --repo")
+				}
 				files, err := listEmbeddedSkills()
 				if err != nil {
 					return err
@@ -139,6 +155,12 @@ func newSkillsList(rt *Runtime) *cobra.Command {
 			}
 			q := listQuery(pageSize, pageToken)
 			q.Set("type_family", "skill")
+			if templateID != "" {
+				q.Set("template_id", templateID)
+			}
+			if repo != "" {
+				q.Set("repo_full_name", repo)
+			}
 			if includeContent {
 				q.Set("include_content", "true")
 			}
@@ -147,6 +169,8 @@ func newSkillsList(rt *Runtime) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&bundled, "bundled", false, "List the skill files embedded in this CLI binary instead of org skills")
+	cmd.Flags().StringVar(&templateID, "template", "", "Only skills a session from this template loads (same as 'template skills <id>')")
+	cmd.Flags().StringVar(&repo, "repo", "", "Only skills attached to this repo (owner/name)")
 	cmd.Flags().IntVar(&pageSize, "page-size", 0, "Results per page (1-100)")
 	cmd.Flags().StringVar(&pageToken, "page-token", "", "Pagination cursor")
 	cmd.Flags().BoolVar(&includeContent, "include-content", false, "Include each skill's content payload")

--- a/packages/agent/internal/cmd/template.go
+++ b/packages/agent/internal/cmd/template.go
@@ -173,7 +173,9 @@ See https://docs.runtm.com/cloud-api/templates for the full schemas.`,
 		newTemplateRepos(rt),
 		newTemplateSecrets(rt),
 		newTemplateDirectives(rt, "skills", "skill"),
-		newTemplateDirectives(rt, "mcp", "mcp_server"),
+		// "mcp" is the backend's type_family; the type name ("mcp_server")
+		// matches no family and silently disables the type filter.
+		newTemplateDirectives(rt, "mcp", "mcp"),
 	)
 	return cmd
 }
@@ -190,7 +192,11 @@ func newTemplateDirectives(rt *Runtime, use, typeFamily string) *cobra.Command {
 		Use:   use + " <template_id>",
 		Short: fmt.Sprintf("List %s attached to a template (sessions from it load these)", use),
 		Long: fmt.Sprintf(`List the %s attached to a template. Attach/detach them with
-'runtm-api %s attach|detach <id> --template <template_id>'.`, use, use),
+'runtm-api %s attach|detach <id> --template <template_id>'.
+
+Same answer as 'runtm-api %s list --template <template_id>', and
+'runtm-api template get <template_id>' carries the resolved list inline.`,
+			use, use, use),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, _, err := requireOrgClient(rt, "org templates")
@@ -245,8 +251,20 @@ func newTemplateList(rt *Runtime) *cobra.Command {
 func newTemplateGet(rt *Runtime) *cobra.Command {
 	return &cobra.Command{
 		Use:   "get <template_id>",
-		Short: "Get a template (GET /api/org-templates/{id})",
-		Args:  cobra.ExactArgs(1),
+		Short: "Get a template, including its attached skills and MCP servers",
+		Long: `Full template detail. Two fields worth reading before you trust a template:
+
+  skills / mcp_servers            what a session launched from this template
+                                  actually loads, each with 'attached_via'
+                                  (template, repo, or all). An empty 'skills'
+                                  means nothing is attached, however many
+                                  skills exist in the org.
+
+  attachments_changed_since_build true when those attachments changed after
+                                  the snapshot was built, so the running image
+                                  is behind the configuration. Fix with
+                                  'runtm-api template build <id>'.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, _, err := requireOrgClient(rt, "org templates")
 			if err != nil {

--- a/packages/agent/internal/skills/files/SKILL.md
+++ b/packages/agent/internal/skills/files/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: runtm
-description: "Runtm (Runtime) Cloud CLI for AI agents. Full cloud-API surface: sessions (CRUD + files + env + deploy + lifecycle + history + events + visibility + collaborators), org templates (CRUD + build + fix-session + snapshot + secrets), activity telemetry, secrets, instructions, guardrails, LLM provider keys (Anthropic/OpenAI), external integrations (MCP servers, skills, tools, CLIs, APIs). Trigger on: runtm, runtime, runtm cloud, runtime cloud, runtm session, runtime session, cloud sandbox, integration, integrations, connect an integration, mcp, skill, provider key."
+description: "Runtm (Runtime) Cloud CLI for AI agents. Full cloud-API surface: sessions (CRUD + files + env + deploy + lifecycle + history + events + visibility + collaborators), org templates (CRUD + build + fix-session + snapshot + secrets), scheduled agents (cron automation + run-now), activity telemetry, secrets, instructions, guardrails, LLM provider keys (Anthropic/OpenAI), external integrations (MCP servers, skills, tools, CLIs, APIs). Trigger on: runtm, runtime, runtm cloud, runtime cloud, runtm session, runtime session, cloud sandbox, integration, integrations, connect an integration, mcp, skill, provider key, scheduled agent, cron, automation, recurring agent."
 metadata:
-  version: "0.8.0"
+  version: "0.9.0"
   repository: https://github.com/runtm-ai/runtm
   tags: runtm,runtime,cli,sandboxes,coding-agents
 ---
@@ -43,9 +43,15 @@ runtm-api session connect a6414511-4430-4e1f-8c51-8ea8824dadec
 
 # 4b. Or run one command non-interactively and capture its output + exit code
 runtm-api session exec a6414511-4430-4e1f-8c51-8ea8824dadec -- pwd
+
+# 4c. Parsing the output? Use --json for separated streams and no shell noise.
+runtm-api session exec a6414511-4430-4e1f-8c51-8ea8824dadec --json -- npm test
+# -> {"stdout": "...", "stderr": "...", "exit_code": 0}
 ```
 
-Use `session connect` when a human wants a live shell; use `session exec` for scripted, one-shot commands (it streams stdout and exits with the command's exit code). Both need the `sessions:terminal` scope. See the `runtm-sessions` skill for the full recipe.
+Use `session connect` when a human wants a live shell; use `session exec` for scripted, one-shot commands. Both need the `sessions:terminal` scope, and both auto-resume a paused sandbox. See the `runtm-sessions` skill for the full recipe.
+
+**Always pass `--json` to `session exec` when you are going to parse the output.** The default is the raw PTY stream, which merges stderr into stdout and carries shell startup noise (mise/nvm banners and the like) that you would otherwise have to filter out with `grep -v`. `--json` captures the two streams separately and strips PTY carriage returns.
 
 To parameterize a template, declare **session arguments** with `--session-arg` (each becomes an env var in the session); supply values at boot with `session create --template-id <uuid> --template-args KEY=VALUE`. See the `runtm-templates` skill.
 
@@ -62,6 +68,7 @@ To parameterize a template, declare **session arguments** with `--session-arg` (
 | Boot template session with arg values | `runtm-api session create --template-id <uuid> --template-args KEY=VALUE` |
 | Attach interactive terminal (PTY) | `runtm-api session connect <id>` |
 | Run one command (scripted) | `runtm-api session exec <id> -- <command>` |
+| Run one command, parseable output | `runtm-api session exec <id> --json -- <command>` |
 | Stream prompt | `runtm-api session prompt <id> "<task>"` |
 | Stream live event bus | `runtm-api session events <id>` |
 | Poll status (last_prompt) | `runtm-api session status <id>` |
@@ -91,7 +98,7 @@ To parameterize a template, declare **session arguments** with `--session-arg` (
 | Task | Command |
 |------|---------|
 | List templates | `runtm-api template list` |
-| Get template detail | `runtm-api template get <tmpl_id>` |
+| Get template detail (incl. attached skills + build staleness) | `runtm-api template get <tmpl_id>` |
 | Create new template | `runtm-api template create --display-name "..." --github-repo owner/repo` |
 | Create + clone-only build (no AI step) | `runtm-api template create --display-name "..." --github-repo owner/repo --skip-agent` |
 | Declare session args (create/update) | `runtm-api template create ... --session-arg KEY=DEFAULT --session-arg '{"key":"ENV","type":"select","options":["dev","prod"]}'` |
@@ -106,8 +113,63 @@ To parameterize a template, declare **session arguments** with `--session-arg` (
 | List template secrets | `runtm-api template secrets list <tmpl_id>` |
 | Set template secrets | `runtm-api template secrets set <tmpl_id> KEY value [KEY value ...]` |
 | Delete a template secret | `runtm-api template secrets delete <tmpl_id> KEY` |
-| Skills/MCP attached to a template | `runtm-api template skills\|mcp <tmpl_id>` |
+| Skills/MCP attached to a template | `runtm-api template skills\|mcp <tmpl_id>` (or `skills\|mcp list --template <tmpl_id>`) |
 | Attach a skill/MCP to a template | `runtm-api skills\|mcp attach <id> --template <tmpl_id>` |
+
+#### Verify a template actually loads your skills
+
+The most common template mistake is creating skills and never attaching them, so sessions boot without the behaviour you wrote. `template get` answers this inline — no second call needed:
+
+```bash
+runtm-api template get <tmpl_id> | jq '{
+  skills: [.skills[].name],
+  stale: .attachments_changed_since_build
+}'
+```
+
+- **`skills: []`** means nothing is attached, however many skills exist in the org. Fix with `runtm-api skills attach <skill_id> --template <tmpl_id>`.
+- **`stale: true`** means the attachments changed after the last build, so the snapshot sessions boot from is behind the config. Fix with `runtm-api template build <tmpl_id>`.
+
+Each entry carries `attached_via`: `template` (attached directly), `repo` (via one of the template's repos), or `all` (org-wide). Three commands give the same skills answer, so reach for whichever you thought of first:
+
+```bash
+runtm-api template get <tmpl_id> | jq .skills   # inline, plus staleness
+runtm-api template skills <tmpl_id>             # template-first
+runtm-api skills list --template <tmpl_id>      # skills-first
+```
+
+### Scheduled agents (cron automation)
+
+Run a prompt on a schedule. Distinct from `runtm-api agents`, which fires on Slack/GitHub *events*; these fire on a *clock*.
+
+| Task | Command |
+|------|---------|
+| List (with `next_run_at`) | `runtm-api scheduled-agents list` |
+| Get one | `runtm-api scheduled-agents get <id>` |
+| Create | `runtm-api scheduled-agents create --name X --cron '0 18 * * 1' --prompt "..." [--template <tmpl_id>]` |
+| **Run once, right now** | `runtm-api scheduled-agents run-now <id>` |
+| Enable / disable | `runtm-api scheduled-agents update <id> --enabled\|--disabled` |
+| Change the schedule | `runtm-api scheduled-agents update <id> --cron '0 17 * * 1'` |
+| Post results to Slack | `runtm-api scheduled-agents create ... --slack-integration <id> --slack-channel <chan_id>` |
+| Delete | `runtm-api scheduled-agents delete <id> --yes` |
+
+**Always `run-now` before enabling.** It executes the same path the cron tick takes — same template resolution, same Slack target, same orchestrator call — so a bad template name or missing integration fails in front of you instead of silently at the scheduled hour. It works on disabled agents, which is what makes this order safe:
+
+```bash
+# 1. Create it switched off
+runtm-api scheduled-agents create --name weekly-outbound --disabled \
+  --cron '0 18 * * 1' --template <tmpl_id> \
+  --prompt 'Build this week's outbound lists and post them for approval'
+
+# 2. Prove it works (returns the launched session_id)
+runtm-api scheduled-agents run-now <id>
+runtm-api session history <session_id>
+
+# 3. Only then turn the schedule on
+runtm-api scheduled-agents update <id> --enabled
+```
+
+Cron is **5 fields in UTC** — there is no per-agent time zone. 11am Pacific is `0 18 * * *` in winter and `0 17 * * *` under daylight time, so pick the one that matches now and revisit at the DST boundary. `list` reports `next_run_at` (null when disabled) next to `last_run_at` and `last_session_id`, which is the fastest way to check whether a schedule is actually live.
 
 ### Activity (telemetry)
 
@@ -129,8 +191,9 @@ To parameterize a template, declare **session arguments** with `--session-arg` (
 | Instructions | `runtm-api instructions get\|set [--org-scope] [--text "..."\|--clear]` |
 | Guardrails | `runtm-api guardrails limits\|allowlist get\|set`, `can-deploy`, `deploy-limits`, `cleanup --yes` |
 | Providers (LLM keys) | `runtm-api providers anthropic\|openai get\|set\|delete\|resolved [--org-scope]` |
-| Integrations (external) | Skills / MCP servers / tools -- `runtm-api skills\|mcp\|tools create\|get\|list\|update\|delete`; attach skills/MCP to templates with `skills\|mcp attach\|detach\|attachments <id> --template <tmpl_id>` (see `runtm-integrations`) |
-| Agents (Slack/GitHub) | `runtm-api agents create\|list\|get\|update\|delete --type slack\|github` (see `runtm-agents`) |
+| Integrations (external) | Skills / MCP servers / tools -- `runtm-api skills\|mcp\|tools create\|get\|list\|update\|delete`; scope a listing with `list --template <tmpl_id>` / `--repo owner/name`; attach with `skills\|mcp attach\|detach\|attachments <id> --template <tmpl_id>` (see `runtm-integrations`) |
+| Agents (Slack/GitHub events) | `runtm-api agents create\|list\|get\|update\|delete --type slack\|github` (see `runtm-agents`) |
+| Scheduled agents (cron) | `runtm-api scheduled-agents list\|get\|create\|update\|run-now\|delete` |
 | Auth | `runtm-api auth status` |
 
 ## Endpoint Strategy
@@ -216,6 +279,8 @@ If `authenticated: false`, ask the user to set `RUNTM_API_KEY` (or run `runtm-ap
 | 409 | Conflict (e.g. duplicate name) | Use a different name / --name flag |
 | 422 | Body validation failed | Check the canonical endpoint schema at https://docs.runtm.com/cloud-api |
 | 429 | Rate limited | Back off (5-10s) and retry |
+| 502 on `scheduled-agents run-now` | The run itself failed (bad template name, missing Slack integration) | The `detail` carries the reason — this is run-now working as intended, catching what would otherwise fail silently at the scheduled hour |
+| 503 on `scheduled-agents create\|update` | Cloud Scheduler isn't configured in this environment | Create with `--disabled` and drive it with `run-now` |
 | 5xx | Sandbox / upstream | Retry once; check https://status.runtm.com |
 
 ## Scope Reference
@@ -253,6 +318,8 @@ If `authenticated: false`, ask the user to set `RUNTM_API_KEY` (or run `runtm-ap
 | `guardrails cleanup` | `guardrails:write` (admin/owner) |
 | `providers * get\|resolved` | `integrations:read` (backend scope unchanged) |
 | `providers * set\|delete` | `integrations:write` (org needs admin/owner) |
+| `scheduled-agents list\|get` | `sessions:read` |
+| `scheduled-agents create\|update\|delete\|run-now` | `sessions:write` (admin/owner) |
 
 ## More Skills
 
@@ -260,13 +327,14 @@ If `authenticated: false`, ask the user to set `RUNTM_API_KEY` (or run `runtm-ap
 - `runtm-templates` -- full template lifecycle (create, build, fix, snapshot).
 - `runtm-debug` -- inspect a session's state when something is wrong.
 - `runtm-integrations` -- add/connect an **external** integration (research API/SDK/CLI/MCP/repos/skills → weigh auth methods → user picks → build definition → connect in the UI); CRUD skills, MCP servers, and tools. NB: "integration" means external tooling; LLM provider keys (Anthropic/OpenAI) live under `runtm-api providers`.
-- `runtm-agents` -- create, list, and edit Slack/GitHub integration agents.
+- `runtm-agents` -- create, list, and edit Slack/GitHub integration agents (event-driven).
+- `runtm-automation` -- scheduled agents: cron syntax, the create-disabled → `run-now` → enable order, and debugging a schedule that didn't fire.
 
 ## Subcommand Discovery
 
 ```bash
 runtm-api --help
-runtm-api <area> --help            # session, template, activity, secrets, instructions, guardrails, integrations, auth
+runtm-api <area> --help            # session, template, scheduled-agents, activity, secrets, instructions, guardrails, integrations, auth
 runtm-api session deploy --help    # nested subcommand trees
 runtm-api template fix-session --help
 ```

--- a/packages/agent/internal/skills/files/runtm-automation.md
+++ b/packages/agent/internal/skills/files/runtm-automation.md
@@ -1,0 +1,167 @@
+---
+name: runtm-automation
+description: "Schedule Runtm Cloud agents to run a prompt on a cron — create, verify with run-now, enable, and debug a schedule that did not fire. Use when the user wants recurring/automated agent runs, a weekly or nightly job, a cron agent, a Slack digest on a schedule, or asks why a scheduled agent produced nothing."
+metadata:
+  version: "0.1.0"
+  tags: runtm,runtime,scheduled-agents,cron,automation,recurring
+---
+
+# Runtm Scheduled Agents
+
+`runtm-api scheduled-agents` runs a prompt on a clock. Each agent pairs a cron
+expression with a prompt, an optional org template, and an optional Slack
+channel to post the result to. Every tick launches a fresh session in autopilot
+mode and runs the prompt to completion.
+
+Not to be confused with `runtm-api agents`, which manages Slack/GitHub bots that
+fire on an **event**. These fire on a **schedule**.
+
+| Verb | Command |
+|------|---------|
+| List (with `next_run_at`) | `runtm-api scheduled-agents list` |
+| Get one | `runtm-api scheduled-agents get <id>` |
+| Create | `runtm-api scheduled-agents create --name X --cron '...' --prompt '...'` |
+| **Run once now** | `runtm-api scheduled-agents run-now <id>` |
+| Enable / disable | `runtm-api scheduled-agents update <id> --enabled\|--disabled` |
+| Edit | `runtm-api scheduled-agents update <id> [flags]` |
+| Delete | `runtm-api scheduled-agents delete <id> --yes` |
+
+Aliases: `schedules`, `cron`. `run-now` also answers to `run` and `trigger`.
+
+## Org context + scope
+
+Org-scoped, so an **org-scoped API key** is required — the org is read from the
+key and `--org` / `RUNTM_ORG_ID` cannot substitute for one. Reads need
+`sessions:read`; create/update/delete/run-now need `sessions:write` **and an
+admin or owner role**, because a run costs compute and can post to a shared
+channel.
+
+## The order that works: create disabled → run-now → enable
+
+A scheduled agent that is wrong fails at its scheduled hour, into a channel,
+with nobody watching. `run-now` executes the identical code path the cron tick
+takes — same template resolution, same Slack target, same orchestrator call —
+so build the habit of proving it first:
+
+```bash
+# 1. Create it switched off so the schedule can't fire before you've checked it
+runtm-api scheduled-agents create \
+  --name weekly-outbound \
+  --disabled \
+  --cron '0 18 * * 1' \
+  --template 28f6e6e6-d73d-4f21-8b1f-312e17e8f47b \
+  --prompt 'Build this week'"'"'s outbound lists and post them for approval' \
+  --slack-integration <integration_id> \
+  --slack-channel C0123456789
+# -> {"id": "9f3c...", "enabled": false, "next_run_at": null, ...}
+
+# 2. Prove it. Returns the launched session_id; a bad template or missing
+#    integration surfaces here as a 502 with the reason.
+runtm-api scheduled-agents run-now 9f3c...
+# -> {"session_id": "a641...", "enabled": false, "trigger": "manual", ...}
+
+# 3. Watch the run you just triggered
+runtm-api session status a641...
+runtm-api session history a641...
+
+# 4. Only once the output is what you want, turn the schedule on
+runtm-api scheduled-agents update 9f3c... --enabled
+runtm-api scheduled-agents get 9f3c... | jq .next_run_at
+```
+
+`run-now` deliberately works on disabled agents — that is what makes this order
+possible. It stamps `last_run_at` / `last_session_id` like any other run.
+
+## Cron is 5 fields, in UTC, with no per-agent time zone
+
+Cloud Scheduler runs every job in `Etc/UTC`. There is no per-agent time zone
+setting, so a local time has to be converted by hand — and revisited when
+daylight saving shifts:
+
+| Intent | Winter (PST, UTC-8) | Summer (PDT, UTC-7) |
+|--------|--------------------|--------------------|
+| Daily 11am Pacific | `0 19 * * *` | `0 18 * * *` |
+| Mondays 11am Pacific | `0 19 * * 1` | `0 18 * * 1` |
+| Every hour | `0 * * * *` | `0 * * * *` |
+| Weekdays 9am Pacific | `0 17 * * 1-5` | `0 16 * * 1-5` |
+
+Confirm the schedule reads the way you meant by checking `next_run_at`, which
+the API derives from the cron:
+
+```bash
+runtm-api scheduled-agents list | jq '.agents[] | {name, cron, enabled, next_run_at, last_run_at}'
+```
+
+`next_run_at` is `null` when the agent is disabled — a disabled agent has no
+Scheduler job, so there is no next run to report.
+
+## Debugging "it was supposed to run and nothing happened"
+
+Work down this list; each step rules out one layer.
+
+```bash
+# 1. Is the schedule even live? enabled=false or next_run_at=null means no job.
+runtm-api scheduled-agents get <id> | jq '{enabled, cron, next_run_at, last_run_at, last_session_id}'
+
+# 2. Did a tick fire? Compare last_run_at against the time you expected.
+#    Unchanged => the schedule never fired (check enabled + the UTC conversion).
+#    Updated   => it fired and the failure is inside the run; go to step 4.
+
+# 3. Reproduce on demand. A 502 here carries the reason the tick would fail.
+runtm-api scheduled-agents run-now <id>
+
+# 4. Read what the run actually did.
+runtm-api session history <last_session_id>
+runtm-api session status <last_session_id>
+```
+
+Common causes, in rough order of frequency:
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `next_run_at` is null | Agent disabled | `update <id> --enabled` |
+| Fired an hour early/late | Daylight saving moved the UTC offset | Re-derive the cron from the table above |
+| `502` from `run-now` | The launch itself fails (unknown template, deleted Slack integration) | Read `detail`; fix the referenced resource |
+| `503` from `create`/`update` | Cloud Scheduler isn't configured in this environment | Create `--disabled` and drive it with `run-now` |
+| Ran, but nothing reached Slack | No Slack target configured, or the run errored before finishing | `get <id> \| jq '{slack_integration_id, slack_channel_id}'`, then `session history` |
+| Ran, output was wrong | The prompt or template is wrong, not the schedule | Iterate with `run-now`, not by waiting for ticks |
+
+## Slack output
+
+The integration and channel travel together — passing one without the other is
+rejected. When both are set, each run's result is posted to the channel as that
+integration's Slack app.
+
+```bash
+runtm-api scheduled-agents update <id> \
+  --slack-integration <integration_id> \
+  --slack-channel C0123456789
+```
+
+Find integration ids with `runtm-api agents list --type slack`.
+
+Runs are unattended (autopilot), so the prompt should say exactly what to
+produce and in what shape. A prompt that ends "post the Block Kit JSON" gets
+raw JSON pasted into the channel; say "post a short plain-text summary" if that
+is what you want a human to read at 11am.
+
+## Editing a schedule
+
+`update` only sends the flags you pass, so a partial edit never clobbers the
+prompt or cron it did not mention:
+
+```bash
+runtm-api scheduled-agents update <id> --cron '0 18 * * 1'   # DST shift
+runtm-api scheduled-agents update <id> --prompt 'New instructions'
+runtm-api scheduled-agents update <id> --disabled            # stop, keep the agent
+```
+
+Prefer `--disabled` over `delete` when pausing: it removes the Scheduler job but
+keeps the prompt, template binding, and Slack target so re-enabling is one call.
+
+## Related skills
+
+- `runtm-templates` — build the template a scheduled agent launches from, and
+  verify its skills are attached and baked (`attachments_changed_since_build`).
+- `runtm-agents` — Slack/GitHub agents that fire on events instead of a clock.
+- `runtm-sessions` — inspect the sessions a scheduled run creates.

--- a/packages/agent/internal/skills/files/runtm-integrations.md
+++ b/packages/agent/internal/skills/files/runtm-integrations.md
@@ -288,12 +288,19 @@ runtm-api skills detach <skill_id> --template <template_id>
 runtm-api skills detach <skill_id> --clear
 ```
 
-The template-side view — list what a template loads:
+Three equivalent ways to ask "what does this template load?" — use whichever
+you reached for first:
 
 ```bash
-runtm-api template skills <template_id>   # skills attached to the template
-runtm-api template mcp <template_id>      # MCP servers attached to the template
+runtm-api template skills <template_id>          # template-first
+runtm-api skills list --template <template_id>   # skills-first
+runtm-api template get <template_id> | jq .skills   # inline, plus staleness
 ```
+
+The same three exist for MCP servers (`template mcp`, `mcp list --template`,
+`template get | jq .mcp_servers`). Scope a listing to a repo instead with
+`--repo owner/name`. Every scoped form also includes org-wide items (those
+attached with `--all`), because those load too.
 
 Scopes & semantics:
 
@@ -310,14 +317,28 @@ Scopes & semantics:
 - Only **org-owned** skills/MCP servers can be attached (they come from an
   org-scoped key); personal directives cannot.
 
-The full flow to wire a skill into a template:
+The full flow to wire a skill into a template. **Creating a skill attaches it
+nowhere and bakes it nowhere** — both follow-up steps are required, and both
+fail silently if skipped:
 
 ```bash
 export RUNTM_API_KEY=runtm_sk_live_...   # org-scoped key
 SKILL_ID=$(runtm-api skills create --name deploy-checks --md ./SKILL.md | jq -r .directive.id)
+
+# 1. Attach it — without this, sessions boot without the skill
 runtm-api skills attach "$SKILL_ID" --template <template_id>
-runtm-api template skills <template_id>          # verify it's listed
+
+# 2. Verify, and check whether the snapshot is now behind the config
+runtm-api template get <template_id> | jq '{skills: [.skills[].name], stale: .attachments_changed_since_build}'
+
+# 3. Rebuild if stale — attaching changes config, not the built image
+runtm-api template build <template_id>
 ```
+
+`attachments_changed_since_build: true` means the attachments moved after the
+last build, so sessions still boot with the old set until you rebuild. That
+flag is the reason to prefer `template get` over `template skills` when you are
+about to trust a template.
 
 ---
 

--- a/packages/agent/internal/skills/files/runtm-sessions.md
+++ b/packages/agent/internal/skills/files/runtm-sessions.md
@@ -1,8 +1,8 @@
 ---
 name: runtm-sessions
-description: "Multi-step workflow recipes for Runtm Cloud sessions: launching agents, iterating with prompts, polling status, reading/writing files, managing env vars, and opening PRs."
+description: "Multi-step workflow recipes for Runtm Cloud sessions: launching agents, iterating with prompts, polling status, running commands with exec (incl. --json), reading/writing files, managing env vars, and opening PRs."
 metadata:
-  version: "0.4.0"
+  version: "0.5.0"
   tags: runtm,runtime,sessions,workflows,sandboxes
 ---
 
@@ -16,6 +16,7 @@ Workflow recipes for the `runtm-api session` subcommands. For endpoint details s
 |------|-----|
 | Boot a session from a prebuilt org template | `session create --template-id <uuid>` |
 | Run a single shell command in a session | `session exec <id> -- <command>` (scripted, returns its exit code) |
+| Run a command whose output you will **parse** | `session exec <id> --json -- <command>` |
 | Open a live interactive shell | `session connect <id>` (raw PTY; needs a TTY) |
 | Fire-and-forget background task | `session launch` (v0 -- creates + prompts in one call) |
 | Interactive, streaming response right now | `session create` then `session prompt` |
@@ -63,7 +64,7 @@ runtm-api session connect a6414511-4430-4e1f-8c51-8ea8824dadec
 Two ways to get a shell against a session's sandbox, both over the same terminal WebSocket the dashboard uses (scope: `sessions:terminal`):
 
 ```bash
-# Non-interactive: run one command, stream its output, exit with its exit code.
+# Non-interactive: run one command, print its output, exit with its exit code.
 # A throwaway PTY is used, so it never disturbs interactive terminals. Put the
 # command after `--` so runtm-api does not parse its flags.
 runtm-api session exec <id> -- pwd
@@ -77,7 +78,35 @@ runtm-api session connect <id>
 runtm-api session connect <id> --terminal default   # share the dashboard terminal
 ```
 
-Use `exec` for automation and scripted checks; use `connect` only when a human is at a real terminal. `exec` output is the raw PTY stream and may contain minor terminal formatting.
+Use `exec` for automation and scripted checks; use `connect` only when a human is at a real terminal.
+
+### `--json`: use it whenever you will parse the output
+
+The default output is the raw PTY stream: stderr is merged into stdout and the sandbox's shell startup noise (mise, nvm, and similar banners) rides along, which is why hand-rolled pipelines end up with a `grep -v` filter. `--json` avoids all of that:
+
+```bash
+runtm-api session exec <id> --json -- npm test
+# -> {"stdout": "...", "stderr": "...", "exit_code": 1}
+
+# Read one stream at a time
+runtm-api session exec <id> --json -- ./build.sh | jq -r .stderr
+
+# Branch on the exit code without trusting $? through a pipe
+result=$(runtm-api session exec <id> --json -- pytest -q || true)
+[ "$(jq -r .exit_code <<<"$result")" = "0" ] || echo "tests failed"
+```
+
+- The two streams are captured separately (stderr goes to a temp file in the sandbox and is replayed after a sentinel), so neither can interleave into the other.
+- PTY carriage returns are stripped, so `stdout` compares cleanly against expected text.
+- The process **still exits with the remote exit code**, so under `set -e` a failing command aborts the script before you can read the JSON — capture it with `|| true` as above, then read `exit_code`.
+
+### `!` is safe
+
+Bash history expansion is disabled for the command in both modes. A literal `!` in a heredoc, a commit message, or a regex reaches the sandbox intact instead of being silently rewritten against shell history.
+
+### Paused sandboxes resume automatically
+
+Sessions auto-pause after ~20 minutes idle. `exec`, `connect`, and the file commands now resume a paused sandbox in place rather than failing, so a scripted run against a session you left alone yesterday just works. The first command after a resume takes a few extra seconds. Use `session pause` when you deliberately want to stop the clock.
 
 ## Recipe: launch an agent from scratch
 

--- a/packages/agent/internal/skills/files/runtm-templates.md
+++ b/packages/agent/internal/skills/files/runtm-templates.md
@@ -1,8 +1,8 @@
 ---
 name: runtm-templates
-description: "Full lifecycle workflows for Runtm Cloud org templates: discover, create, build, monitor builds, fix broken templates via fix-session, save snapshots, manage template secrets."
+description: "Full lifecycle workflows for Runtm Cloud org templates: discover, create, build, monitor builds, verify attached skills and build staleness, fix broken templates via fix-session, save snapshots, manage template secrets."
 metadata:
-  version: "0.4.0"
+  version: "0.5.0"
   tags: runtm,runtime,templates,org,workflows
 ---
 
@@ -49,6 +49,49 @@ Key fields to inspect:
 - `has_all_required`: false means a template will fail to boot until missing secrets are set.
 - `services`: array of detected services (web, api, db). Each has its own port + start_cmd.
 - `agents`: list of coding agents the snapshot was built for.
+- `skills` / `mcp_servers`: what a session from this template actually loads.
+- `attachments_changed_since_build`: true means those changed after the last build, so the snapshot is behind.
+
+## Recipe: verify a template loads the skills you think it does
+
+Skills define agent behaviour, and the two ways to get this wrong are both silent: creating a skill and never attaching it, or attaching one and never rebuilding. `template get` reports both:
+
+```bash
+runtm-api template get <tmpl_id> | jq '{
+  skills: [.skills[] | {name, attached_via}],
+  mcp: [.mcp_servers[].name],
+  stale: .attachments_changed_since_build
+}'
+```
+
+```json
+{
+  "skills": [
+    { "name": "outbound-writing", "attached_via": "template" },
+    { "name": "company-context", "attached_via": "all" }
+  ],
+  "mcp": ["notion"],
+  "stale": true
+}
+```
+
+| What you see | What it means | Fix |
+|---|---|---|
+| `skills: []` | Nothing is attached, however many skills exist in the org | `runtm-api skills attach <skill_id> --template <tmpl_id>` |
+| `stale: true` | Attachments changed after the snapshot was built; sessions boot with the old set | `runtm-api template build <tmpl_id>` |
+| `attached_via: "template"` | Attached directly to this template | Detach with `skills detach <id> --template <tmpl_id>` |
+| `attached_via: "repo"` | Reaches the template through one of its repos | Detach with `skills detach <id> --repo owner/name` |
+| `attached_via: "all"` | Org-wide (`--all`), loads into every session | Detach with `skills detach <id> --all` |
+
+The same list is available from either direction, so use whichever command you reached for first:
+
+```bash
+runtm-api template get <tmpl_id> | jq .skills   # inline, plus staleness
+runtm-api template skills <tmpl_id>             # template-first
+runtm-api skills list --template <tmpl_id>      # skills-first
+```
+
+Full attach/detach mechanics live in the `runtm-integrations` skill.
 
 ## Recipe: create a new template
 

--- a/packages/agent/skills/SKILL.md
+++ b/packages/agent/skills/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: runtm
-description: "Runtm (Runtime) Cloud CLI for AI agents. Full cloud-API surface: sessions (CRUD + files + env + deploy + lifecycle + history + events + visibility + collaborators), org templates (CRUD + build + fix-session + snapshot + secrets), activity telemetry, secrets, instructions, guardrails, LLM provider keys (Anthropic/OpenAI), external integrations (MCP servers, skills, tools, CLIs, APIs). Trigger on: runtm, runtime, runtm cloud, runtime cloud, runtm session, runtime session, cloud sandbox, integration, integrations, connect an integration, mcp, skill, provider key."
+description: "Runtm (Runtime) Cloud CLI for AI agents. Full cloud-API surface: sessions (CRUD + files + env + deploy + lifecycle + history + events + visibility + collaborators), org templates (CRUD + build + fix-session + snapshot + secrets), scheduled agents (cron automation + run-now), activity telemetry, secrets, instructions, guardrails, LLM provider keys (Anthropic/OpenAI), external integrations (MCP servers, skills, tools, CLIs, APIs). Trigger on: runtm, runtime, runtm cloud, runtime cloud, runtm session, runtime session, cloud sandbox, integration, integrations, connect an integration, mcp, skill, provider key, scheduled agent, cron, automation, recurring agent."
 metadata:
-  version: "0.8.0"
+  version: "0.9.0"
   repository: https://github.com/runtm-ai/runtm
   tags: runtm,runtime,cli,sandboxes,coding-agents
 ---
@@ -43,9 +43,15 @@ runtm-api session connect a6414511-4430-4e1f-8c51-8ea8824dadec
 
 # 4b. Or run one command non-interactively and capture its output + exit code
 runtm-api session exec a6414511-4430-4e1f-8c51-8ea8824dadec -- pwd
+
+# 4c. Parsing the output? Use --json for separated streams and no shell noise.
+runtm-api session exec a6414511-4430-4e1f-8c51-8ea8824dadec --json -- npm test
+# -> {"stdout": "...", "stderr": "...", "exit_code": 0}
 ```
 
-Use `session connect` when a human wants a live shell; use `session exec` for scripted, one-shot commands (it streams stdout and exits with the command's exit code). Both need the `sessions:terminal` scope. See the `runtm-sessions` skill for the full recipe.
+Use `session connect` when a human wants a live shell; use `session exec` for scripted, one-shot commands. Both need the `sessions:terminal` scope, and both auto-resume a paused sandbox. See the `runtm-sessions` skill for the full recipe.
+
+**Always pass `--json` to `session exec` when you are going to parse the output.** The default is the raw PTY stream, which merges stderr into stdout and carries shell startup noise (mise/nvm banners and the like) that you would otherwise have to filter out with `grep -v`. `--json` captures the two streams separately and strips PTY carriage returns.
 
 To parameterize a template, declare **session arguments** with `--session-arg` (each becomes an env var in the session); supply values at boot with `session create --template-id <uuid> --template-args KEY=VALUE`. See the `runtm-templates` skill.
 
@@ -62,6 +68,7 @@ To parameterize a template, declare **session arguments** with `--session-arg` (
 | Boot template session with arg values | `runtm-api session create --template-id <uuid> --template-args KEY=VALUE` |
 | Attach interactive terminal (PTY) | `runtm-api session connect <id>` |
 | Run one command (scripted) | `runtm-api session exec <id> -- <command>` |
+| Run one command, parseable output | `runtm-api session exec <id> --json -- <command>` |
 | Stream prompt | `runtm-api session prompt <id> "<task>"` |
 | Stream live event bus | `runtm-api session events <id>` |
 | Poll status (last_prompt) | `runtm-api session status <id>` |
@@ -91,7 +98,7 @@ To parameterize a template, declare **session arguments** with `--session-arg` (
 | Task | Command |
 |------|---------|
 | List templates | `runtm-api template list` |
-| Get template detail | `runtm-api template get <tmpl_id>` |
+| Get template detail (incl. attached skills + build staleness) | `runtm-api template get <tmpl_id>` |
 | Create new template | `runtm-api template create --display-name "..." --github-repo owner/repo` |
 | Create + clone-only build (no AI step) | `runtm-api template create --display-name "..." --github-repo owner/repo --skip-agent` |
 | Declare session args (create/update) | `runtm-api template create ... --session-arg KEY=DEFAULT --session-arg '{"key":"ENV","type":"select","options":["dev","prod"]}'` |
@@ -106,8 +113,63 @@ To parameterize a template, declare **session arguments** with `--session-arg` (
 | List template secrets | `runtm-api template secrets list <tmpl_id>` |
 | Set template secrets | `runtm-api template secrets set <tmpl_id> KEY value [KEY value ...]` |
 | Delete a template secret | `runtm-api template secrets delete <tmpl_id> KEY` |
-| Skills/MCP attached to a template | `runtm-api template skills\|mcp <tmpl_id>` |
+| Skills/MCP attached to a template | `runtm-api template skills\|mcp <tmpl_id>` (or `skills\|mcp list --template <tmpl_id>`) |
 | Attach a skill/MCP to a template | `runtm-api skills\|mcp attach <id> --template <tmpl_id>` |
+
+#### Verify a template actually loads your skills
+
+The most common template mistake is creating skills and never attaching them, so sessions boot without the behaviour you wrote. `template get` answers this inline — no second call needed:
+
+```bash
+runtm-api template get <tmpl_id> | jq '{
+  skills: [.skills[].name],
+  stale: .attachments_changed_since_build
+}'
+```
+
+- **`skills: []`** means nothing is attached, however many skills exist in the org. Fix with `runtm-api skills attach <skill_id> --template <tmpl_id>`.
+- **`stale: true`** means the attachments changed after the last build, so the snapshot sessions boot from is behind the config. Fix with `runtm-api template build <tmpl_id>`.
+
+Each entry carries `attached_via`: `template` (attached directly), `repo` (via one of the template's repos), or `all` (org-wide). Three commands give the same skills answer, so reach for whichever you thought of first:
+
+```bash
+runtm-api template get <tmpl_id> | jq .skills   # inline, plus staleness
+runtm-api template skills <tmpl_id>             # template-first
+runtm-api skills list --template <tmpl_id>      # skills-first
+```
+
+### Scheduled agents (cron automation)
+
+Run a prompt on a schedule. Distinct from `runtm-api agents`, which fires on Slack/GitHub *events*; these fire on a *clock*.
+
+| Task | Command |
+|------|---------|
+| List (with `next_run_at`) | `runtm-api scheduled-agents list` |
+| Get one | `runtm-api scheduled-agents get <id>` |
+| Create | `runtm-api scheduled-agents create --name X --cron '0 18 * * 1' --prompt "..." [--template <tmpl_id>]` |
+| **Run once, right now** | `runtm-api scheduled-agents run-now <id>` |
+| Enable / disable | `runtm-api scheduled-agents update <id> --enabled\|--disabled` |
+| Change the schedule | `runtm-api scheduled-agents update <id> --cron '0 17 * * 1'` |
+| Post results to Slack | `runtm-api scheduled-agents create ... --slack-integration <id> --slack-channel <chan_id>` |
+| Delete | `runtm-api scheduled-agents delete <id> --yes` |
+
+**Always `run-now` before enabling.** It executes the same path the cron tick takes — same template resolution, same Slack target, same orchestrator call — so a bad template name or missing integration fails in front of you instead of silently at the scheduled hour. It works on disabled agents, which is what makes this order safe:
+
+```bash
+# 1. Create it switched off
+runtm-api scheduled-agents create --name weekly-outbound --disabled \
+  --cron '0 18 * * 1' --template <tmpl_id> \
+  --prompt 'Build this week's outbound lists and post them for approval'
+
+# 2. Prove it works (returns the launched session_id)
+runtm-api scheduled-agents run-now <id>
+runtm-api session history <session_id>
+
+# 3. Only then turn the schedule on
+runtm-api scheduled-agents update <id> --enabled
+```
+
+Cron is **5 fields in UTC** — there is no per-agent time zone. 11am Pacific is `0 18 * * *` in winter and `0 17 * * *` under daylight time, so pick the one that matches now and revisit at the DST boundary. `list` reports `next_run_at` (null when disabled) next to `last_run_at` and `last_session_id`, which is the fastest way to check whether a schedule is actually live.
 
 ### Activity (telemetry)
 
@@ -129,8 +191,9 @@ To parameterize a template, declare **session arguments** with `--session-arg` (
 | Instructions | `runtm-api instructions get\|set [--org-scope] [--text "..."\|--clear]` |
 | Guardrails | `runtm-api guardrails limits\|allowlist get\|set`, `can-deploy`, `deploy-limits`, `cleanup --yes` |
 | Providers (LLM keys) | `runtm-api providers anthropic\|openai get\|set\|delete\|resolved [--org-scope]` |
-| Integrations (external) | Skills / MCP servers / tools -- `runtm-api skills\|mcp\|tools create\|get\|list\|update\|delete`; attach skills/MCP to templates with `skills\|mcp attach\|detach\|attachments <id> --template <tmpl_id>` (see `runtm-integrations`) |
-| Agents (Slack/GitHub) | `runtm-api agents create\|list\|get\|update\|delete --type slack\|github` (see `runtm-agents`) |
+| Integrations (external) | Skills / MCP servers / tools -- `runtm-api skills\|mcp\|tools create\|get\|list\|update\|delete`; scope a listing with `list --template <tmpl_id>` / `--repo owner/name`; attach with `skills\|mcp attach\|detach\|attachments <id> --template <tmpl_id>` (see `runtm-integrations`) |
+| Agents (Slack/GitHub events) | `runtm-api agents create\|list\|get\|update\|delete --type slack\|github` (see `runtm-agents`) |
+| Scheduled agents (cron) | `runtm-api scheduled-agents list\|get\|create\|update\|run-now\|delete` |
 | Auth | `runtm-api auth status` |
 
 ## Endpoint Strategy
@@ -216,6 +279,8 @@ If `authenticated: false`, ask the user to set `RUNTM_API_KEY` (or run `runtm-ap
 | 409 | Conflict (e.g. duplicate name) | Use a different name / --name flag |
 | 422 | Body validation failed | Check the canonical endpoint schema at https://docs.runtm.com/cloud-api |
 | 429 | Rate limited | Back off (5-10s) and retry |
+| 502 on `scheduled-agents run-now` | The run itself failed (bad template name, missing Slack integration) | The `detail` carries the reason — this is run-now working as intended, catching what would otherwise fail silently at the scheduled hour |
+| 503 on `scheduled-agents create\|update` | Cloud Scheduler isn't configured in this environment | Create with `--disabled` and drive it with `run-now` |
 | 5xx | Sandbox / upstream | Retry once; check https://status.runtm.com |
 
 ## Scope Reference
@@ -253,6 +318,8 @@ If `authenticated: false`, ask the user to set `RUNTM_API_KEY` (or run `runtm-ap
 | `guardrails cleanup` | `guardrails:write` (admin/owner) |
 | `providers * get\|resolved` | `integrations:read` (backend scope unchanged) |
 | `providers * set\|delete` | `integrations:write` (org needs admin/owner) |
+| `scheduled-agents list\|get` | `sessions:read` |
+| `scheduled-agents create\|update\|delete\|run-now` | `sessions:write` (admin/owner) |
 
 ## More Skills
 
@@ -260,13 +327,14 @@ If `authenticated: false`, ask the user to set `RUNTM_API_KEY` (or run `runtm-ap
 - `runtm-templates` -- full template lifecycle (create, build, fix, snapshot).
 - `runtm-debug` -- inspect a session's state when something is wrong.
 - `runtm-integrations` -- add/connect an **external** integration (research API/SDK/CLI/MCP/repos/skills → weigh auth methods → user picks → build definition → connect in the UI); CRUD skills, MCP servers, and tools. NB: "integration" means external tooling; LLM provider keys (Anthropic/OpenAI) live under `runtm-api providers`.
-- `runtm-agents` -- create, list, and edit Slack/GitHub integration agents.
+- `runtm-agents` -- create, list, and edit Slack/GitHub integration agents (event-driven).
+- `runtm-automation` -- scheduled agents: cron syntax, the create-disabled → `run-now` → enable order, and debugging a schedule that didn't fire.
 
 ## Subcommand Discovery
 
 ```bash
 runtm-api --help
-runtm-api <area> --help            # session, template, activity, secrets, instructions, guardrails, integrations, auth
+runtm-api <area> --help            # session, template, scheduled-agents, activity, secrets, instructions, guardrails, integrations, auth
 runtm-api session deploy --help    # nested subcommand trees
 runtm-api template fix-session --help
 ```

--- a/packages/agent/skills/runtm-automation.md
+++ b/packages/agent/skills/runtm-automation.md
@@ -1,0 +1,167 @@
+---
+name: runtm-automation
+description: "Schedule Runtm Cloud agents to run a prompt on a cron — create, verify with run-now, enable, and debug a schedule that did not fire. Use when the user wants recurring/automated agent runs, a weekly or nightly job, a cron agent, a Slack digest on a schedule, or asks why a scheduled agent produced nothing."
+metadata:
+  version: "0.1.0"
+  tags: runtm,runtime,scheduled-agents,cron,automation,recurring
+---
+
+# Runtm Scheduled Agents
+
+`runtm-api scheduled-agents` runs a prompt on a clock. Each agent pairs a cron
+expression with a prompt, an optional org template, and an optional Slack
+channel to post the result to. Every tick launches a fresh session in autopilot
+mode and runs the prompt to completion.
+
+Not to be confused with `runtm-api agents`, which manages Slack/GitHub bots that
+fire on an **event**. These fire on a **schedule**.
+
+| Verb | Command |
+|------|---------|
+| List (with `next_run_at`) | `runtm-api scheduled-agents list` |
+| Get one | `runtm-api scheduled-agents get <id>` |
+| Create | `runtm-api scheduled-agents create --name X --cron '...' --prompt '...'` |
+| **Run once now** | `runtm-api scheduled-agents run-now <id>` |
+| Enable / disable | `runtm-api scheduled-agents update <id> --enabled\|--disabled` |
+| Edit | `runtm-api scheduled-agents update <id> [flags]` |
+| Delete | `runtm-api scheduled-agents delete <id> --yes` |
+
+Aliases: `schedules`, `cron`. `run-now` also answers to `run` and `trigger`.
+
+## Org context + scope
+
+Org-scoped, so an **org-scoped API key** is required — the org is read from the
+key and `--org` / `RUNTM_ORG_ID` cannot substitute for one. Reads need
+`sessions:read`; create/update/delete/run-now need `sessions:write` **and an
+admin or owner role**, because a run costs compute and can post to a shared
+channel.
+
+## The order that works: create disabled → run-now → enable
+
+A scheduled agent that is wrong fails at its scheduled hour, into a channel,
+with nobody watching. `run-now` executes the identical code path the cron tick
+takes — same template resolution, same Slack target, same orchestrator call —
+so build the habit of proving it first:
+
+```bash
+# 1. Create it switched off so the schedule can't fire before you've checked it
+runtm-api scheduled-agents create \
+  --name weekly-outbound \
+  --disabled \
+  --cron '0 18 * * 1' \
+  --template 28f6e6e6-d73d-4f21-8b1f-312e17e8f47b \
+  --prompt 'Build this week'"'"'s outbound lists and post them for approval' \
+  --slack-integration <integration_id> \
+  --slack-channel C0123456789
+# -> {"id": "9f3c...", "enabled": false, "next_run_at": null, ...}
+
+# 2. Prove it. Returns the launched session_id; a bad template or missing
+#    integration surfaces here as a 502 with the reason.
+runtm-api scheduled-agents run-now 9f3c...
+# -> {"session_id": "a641...", "enabled": false, "trigger": "manual", ...}
+
+# 3. Watch the run you just triggered
+runtm-api session status a641...
+runtm-api session history a641...
+
+# 4. Only once the output is what you want, turn the schedule on
+runtm-api scheduled-agents update 9f3c... --enabled
+runtm-api scheduled-agents get 9f3c... | jq .next_run_at
+```
+
+`run-now` deliberately works on disabled agents — that is what makes this order
+possible. It stamps `last_run_at` / `last_session_id` like any other run.
+
+## Cron is 5 fields, in UTC, with no per-agent time zone
+
+Cloud Scheduler runs every job in `Etc/UTC`. There is no per-agent time zone
+setting, so a local time has to be converted by hand — and revisited when
+daylight saving shifts:
+
+| Intent | Winter (PST, UTC-8) | Summer (PDT, UTC-7) |
+|--------|--------------------|--------------------|
+| Daily 11am Pacific | `0 19 * * *` | `0 18 * * *` |
+| Mondays 11am Pacific | `0 19 * * 1` | `0 18 * * 1` |
+| Every hour | `0 * * * *` | `0 * * * *` |
+| Weekdays 9am Pacific | `0 17 * * 1-5` | `0 16 * * 1-5` |
+
+Confirm the schedule reads the way you meant by checking `next_run_at`, which
+the API derives from the cron:
+
+```bash
+runtm-api scheduled-agents list | jq '.agents[] | {name, cron, enabled, next_run_at, last_run_at}'
+```
+
+`next_run_at` is `null` when the agent is disabled — a disabled agent has no
+Scheduler job, so there is no next run to report.
+
+## Debugging "it was supposed to run and nothing happened"
+
+Work down this list; each step rules out one layer.
+
+```bash
+# 1. Is the schedule even live? enabled=false or next_run_at=null means no job.
+runtm-api scheduled-agents get <id> | jq '{enabled, cron, next_run_at, last_run_at, last_session_id}'
+
+# 2. Did a tick fire? Compare last_run_at against the time you expected.
+#    Unchanged => the schedule never fired (check enabled + the UTC conversion).
+#    Updated   => it fired and the failure is inside the run; go to step 4.
+
+# 3. Reproduce on demand. A 502 here carries the reason the tick would fail.
+runtm-api scheduled-agents run-now <id>
+
+# 4. Read what the run actually did.
+runtm-api session history <last_session_id>
+runtm-api session status <last_session_id>
+```
+
+Common causes, in rough order of frequency:
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `next_run_at` is null | Agent disabled | `update <id> --enabled` |
+| Fired an hour early/late | Daylight saving moved the UTC offset | Re-derive the cron from the table above |
+| `502` from `run-now` | The launch itself fails (unknown template, deleted Slack integration) | Read `detail`; fix the referenced resource |
+| `503` from `create`/`update` | Cloud Scheduler isn't configured in this environment | Create `--disabled` and drive it with `run-now` |
+| Ran, but nothing reached Slack | No Slack target configured, or the run errored before finishing | `get <id> \| jq '{slack_integration_id, slack_channel_id}'`, then `session history` |
+| Ran, output was wrong | The prompt or template is wrong, not the schedule | Iterate with `run-now`, not by waiting for ticks |
+
+## Slack output
+
+The integration and channel travel together — passing one without the other is
+rejected. When both are set, each run's result is posted to the channel as that
+integration's Slack app.
+
+```bash
+runtm-api scheduled-agents update <id> \
+  --slack-integration <integration_id> \
+  --slack-channel C0123456789
+```
+
+Find integration ids with `runtm-api agents list --type slack`.
+
+Runs are unattended (autopilot), so the prompt should say exactly what to
+produce and in what shape. A prompt that ends "post the Block Kit JSON" gets
+raw JSON pasted into the channel; say "post a short plain-text summary" if that
+is what you want a human to read at 11am.
+
+## Editing a schedule
+
+`update` only sends the flags you pass, so a partial edit never clobbers the
+prompt or cron it did not mention:
+
+```bash
+runtm-api scheduled-agents update <id> --cron '0 18 * * 1'   # DST shift
+runtm-api scheduled-agents update <id> --prompt 'New instructions'
+runtm-api scheduled-agents update <id> --disabled            # stop, keep the agent
+```
+
+Prefer `--disabled` over `delete` when pausing: it removes the Scheduler job but
+keeps the prompt, template binding, and Slack target so re-enabling is one call.
+
+## Related skills
+
+- `runtm-templates` — build the template a scheduled agent launches from, and
+  verify its skills are attached and baked (`attachments_changed_since_build`).
+- `runtm-agents` — Slack/GitHub agents that fire on events instead of a clock.
+- `runtm-sessions` — inspect the sessions a scheduled run creates.

--- a/packages/agent/skills/runtm-integrations.md
+++ b/packages/agent/skills/runtm-integrations.md
@@ -288,12 +288,19 @@ runtm-api skills detach <skill_id> --template <template_id>
 runtm-api skills detach <skill_id> --clear
 ```
 
-The template-side view — list what a template loads:
+Three equivalent ways to ask "what does this template load?" — use whichever
+you reached for first:
 
 ```bash
-runtm-api template skills <template_id>   # skills attached to the template
-runtm-api template mcp <template_id>      # MCP servers attached to the template
+runtm-api template skills <template_id>          # template-first
+runtm-api skills list --template <template_id>   # skills-first
+runtm-api template get <template_id> | jq .skills   # inline, plus staleness
 ```
+
+The same three exist for MCP servers (`template mcp`, `mcp list --template`,
+`template get | jq .mcp_servers`). Scope a listing to a repo instead with
+`--repo owner/name`. Every scoped form also includes org-wide items (those
+attached with `--all`), because those load too.
 
 Scopes & semantics:
 
@@ -310,14 +317,28 @@ Scopes & semantics:
 - Only **org-owned** skills/MCP servers can be attached (they come from an
   org-scoped key); personal directives cannot.
 
-The full flow to wire a skill into a template:
+The full flow to wire a skill into a template. **Creating a skill attaches it
+nowhere and bakes it nowhere** — both follow-up steps are required, and both
+fail silently if skipped:
 
 ```bash
 export RUNTM_API_KEY=runtm_sk_live_...   # org-scoped key
 SKILL_ID=$(runtm-api skills create --name deploy-checks --md ./SKILL.md | jq -r .directive.id)
+
+# 1. Attach it — without this, sessions boot without the skill
 runtm-api skills attach "$SKILL_ID" --template <template_id>
-runtm-api template skills <template_id>          # verify it's listed
+
+# 2. Verify, and check whether the snapshot is now behind the config
+runtm-api template get <template_id> | jq '{skills: [.skills[].name], stale: .attachments_changed_since_build}'
+
+# 3. Rebuild if stale — attaching changes config, not the built image
+runtm-api template build <template_id>
 ```
+
+`attachments_changed_since_build: true` means the attachments moved after the
+last build, so sessions still boot with the old set until you rebuild. That
+flag is the reason to prefer `template get` over `template skills` when you are
+about to trust a template.
 
 ---
 

--- a/packages/agent/skills/runtm-sessions.md
+++ b/packages/agent/skills/runtm-sessions.md
@@ -1,8 +1,8 @@
 ---
 name: runtm-sessions
-description: "Multi-step workflow recipes for Runtm Cloud sessions: launching agents, iterating with prompts, polling status, reading/writing files, managing env vars, and opening PRs."
+description: "Multi-step workflow recipes for Runtm Cloud sessions: launching agents, iterating with prompts, polling status, running commands with exec (incl. --json), reading/writing files, managing env vars, and opening PRs."
 metadata:
-  version: "0.4.0"
+  version: "0.5.0"
   tags: runtm,runtime,sessions,workflows,sandboxes
 ---
 
@@ -16,6 +16,7 @@ Workflow recipes for the `runtm-api session` subcommands. For endpoint details s
 |------|-----|
 | Boot a session from a prebuilt org template | `session create --template-id <uuid>` |
 | Run a single shell command in a session | `session exec <id> -- <command>` (scripted, returns its exit code) |
+| Run a command whose output you will **parse** | `session exec <id> --json -- <command>` |
 | Open a live interactive shell | `session connect <id>` (raw PTY; needs a TTY) |
 | Fire-and-forget background task | `session launch` (v0 -- creates + prompts in one call) |
 | Interactive, streaming response right now | `session create` then `session prompt` |
@@ -63,7 +64,7 @@ runtm-api session connect a6414511-4430-4e1f-8c51-8ea8824dadec
 Two ways to get a shell against a session's sandbox, both over the same terminal WebSocket the dashboard uses (scope: `sessions:terminal`):
 
 ```bash
-# Non-interactive: run one command, stream its output, exit with its exit code.
+# Non-interactive: run one command, print its output, exit with its exit code.
 # A throwaway PTY is used, so it never disturbs interactive terminals. Put the
 # command after `--` so runtm-api does not parse its flags.
 runtm-api session exec <id> -- pwd
@@ -77,7 +78,35 @@ runtm-api session connect <id>
 runtm-api session connect <id> --terminal default   # share the dashboard terminal
 ```
 
-Use `exec` for automation and scripted checks; use `connect` only when a human is at a real terminal. `exec` output is the raw PTY stream and may contain minor terminal formatting.
+Use `exec` for automation and scripted checks; use `connect` only when a human is at a real terminal.
+
+### `--json`: use it whenever you will parse the output
+
+The default output is the raw PTY stream: stderr is merged into stdout and the sandbox's shell startup noise (mise, nvm, and similar banners) rides along, which is why hand-rolled pipelines end up with a `grep -v` filter. `--json` avoids all of that:
+
+```bash
+runtm-api session exec <id> --json -- npm test
+# -> {"stdout": "...", "stderr": "...", "exit_code": 1}
+
+# Read one stream at a time
+runtm-api session exec <id> --json -- ./build.sh | jq -r .stderr
+
+# Branch on the exit code without trusting $? through a pipe
+result=$(runtm-api session exec <id> --json -- pytest -q || true)
+[ "$(jq -r .exit_code <<<"$result")" = "0" ] || echo "tests failed"
+```
+
+- The two streams are captured separately (stderr goes to a temp file in the sandbox and is replayed after a sentinel), so neither can interleave into the other.
+- PTY carriage returns are stripped, so `stdout` compares cleanly against expected text.
+- The process **still exits with the remote exit code**, so under `set -e` a failing command aborts the script before you can read the JSON — capture it with `|| true` as above, then read `exit_code`.
+
+### `!` is safe
+
+Bash history expansion is disabled for the command in both modes. A literal `!` in a heredoc, a commit message, or a regex reaches the sandbox intact instead of being silently rewritten against shell history.
+
+### Paused sandboxes resume automatically
+
+Sessions auto-pause after ~20 minutes idle. `exec`, `connect`, and the file commands now resume a paused sandbox in place rather than failing, so a scripted run against a session you left alone yesterday just works. The first command after a resume takes a few extra seconds. Use `session pause` when you deliberately want to stop the clock.
 
 ## Recipe: launch an agent from scratch
 

--- a/packages/agent/skills/runtm-templates.md
+++ b/packages/agent/skills/runtm-templates.md
@@ -1,8 +1,8 @@
 ---
 name: runtm-templates
-description: "Full lifecycle workflows for Runtm Cloud org templates: discover, create, build, monitor builds, fix broken templates via fix-session, save snapshots, manage template secrets."
+description: "Full lifecycle workflows for Runtm Cloud org templates: discover, create, build, monitor builds, verify attached skills and build staleness, fix broken templates via fix-session, save snapshots, manage template secrets."
 metadata:
-  version: "0.4.0"
+  version: "0.5.0"
   tags: runtm,runtime,templates,org,workflows
 ---
 
@@ -49,6 +49,49 @@ Key fields to inspect:
 - `has_all_required`: false means a template will fail to boot until missing secrets are set.
 - `services`: array of detected services (web, api, db). Each has its own port + start_cmd.
 - `agents`: list of coding agents the snapshot was built for.
+- `skills` / `mcp_servers`: what a session from this template actually loads.
+- `attachments_changed_since_build`: true means those changed after the last build, so the snapshot is behind.
+
+## Recipe: verify a template loads the skills you think it does
+
+Skills define agent behaviour, and the two ways to get this wrong are both silent: creating a skill and never attaching it, or attaching one and never rebuilding. `template get` reports both:
+
+```bash
+runtm-api template get <tmpl_id> | jq '{
+  skills: [.skills[] | {name, attached_via}],
+  mcp: [.mcp_servers[].name],
+  stale: .attachments_changed_since_build
+}'
+```
+
+```json
+{
+  "skills": [
+    { "name": "outbound-writing", "attached_via": "template" },
+    { "name": "company-context", "attached_via": "all" }
+  ],
+  "mcp": ["notion"],
+  "stale": true
+}
+```
+
+| What you see | What it means | Fix |
+|---|---|---|
+| `skills: []` | Nothing is attached, however many skills exist in the org | `runtm-api skills attach <skill_id> --template <tmpl_id>` |
+| `stale: true` | Attachments changed after the snapshot was built; sessions boot with the old set | `runtm-api template build <tmpl_id>` |
+| `attached_via: "template"` | Attached directly to this template | Detach with `skills detach <id> --template <tmpl_id>` |
+| `attached_via: "repo"` | Reaches the template through one of its repos | Detach with `skills detach <id> --repo owner/name` |
+| `attached_via: "all"` | Org-wide (`--all`), loads into every session | Detach with `skills detach <id> --all` |
+
+The same list is available from either direction, so use whichever command you reached for first:
+
+```bash
+runtm-api template get <tmpl_id> | jq .skills   # inline, plus staleness
+runtm-api template skills <tmpl_id>             # template-first
+runtm-api skills list --template <tmpl_id>      # skills-first
+```
+
+Full attach/detach mechanics live in the `runtm-integrations` skill.
 
 ## Recipe: create a new template
 


### PR DESCRIPTION
Closes the CLI gaps that let a broken automation reach Slack unnoticed and made attached skills invisible from the commands people actually reach for. Backend counterpart: runtm-ai/runtm-cloud#346.

## `scheduled-agents` — the automation primitive had no CLI

Adds `list` / `get` / `create` / `update` / `run-now` / `delete` against `/api/v1/scheduled-agents` (aliases: `schedules`, `cron`).

`run-now` is the point of the change. It executes the same path the cron tick takes — same template resolution, same Slack target, same orchestrator call — so a bad template name or a deleted Slack integration fails in front of you instead of silently at 11am. It works on **disabled** agents, which makes the safe order possible:

```bash
runtm-api scheduled-agents create --name weekly --disabled --cron '0 18 * * 1' --prompt '...'
runtm-api scheduled-agents run-now <id>      # prove it, get a session_id back
runtm-api scheduled-agents update <id> --enabled
```

Listings carry `next_run_at` (null when disabled) next to `last_run_at`, so you can tell at a glance whether a schedule is actually live. Cron is 5 fields in UTC with no per-agent timezone, which the help text and the new skill spell out along with the DST offsets.

## Skills findable from wherever you start looking

`skills list --template <id>` now answers the same question as `template skills <id>`, and `template get` carries the resolved list inline along with `attachments_changed_since_build`. Three routes to one answer, so the one you happen to try first is not a dead end. `--repo owner/name` scopes the same way.

**Bug found while here:** `mcp list` and `template mcp` sent `type_family=mcp_server`, which matches no family. The backend treats an unknown family as *no type filter*, so both were quietly returning skills mixed into the results. Now sends `mcp`; the backend also aliases the old value for CLI binaries already baked into sandbox snapshots.

## `session exec --json`

Emits `{stdout, stderr, exit_code}` with the streams genuinely separated (stderr captured to a pid-scoped temp file and replayed after a sentinel) and PTY carriage returns stripped. Parsing exec output no longer means filtering shell startup banners out of a merged stream.

## Two shell fixes in the exec payload

Both found by running the payload against a real shell rather than reasoning about it:

- **History expansion is now disabled.** The sandbox PTY is bash, where `!` is expanded against history as the line is read — before the command runs — so a literal `!` in a heredoc, commit message, or regex was silently rewritten. The guard probes in a subshell first (`if (set +H) 2>/dev/null; then set +H; fi`) because `set +H` is *unrecoverable* in shells that lack it: dash aborts on the spot, before a trailing `|| true` can run. Verified across bash, dash, sh, and zsh.
- **The command runs in a subshell.** A bare `exit 3` previously killed the wrapper shell before it printed the end marker, surfacing as "connection closed before the command completed" with the output lost. This affected the default mode too, so it is a pre-existing bug fixed here.

## Docs

New `runtm-automation` skill (cron syntax, the create-disabled → run-now → enable order, and a debugging table for "it was supposed to run and nothing happened"), new `cloud-api/scheduled-agents` pages, and updates to `SKILL.md`, the sessions / templates / integrations skills, `agent-cli`, `templates/get`, and `sessions/lifecycle`. Embedded `internal/skills/files/` copies are synced.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` passes, including new coverage for the stream split, the history-expansion guard, the subshell wrapping, and the command tree
- [x] Exec payload exercised against a real interactive bash: verified separated stdout/stderr, correct exit code for `exit 7` and for a failing command, and that `set +H` flips `histexpand` off without breaking dash/sh/zsh
- [ ] End-to-end `run-now` against a live scheduled agent once the backend PR is deployed

Made with [Cursor](https://cursor.com)