### PR TITLE
fix(agent): per-request timeout + --timeout flag for template save-snapshot

### DIFF
--- a/packages/agent/internal/client/client.go
+++ b/packages/agent/internal/client/client.go
@@ -79,6 +79,17 @@ func (c *Client) PostJSON(path string, body any) ([]byte, error) {
 	return c.do(http.MethodPost, path, nil, payload)
 }
 
+// PostJSONWithTimeout is PostJSON with a per-request timeout override for
+// long-running synchronous endpoints (e.g. template save-snapshot, which can
+// exceed the default cap on large templates).
+func (c *Client) PostJSONWithTimeout(path string, body any, timeout time.Duration) ([]byte, error) {
+	payload, err := marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	return c.doWithTimeout(http.MethodPost, path, nil, payload, timeout)
+}
+
 // PutJSON marshals body as JSON and PUTs it, returning the response body.
 func (c *Client) PutJSON(path string, body any) ([]byte, error) {
 	payload, err := marshal(body)
@@ -204,12 +215,16 @@ func (c *Client) streamSSE(method, path string, body []byte, out io.Writer) erro
 }
 
 func (c *Client) do(method, path string, query url.Values, body []byte) ([]byte, error) {
+	// Cap non-streaming requests at 2 minutes; SSE bypasses this path.
+	return c.doWithTimeout(method, path, query, body, 2*time.Minute)
+}
+
+func (c *Client) doWithTimeout(method, path string, query url.Values, body []byte, timeout time.Duration) ([]byte, error) {
 	req, err := c.newRequest(method, path, query, body)
 	if err != nil {
 		return nil, err
 	}
-	// Cap non-streaming requests at 2 minutes; SSE bypasses this path.
-	c.http.Timeout = 2 * time.Minute
+	c.http.Timeout = timeout
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/packages/agent/internal/cmd/template.go
+++ b/packages/agent/internal/cmd/template.go
@@ -586,6 +586,11 @@ command waits longer than other calls; tune with --timeout.`,
 			if sessionID == "" {
 				return fmt.Errorf("--session is required")
 			}
+			if timeoutSecs <= 0 {
+				return fmt.Errorf("--timeout must be positive")
+			}
+				return fmt.Errorf("--session is required")
+			}
 			c, _, err := requireOrgClient(rt, "org templates")
 			if err != nil {
 				return err

--- a/packages/agent/internal/cmd/template.go
+++ b/packages/agent/internal/cmd/template.go
@@ -586,10 +586,10 @@ command waits longer than other calls; tune with --timeout.`,
 			if sessionID == "" {
 				return fmt.Errorf("--session is required")
 			}
+			// A zero http.Client.Timeout means "wait forever" — reject it so a
+			// typo can't silently disable the timeout.
 			if timeoutSecs <= 0 {
-				return fmt.Errorf("--timeout must be positive")
-			}
-				return fmt.Errorf("--session is required")
+				return fmt.Errorf("--timeout must be a positive number of seconds")
 			}
 			c, _, err := requireOrgClient(rt, "org templates")
 			if err != nil {

--- a/packages/agent/internal/cmd/template.go
+++ b/packages/agent/internal/cmd/template.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/runtm-ai/runtm/packages/agent/internal/client"
 	"github.com/spf13/cobra"
@@ -571,11 +572,15 @@ Required scope: templates:write.`,
 
 func newTemplateSaveSnapshot(rt *Runtime) *cobra.Command {
 	var sessionID string
+	var timeoutSecs int
 	cmd := &cobra.Command{
 		Use:   "save-snapshot <template_id>",
 		Short: "Promote a session's sandbox state into the template snapshot",
 		Long: `After fixing or extending a fix-session, save its sandbox as the template's
-new snapshot. Existing sessions keep using the old snapshot until destroyed.`,
+new snapshot. Existing sessions keep using the old snapshot until destroyed.
+
+Snapshotting is synchronous and can take minutes on large templates, so this
+command waits longer than other calls; tune with --timeout.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if sessionID == "" {
@@ -586,11 +591,18 @@ new snapshot. Existing sessions keep using the old snapshot until destroyed.`,
 				return err
 			}
 			body := map[string]any{"session_id": sessionID}
-			resp, err := c.PostJSON("/org-templates/"+url.PathEscape(args[0])+"/save-snapshot", body)
+			resp, err := c.PostJSONWithTimeout(
+				"/org-templates/"+url.PathEscape(args[0])+"/save-snapshot",
+				body,
+				time.Duration(timeoutSecs)*time.Second,
+			)
 			return runJSON(rt, resp, err)
 		},
 	}
 	cmd.Flags().StringVar(&sessionID, "session", "", "Session ID whose sandbox to snapshot (required)")
+	// Default sits above the server proxy's 150s ceiling so a slow save
+	// surfaces the server's error instead of the client hanging up first.
+	cmd.Flags().IntVar(&timeoutSecs, "timeout", 180, "Seconds to wait for the snapshot to complete")
 	_ = cmd.MarkFlagRequired("session")
 	return cmd
 }


### PR DESCRIPTION
## Problem

A customer's per-merge snapshot re-bake automation has failed 100% of the time since Jul 21 (~21:09 UTC): `runtm-api template save-snapshot` dies at exactly 30s with a bare `{"error":"Internal Server Error","status":500}`.

Root cause is server-side — the `/api/cloud/*` Next.js rewrite in runtm-cloud proxies CLI traffic to the FastAPI backend with Next's default 30s `proxyTimeout`, which kills long saves mid-flight (fix landing in runtm-cloud: `experimental.proxyTimeout: 150_000`). But once that wall is lifted, the CLI's own blanket 2-minute cap becomes the next ceiling, and `save-snapshot` exposes no lever to tune it.

## Change

- `client.go`: add `PostJSONWithTimeout`; `do()` now delegates to `doWithTimeout` with the unchanged 2-minute default, so every other call behaves exactly as before.
- `template.go`: `save-snapshot` uses the new call with a `--timeout` flag defaulting to **180s** — deliberately above the rewrite proxy's 150s ceiling so a slow save surfaces the server's error rather than the client hanging up first.

## Verification

Against a 45s-slow stub backend behind the actual Next rewrite:
- `runtm-api template save-snapshot` → HTTP 200, exit 0 in 45.8s (previously a bare 500 at 30s through the proxy).
- `--timeout 10` → aborts at 10.3s, confirming flag plumbing.
- `go build` / `go vet` / `go test ./internal/...` pass; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)