### PR TITLE
fix(agent): stop history expansion from rewriting exec commands

### DIFF
--- a/packages/agent/internal/auth/auth.go
+++ b/packages/agent/internal/auth/auth.go
@@ -60,7 +60,7 @@ func Load(apiURLOverride, orgOverride string) (*Credentials, error) {
 }
 
 // LoadOptional returns credentials when present and nil when missing, without
-// erroring. Useful for `runtm auth status` which should not fail when unset.
+// erroring. Useful for `runtm-api auth status` which should not fail when unset.
 func LoadOptional(apiURLOverride, orgOverride string) *Credentials {
 	creds, err := Load(apiURLOverride, orgOverride)
 	if err != nil {

--- a/packages/agent/internal/cmd/runtime.go
+++ b/packages/agent/internal/cmd/runtime.go
@@ -218,7 +218,7 @@ func (r *Runtime) ReportError(err error) int {
 		case http.StatusUnauthorized:
 			payload["hint"] = "Check RUNTM_API_KEY or rotate the key in the dashboard."
 		case http.StatusForbidden:
-			payload["hint"] = "Run `runtm auth status` to inspect scopes and org context."
+			payload["hint"] = "Run `runtm-api auth status` to inspect scopes and org context."
 		case http.StatusNotFound:
 			payload["hint"] = "Run the matching list command to discover valid IDs."
 		case http.StatusTooManyRequests:

--- a/packages/agent/internal/cmd/runtime_test.go
+++ b/packages/agent/internal/cmd/runtime_test.go
@@ -239,3 +239,34 @@ func TestRequireOrgClientPersonalKeyGuidance(t *testing.T) {
 		t.Errorf("hint should explain the 403, got %q", payload.Hint)
 	}
 }
+
+func TestErrorHintsNameThisBinary(t *testing.T) {
+	// A hint that names a command of this binary has to spell it `runtm-api`.
+	// `runtm` is the separate pip CLI, so `runtm auth status` sent people to a
+	// tool that does not have the subcommand. Only `runtm login` is genuinely
+	// the pip CLI's, so that one stays.
+	for status, hint := range map[int]string{
+		http.StatusUnauthorized:    "Check RUNTM_API_KEY",
+		http.StatusForbidden:       "auth status",
+		http.StatusNotFound:        "list command",
+		http.StatusTooManyRequests: "Rate limited",
+	} {
+		stderr := &bytes.Buffer{}
+		rt := &Runtime{Flags: &GlobalFlags{}, Stdout: &bytes.Buffer{}, Stderr: stderr}
+
+		rt.ReportError(&client.APIError{Status: status, Detail: "nope"})
+
+		var payload struct {
+			Hint string `json:"hint"`
+		}
+		if err := json.Unmarshal(stderr.Bytes(), &payload); err != nil {
+			t.Fatalf("status %d: unmarshal %q: %v", status, stderr.String(), err)
+		}
+		if !strings.Contains(payload.Hint, hint) {
+			t.Errorf("status %d: hint %q should mention %q", status, payload.Hint, hint)
+		}
+		if strings.Contains(payload.Hint, "`runtm ") && !strings.Contains(payload.Hint, "`runtm login") {
+			t.Errorf("status %d: hint names the pip CLI for a runtm-api command: %q", status, payload.Hint)
+		}
+	}
+}

--- a/packages/agent/internal/cmd/session_terminal_cmd.go
+++ b/packages/agent/internal/cmd/session_terminal_cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -315,46 +316,60 @@ func splitExecStreams(output []byte, pid string) (stdout, stderr []byte) {
 	return output[:m[0]], output[m[1]:]
 }
 
-// execPayload builds the one-line shell program the PTY runs.
+// execPayload builds the shell program the PTY runs.
 //
-// Three things it has to get right:
+// Four things it has to get right:
 //
-//  1. `set +H` disables bash history expansion. E2B's pty.create() always
-//     starts bash, and an interactive bash expands `!` against history as the
-//     line is read — before the command ever runs. So a literal `!` in a
-//     heredoc, a commit message, or a regex silently rewrites the command.
-//     The option is probed in a subshell first because `set +H` is an
-//     *unrecoverable* error in shells that lack it (dash aborts on the spot,
-//     before a trailing `|| true` can run); the subshell contains that.
+//  1. The command travels base64-encoded and is decoded into a variable the
+//     wrapper `eval`s. Nothing the caller wrote ever appears on a line the
+//     interactive shell reads, which is what makes `!` safe: bash expands `!`
+//     against history as it accepts a line, long before the command runs, so
+//     an inlined `!!` in a commit message or regex came back as the *previous*
+//     command's text. Expansion does not apply to `eval`, so encoding removes
+//     the hazard at the source rather than trying to switch it off in time.
 //
-//  2. The command runs in a subshell, so `exit 3` (or anything that calls
+//  2. Encoding also lets a command span lines. Inlined, the newlines in a
+//     heredoc split the wrapper itself across lines, so the end marker never
+//     printed and the call hung until it timed out.
+//
+//  3. The command runs in a subshell, so `exit 3` (or anything that calls
 //     `exit`) yields an exit code instead of killing the wrapper before it can
 //     print the end marker — which surfaced as "connection closed before the
 //     command completed" with the output lost.
 //
-//  3. When splitStreams is set, stderr is redirected to a pid-scoped temp file
+//  4. When splitStreams is set, stderr is redirected to a pid-scoped temp file
 //     and replayed after a mid sentinel, which is what lets --json hand back
 //     stdout and stderr separately. Otherwise the two interleave as before.
+//
+// `set +H` stays as a second line of defence for the wrapper itself. It is
+// probed in a subshell first because `set +H` is an *unrecoverable* error in
+// shells that lack it (dash aborts on the spot, before a trailing `|| true`
+// could run); the subshell contains that.
 func execPayload(cmdLine string, splitStreams bool) string {
-	const prelude = "if (set +H) 2>/dev/null; then set +H; fi; "
+	const prelude = "if (set +H) 2>/dev/null; then set +H; fi\n"
+
+	// A missing base64 would otherwise decode to nothing and run nothing,
+	// reporting success for a command that never executed.
+	decode := fmt.Sprintf(
+		"__c=$(printf %%s '%s' | base64 -d 2>/dev/null) || "+
+			"__c='echo \"runtm-api: exec needs base64, which is missing from this sandbox\" >&2; exit 127'; ",
+		base64.StdEncoding.EncodeToString([]byte(cmdLine)),
+	)
 
 	if !splitStreams {
-		return prelude + fmt.Sprintf(
-			"printf '__RUNTM_%%d_S\\n' \"$$\"; ( %s ); __rc=$?; printf '__RUNTM_%%d_E%%d\\n' \"$$\" \"$__rc\"; exit\n",
-			cmdLine,
-		)
+		return prelude + decode +
+			"printf '__RUNTM_%d_S\\n' \"$$\"; ( eval \"$__c\" ); __rc=$?; " +
+			"printf '__RUNTM_%d_E%d\\n' \"$$\" \"$__rc\"; exit\n"
 	}
 	// Order matters: print the start marker, run with stderr captured, then
 	// mid marker, then replay stderr, then the exit marker carrying $?.
-	return prelude + fmt.Sprintf(
-		"__errf=$(mktemp 2>/dev/null || echo /tmp/runtm-exec-$$.err); "+
-			"printf '__RUNTM_%%d_S\\n' \"$$\"; "+
-			"( %s ) 2>\"$__errf\"; __rc=$?; "+
-			"printf '__RUNTM_%%d_M\\n' \"$$\"; "+
-			"cat \"$__errf\" 2>/dev/null; rm -f \"$__errf\"; "+
-			"printf '__RUNTM_%%d_E%%d\\n' \"$$\" \"$__rc\"; exit\n",
-		cmdLine,
-	)
+	return prelude + decode +
+		"__errf=$(mktemp 2>/dev/null || echo /tmp/runtm-exec-$$.err); " +
+		"printf '__RUNTM_%d_S\\n' \"$$\"; " +
+		"( eval \"$__c\" ) 2>\"$__errf\"; __rc=$?; " +
+		"printf '__RUNTM_%d_M\\n' \"$$\"; " +
+		"cat \"$__errf\" 2>/dev/null; rm -f \"$__errf\"; " +
+		"printf '__RUNTM_%d_E%d\\n' \"$$\" \"$__rc\"; exit\n"
 }
 
 // normalizeExecOutput turns PTY line endings into plain newlines. The remote
@@ -387,8 +402,9 @@ the default merged stream also carries shell startup noise that otherwise has
 to be filtered out. The process still exits with the remote exit code, so
 check exit_code or the process status, not both.
 
-Bash history expansion is disabled for the command, so '!' is safe to use in
-heredocs, commit messages, and regexes.
+The command is sent encoded, so it may span lines (heredocs and short scripts
+work) and '!' stays literal in commit messages, regexes, and heredoc bodies
+instead of being replaced by bash history expansion.
 
 A paused sandbox is resumed automatically. Scope required: sessions:terminal.`,
 		Args: cobra.MinimumNArgs(2),

--- a/packages/agent/internal/cmd/session_terminal_cmd_test.go
+++ b/packages/agent/internal/cmd/session_terminal_cmd_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/base64"
 	"net/url"
 	"strings"
 	"testing"
@@ -186,6 +187,27 @@ func TestNormalizeExecOutput(t *testing.T) {
 
 // --- payload construction -------------------------------------------------
 
+// payloadCommand recovers the command execPayload encoded, so the tests can
+// assert on what will actually run rather than on the wrapper's scaffolding.
+func payloadCommand(t *testing.T, payload string) string {
+	t.Helper()
+	const open = "printf %s '"
+	i := strings.Index(payload, open)
+	if i < 0 {
+		t.Fatalf("payload does not carry an encoded command: %q", payload)
+	}
+	rest := payload[i+len(open):]
+	j := strings.Index(rest, "'")
+	if j < 0 {
+		t.Fatalf("unterminated encoded command: %q", payload)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(rest[:j])
+	if err != nil {
+		t.Fatalf("command is not valid base64: %v", err)
+	}
+	return string(decoded)
+}
+
 func TestExecPayloadDisablesHistoryExpansion(t *testing.T) {
 	// Bash history expansion rewrites '!' before the command runs, which has
 	// silently corrupted heredocs and commit messages. The subshell probe
@@ -193,8 +215,51 @@ func TestExecPayloadDisablesHistoryExpansion(t *testing.T) {
 	// the shell down before the fallback could run.
 	for _, split := range []bool{false, true} {
 		payload := execPayload("echo hi", split)
-		if !strings.HasPrefix(payload, "if (set +H) 2>/dev/null; then set +H; fi; ") {
+		if !strings.HasPrefix(payload, "if (set +H) 2>/dev/null; then set +H; fi\n") {
 			t.Errorf("split=%v: payload must start by disabling history expansion, got %q", split, payload)
+		}
+	}
+}
+
+func TestExecPayloadEncodesCommand(t *testing.T) {
+	// The real guard against history expansion: a '!' the caller wrote must
+	// never reach a line the interactive shell reads, because expansion
+	// happens as that line is accepted. Encoded, `!!` stays literal.
+	const cmdLine = `git commit -m "fix: don't drop events!!"`
+	for _, split := range []bool{false, true} {
+		payload := execPayload(cmdLine, split)
+		if strings.Contains(payload, "!") {
+			t.Errorf("split=%v: payload must not carry a raw '!', got %q", split, payload)
+		}
+		if got := payloadCommand(t, payload); got != cmdLine {
+			t.Errorf("split=%v: encoded command = %q, want %q", split, got, cmdLine)
+		}
+	}
+}
+
+func TestExecPayloadEncodesMultilineCommand(t *testing.T) {
+	// Inlined, a heredoc's newlines split the wrapper across lines, so the end
+	// marker never printed and the call hung until it timed out.
+	cmdLine := "cat <<EOF\nhello\nEOF"
+	for _, split := range []bool{false, true} {
+		payload := execPayload(cmdLine, split)
+		if got := payloadCommand(t, payload); got != cmdLine {
+			t.Errorf("split=%v: encoded command = %q, want %q", split, got, cmdLine)
+		}
+		// The wrapper itself stays on one line after the guard.
+		if body := payload[strings.Index(payload, "\n")+1:]; strings.Count(body, "\n") != 1 {
+			t.Errorf("split=%v: wrapper must be a single line, got %q", split, body)
+		}
+	}
+}
+
+func TestExecPayloadFailsLoudlyWithoutBase64(t *testing.T) {
+	// A missing base64 decodes to nothing, and running nothing would report
+	// success for a command that never executed.
+	for _, split := range []bool{false, true} {
+		payload := execPayload("npm test", split)
+		if !strings.Contains(payload, "exit 127") {
+			t.Errorf("split=%v: payload must fail when base64 is unavailable, got %q", split, payload)
 		}
 	}
 }
@@ -204,7 +269,7 @@ func TestExecPayloadRunsCommandInSubshell(t *testing.T) {
 	// printed the end marker, losing both the output and the exit code.
 	for _, split := range []bool{false, true} {
 		payload := execPayload("exit 3", split)
-		if !strings.Contains(payload, "( exit 3 )") {
+		if !strings.Contains(payload, `( eval "$__c" )`) {
 			t.Errorf("split=%v: command must run in a subshell, got %q", split, payload)
 		}
 	}
@@ -218,18 +283,18 @@ func TestExecPayloadMergedStreamsByDefault(t *testing.T) {
 	if strings.Contains(payload, "mktemp") {
 		t.Error("default payload must not redirect stderr to a file")
 	}
-	if !strings.Contains(payload, "npm test") {
-		t.Error("payload must contain the command")
+	if got := payloadCommand(t, payload); got != "npm test" {
+		t.Errorf("encoded command = %q, want %q", got, "npm test")
 	}
 }
 
 func TestExecPayloadSplitStreams(t *testing.T) {
 	payload := execPayload("npm test", true)
 	for _, want := range []string{
-		`( npm test ) 2>"$__errf"`, // stderr captured, not interleaved
-		`_M\n`,                     // mid marker separates the streams
-		`cat "$__errf"`,            // stderr replayed after the marker
-		`rm -f "$__errf"`,          // and cleaned up
+		`( eval "$__c" ) 2>"$__errf"`, // stderr captured, not interleaved
+		`_M\n`,                        // mid marker separates the streams
+		`cat "$__errf"`,               // stderr replayed after the marker
+		`rm -f "$__errf"`,             // and cleaned up
 	} {
 		if !strings.Contains(payload, want) {
 			t.Errorf("split payload missing %q\ngot: %s", want, payload)


### PR DESCRIPTION
## Summary

Found by running the released binary against prod. Two of these are bugs in code that shipped in #49/#50.

**History expansion was still rewriting commands.** `session exec` disabled it with a `set +H` that shared a line with the command. Bash applies expansion as it *accepts* a line, so the guard ran after that line had already been rewritten. Against a live sandbox:

```
$ runtm-api session exec $SID --json -- 'echo "wow!! done"'
{"stdout": "wowif (set +H) 2>/dev/null; then set +H; fi; __errf=/tmp/... it works\n", ...}
```

`!!` had been substituted with the previous exec's payload. `!word` forms (`echo "oops!ls"`, `grep "a!b"`) were worse: expansion failed, the end marker never printed, and the call hung until it timed out.

**Multi-line commands hung.** Inlined, a heredoc's newlines split the wrapper itself across lines, so the end marker never printed. `session exec` returned `connection closed before the command completed` after ~45s, even though the help text advertised heredocs.

The fix for both: the command travels base64-encoded and is decoded into a variable the wrapper `eval`s. Nothing the caller wrote reaches a line the interactive shell reads, and expansion does not apply to `eval` — so the hazard is removed at the source rather than raced. A missing `base64` now fails loudly instead of evaluating an empty string and reporting success for a command that never ran.

**Wrong binary in the 403 hint.** It said `runtm auth status`; `runtm` is the separate pip CLI and has no such subcommand. Dates to the CLI's first commit.

## Verification

Against a live prod sandbox, before and after:

| case | before | after |
|---|---|---|
| `echo "wow!! done"` | previous command spliced in | `wow!! done` |
| `echo "oops!ls here"` | hung to timeout | `oops!ls here` |
| `grep -c "a!b" /dev/null` | hung to timeout | exits 1, `rc=1` |
| heredoc with `!!` and `$(...)` | hung to timeout | body + substitution correct |
| multi-line `if` block | hung to timeout | runs |
| `git commit -m "...events!!"` | corrupted | literal |

Also re-ran the full exec matrix clean: quoting (single, double, `$'...'`), unicode, tabs, backslashes, backticks, empty output, exit codes 0/5/7/127/255, stdout/stderr separation, and 5000 lines of output byte-intact.

## Test plan

- [x] `go test ./...` green
- [x] `go vet ./...` and `gofmt` clean
- [x] New: payload is encoded, carries no raw `!`, round-trips multi-line, and fails loudly without base64
- [x] New: error hints name `runtm-api`, not the pip CLI — verified red/green by reverting the fix
- [x] Verified against a live prod sandbox (created and destroyed a throwaway session)

Backend counterpart, including the `exec` auto-resume gap this testing also surfaced: runtm-ai/runtm-cloud#350

Made with [Cursor](https://cursor.com)