### PR TITLE
docs(agent): add the build-an-agent recipe and name the capability chain

### DIFF
--- a/packages/agent/internal/skills/files/SKILL.md
+++ b/packages/agent/internal/skills/files/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: runtm
-description: "Runtm (Runtime) Cloud CLI for AI agents. Full cloud-API surface: sessions (CRUD + search + files + upload/download + env + deploy + approvals + capability loading + lifecycle + history + events), the agent roster (identity + instructions + evaluation rubric + budget + scorecard + run grades), scheduled agents (cron automation + run-now), org templates (CRUD + build + context + guardrails + owning groups + secrets), guardrail content (allowlist rules, hooks, network rules), skills lifecycle (import, discover, resync, lock), deployments, GitHub App installations, groups, activity telemetry, secrets, instructions, LLM provider keys, external integrations (MCP, tools, Slack, GitHub, Linear, Email). Trigger on: runtm, runtime, runtm cloud, runtime cloud, runtm session, runtime session, cloud sandbox, integration, integrations, mcp, skill, provider key, scheduled agent, cron, automation, agent roster, evals, evaluation, scorecard, guardrail, approvals, deployment."
+description: "Runtm (Runtime) Cloud CLI for AI agents. Full cloud-API surface: sessions (CRUD + search + files + upload/download + env + deploy + approvals + capability loading + lifecycle + history + events), the agent roster (identity + instructions + evaluation rubric + budget + scorecard + run grades), scheduled agents (cron automation + run-now), org templates (CRUD + build + context + guardrails + owning groups + secrets), guardrail content (allowlist rules, hooks, network rules), skills lifecycle (import, discover, resync, lock), deployments, GitHub App installations, groups, activity telemetry, secrets, instructions, LLM provider keys, external integrations (MCP, tools, Slack, GitHub, Linear, Email). Trigger on: runtm, runtime, runtm cloud, runtime cloud, runtm session, runtime session, cloud sandbox, integration, integrations, mcp, skill, provider key, scheduled agent, cron, automation, agent roster, evals, evaluation, scorecard, guardrail, approvals, deployment, build an agent, create an agent, support agent."
 metadata:
-  version: "0.10.0"
+  version: "0.11.0"
   repository: https://github.com/runtm-ai/runtm
   tags: runtm,runtime,cli,sandboxes,coding-agents
 ---
@@ -54,6 +54,18 @@ Use `session connect` when a human wants a live shell; use `session exec` for sc
 **Always pass `--json` to `session exec` when you are going to parse the output.** The default is the raw PTY stream, which merges stderr into stdout and carries shell startup noise (mise/nvm banners and the like) that you would otherwise have to filter out with `grep -v`. `--json` captures the two streams separately and strips PTY carriage returns.
 
 To parameterize a template, declare **session arguments** with `--session-arg` (each becomes an env var in the session); supply values at boot with `session create --template-id <uuid> --template-args KEY=VALUE`. See the `runtm-templates` skill.
+
+## Other common path: building an agent
+
+The loop above is for **driving a sandbox yourself**. When the ask is "build me an agent that does X" (support triage, on-call, research, code review), the shape is different and the order matters. Read the **`runtm-build-agent`** skill first.
+
+The one thing to know before you start: **every capability an agent has hangs off one template.**
+
+```
+trigger -> roster agent -> template -> { skills, MCP servers, tools, guardrails, context } -> session
+```
+
+So a roster agent without `--template` can do nothing special, a skill that is never attached to that template is never loaded, and an attachment made after the last build does nothing until you rebuild. All three fail **silently**. Create the template, attach everything, verify with `template get`, then build **once**. Note that `template create --skip-agent` implies `--build`, so the fast path above will bake an empty template if you meant to attach skills to it.
 
 ## Quick Reference
 
@@ -424,7 +436,8 @@ If `authenticated: false`, ask the user to set `RUNTM_API_KEY` (or run `runtm-ap
 - `runtm-templates` -- full template lifecycle (create, build, fix, snapshot).
 - `runtm-debug` -- inspect a session's state when something is wrong.
 - `runtm-integrations` -- add/connect an **external** integration (research API/SDK/CLI/MCP/repos/skills → weigh auth methods → user picks → build definition → connect in the UI); CRUD skills, MCP servers, and tools. NB: "integration" means external tooling; LLM provider keys (Anthropic/OpenAI) live under `runtm-api providers`.
-- `runtm-agents` -- create, list, and edit Slack/GitHub integration agents (event-driven).
+- `runtm-build-agent` -- **"build me an agent that does X"**: the end-to-end assembly recipe across templates, skills/MCPs/tools, guardrails, the roster, and triggers, in the order that avoids baking an empty template.
+- `runtm-agents` -- the agent roster (identity, instructions, rubric, budget, scorecard) and its Slack/GitHub/Linear/Email triggers.
 - `runtm-automation` -- scheduled agents: cron syntax, the create-disabled → `run-now` → enable order, and debugging a schedule that didn't fire.
 
 ## Subcommand Discovery

--- a/packages/agent/internal/skills/files/runtm-agents.md
+++ b/packages/agent/internal/skills/files/runtm-agents.md
@@ -2,7 +2,7 @@
 name: runtm-agents
 description: "Create, list/find, and edit Runtm Cloud agents: the named agent roster (identity, instructions, evaluation rubric, budget, scorecard) and the Slack/GitHub/Linear/Email trigger integrations that launch coding sessions on events. Use when the user wants to create or configure an agent, set evaluation criteria or budgets, read the agent scorecard or a run's grade, or wire a Slack, GitHub, Linear, or email trigger from the CLI."
 metadata:
-  version: "0.2.0"
+  version: "0.3.0"
   tags: runtm,runtime,agents,roster,evals,scorecard,slack,github,linear,email,integrations,bots
 ---
 
@@ -17,6 +17,36 @@ system instructions, session defaults, an evaluation rubric, and a budget.
 bindings that launch a session when an event arrives. Triggers bind to a
 roster agent via `config.agent_id`; the roster row is the source of truth for
 defaults and editing them fans out to every linked trigger.
+
+## `--template` is where the agent's capabilities come from
+
+Before creating an agent, understand what actually gives it abilities:
+
+```
+trigger -> roster agent -> template -> { skills, MCP servers, tools, guardrails } -> session
+```
+
+The roster row carries **identity** (name, instructions, rubric, budget). The
+**template** carries **capability**: the skills, MCP servers, credentials, and
+guardrails a launched session loads. So `--template` is not a nicety:
+
+- An agent with no `--template` has instructions and nothing to act with.
+- A skill that exists in the org but is not attached to *that* template is
+  never loaded, however good it is.
+- An attachment added after the template's last build does nothing until you
+  rebuild it.
+
+All three fail silently: the agent runs, it just can't do the job. If you are
+assembling an agent from scratch rather than editing an existing one, follow
+the **`runtm-build-agent`** skill, which sequences the template, its
+capabilities, and the trigger in the order that avoids this.
+
+Check what an agent can actually do:
+
+```bash
+runtm-api agents get <id> | jq .default_template
+runtm-api template get <template_id> | jq '{skills:[.skills[].name], stale:.attachments_changed_since_build}'
+```
 
 | Verb | Roster | Trigger integration |
 |------|--------|---------------------|
@@ -67,6 +97,15 @@ scope; reads need `integrations:read`.
 Slack, GitHub, and managed Linear finish in a **browser** (you authorize the
 app), so `create` returns something to open. Email and manual Linear are
 fully headless.
+
+**Preflight, so you fail with an explanation instead of a bare 400:** Slack
+needs the org's Slack app configuration token, which is set once in the
+dashboard and has no CLI equivalent. If create 400s, that is almost always
+why, so send the user to the dashboard rather than retrying. Linear headless
+needs both `--linear-api-key` and `--service-user`. Email needs the platform
+inbox provider to be available (`GET /api/v1/email/status`). When you are
+running unattended and the user cannot click, say so and stop rather than
+re-reading the manifest endpoint.
 
 ```bash
 # Slack — returns an authorize URL to click

--- a/packages/agent/internal/skills/files/runtm-build-agent.md
+++ b/packages/agent/internal/skills/files/runtm-build-agent.md
@@ -1,0 +1,193 @@
+---
+name: runtm-build-agent
+description: "End-to-end recipe for assembling a working Runtm agent: plan the capabilities, create the template, attach skills/MCP servers/tools/guardrails, build once, then point a roster agent and a trigger at it. Use when the user wants to build an agent that DOES something (support triage, on-call, research, outbound, code review) rather than manage one primitive in isolation. Covers the order the pieces must be created in, and the silent failures that come from getting it wrong."
+metadata:
+  version: "0.1.0"
+  tags: runtm,runtime,agent,build,assemble,template,skills,mcp,tools,guardrails,support-agent,recipe
+---
+
+# Build an agent on Runtm
+
+Use this when the ask is **"build me an agent that does X"**: support triage,
+on-call, research, outbound, code review. It spans templates, directives, the
+roster, and triggers; the per-primitive skills (`runtm-templates`,
+`runtm-integrations`, `runtm-agents`) go deeper on each piece.
+
+## The capability chain
+
+Everything an agent can do hangs off **one template**. Read this before
+creating anything:
+
+```
+trigger          Slack / GitHub / Linear / Email / cron
+  └─ roster agent      identity, system instructions, rubric, budget
+       └─ template     <- THE capability carrier
+            ├─ skills          how to do things (SKILL.md recipes)
+            ├─ MCP servers     structured tool calls
+            ├─ tools           stored provider credentials
+            ├─ guardrails      what it may and may not run
+            └─ context         instructions baked into the environment
+                 └─ session    what actually runs when the trigger fires
+```
+
+The consequences:
+
+- **A roster agent with no template can't do anything special.** `--template`
+  is not a nicety; it is the entire answer to "what can this agent do".
+- **A skill that is created but not attached to that template does nothing.**
+  It exists in the org and is never loaded.
+- **An attachment made after the last build does nothing until you rebuild.**
+  Attaching changes config; the build bakes it into the snapshot.
+
+Templates are not only for coding agents. A support agent's template usually
+clones no repo worth speaking of and exists purely to carry its skills, MCP
+servers, credentials, and guardrails.
+
+## Order matters: build last
+
+The single most common way to waste twenty minutes is to create things in the
+order they come to mind. Plan first, attach everything, then build **once**.
+
+```bash
+export RUNTM_API_KEY=runtm_sk_live_...   # org-scoped; writes need admin/owner
+
+# 0. PLAN. Decide the capability list before creating anything (see below).
+
+# 1. Template first; everything attaches to it. Note: no --build yet.
+TMPL=$(runtm-api template create \
+  --name support-agent --display-name "Support Agent" \
+  --github-repo acme/runbooks --tier standard | jq -r .id)
+
+# 2. Capabilities. Prefer import: it attaches in the same call.
+runtm-api skills import --source github_repo --uri acme/runbooks \
+  --attach-template "$TMPL"
+
+# `skills create` has NO attach flag, so it is always two steps.
+SKILL=$(runtm-api skills create --name support-triage --md ./SKILL.md | jq -r .directive.id)
+runtm-api skills attach "$SKILL" --template "$TMPL"
+
+# Attach MERGES by default, so there is no need to read the current set first.
+# Use --replace only when you mean to discard the other attachments.
+runtm-api mcp attach "$MCP_ID" --template "$TMPL"
+
+# 3. Guardrails for this template. Note the shape differs from the org-level
+#    'guardrails rules create --kind deny --pattern ...': here it is a typed
+#    content object.
+runtm-api template guardrails create "$TMPL" \
+  --name no-force-push --type allowlist \
+  --content '{"kind":"deny","pattern":"git push --force*"}'
+
+# 4. VERIFY BEFORE BUILDING. An empty skills list here means the build bakes nothing.
+runtm-api template get "$TMPL" | jq '{
+  skills: [.skills[].name],
+  mcp: [.mcp_servers[].name],
+  stale: .attachments_changed_since_build
+}'
+
+# 5. Build ONCE, now that everything is attached.
+runtm-api template build "$TMPL" --skip-agent
+runtm-api template get "$TMPL" | jq -r .build_status   # poll to "ready"
+
+# 6. The roster agent, pointed at the template.
+AGENT=$(runtm-api agents create --name "Support" \
+  --instructions 'Triage inbound tickets. Never message a customer directly.' \
+  --template support-agent --agent claude-code | jq -r .id)
+
+# 7. A rubric, so runs get graded and the scorecard is not zeros.
+runtm-api agents update "$AGENT" --evaluator-criteria \
+  '{"objective":"Resolve or correctly escalate each ticket","checks":["cited a source","no customer contact"]}'
+
+# 8. The trigger LAST, since it is what fires all of the above.
+runtm-api agents create --type slack --name Support   # see preflight below
+```
+
+> `template create --skip-agent` implies `--build`. That fast path is right for
+> a plain dev sandbox, but it fires the build **before** anything is attached.
+> If you intend to attach skills, create without `--build` as above, or accept
+> that you must rebuild afterwards.
+
+## Step 0: plan the capability list first
+
+Do not start creating directives until you can name what the agent needs and
+which primitive carries each one. Ask the user, or infer from the job:
+
+| The agent needs to... | Primitive | Command |
+|---|---|---|
+| Follow a written procedure | Skill | `skills create` / `skills import` |
+| Call a service with structured tools | MCP server | `mcp create` |
+| Authenticate to a service | Tool (knowledge integration) | `tools create`, or the dashboard for secrets |
+| Be prevented from doing something | Guardrail | `guardrails rules` / `template guardrails` |
+| Always be told something | Template context | `template context set` |
+
+Check what already exists before authoring anything, because a good chunk of it is
+usually already in the org:
+
+```bash
+runtm-api skills list                  # skills the org already has
+runtm-api mcp list                     # MCP servers already defined
+runtm-api tools providers list         # services already wired for credentials
+runtm-api template list                # a template you can extend instead
+runtm-api skills discover --repo acme/runbooks   # read-only; what a repo offers
+```
+
+For choosing **between** an MCP server, a skill wrapping a CLI, and a raw API
+recipe, and for the auth trade-offs, use the `runtm-integrations` skill. That
+decision is the one worth slowing down for; the rest of this file is mechanics.
+
+## Failure modes
+
+These fail **silently**: no error, just an agent that cannot do its job.
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Agent runs but ignores its skills | Skills created, never attached | `skills attach <id> --template <t>`, then rebuild |
+| `template get` shows the skills, sessions still don't have them | Attached after the last build | `attachments_changed_since_build: true` -> `template build` |
+| Built template has an empty `skills` list | Built before attaching (often via `--skip-agent`) | Attach, then rebuild |
+| Agent has no special behavior at all | Roster agent has no `--template` | `agents update <id> --template <slug>` |
+| Scorecard is all zeros | No `evaluator_criteria` on the agent | `agents update <id> --evaluator-criteria '{...}'` |
+| Trigger fires, but with none of the agent's identity | Trigger not bound to the roster agent | Triggers bind via `config.agent_id`: `--agent-id` on email, `--config '{"agent_id":"<roster_id>"}'` elsewhere |
+
+Rebuilding after every single attach also wastes minutes and churns the
+snapshot. Batch the attachments, then build once.
+
+## Trigger preflight
+
+Check these **before** calling `agents create --type ...`, so you fail with an
+explanation instead of a bare 400:
+
+- **Slack** needs the org's Slack *app configuration token*, set once in the
+  dashboard. Without it, create returns 400. There is no CLI command to set it
+  so send the user to the dashboard, then retry.
+- **GitHub** cannot be a clickable link: the App-manifest flow must be POSTed,
+  so the CLI writes an auto-submitting HTML page for you to open.
+- **Linear** is headless only with `--linear-api-key` plus `--service-user`;
+  the managed OAuth path returns an install URL to open.
+- **Email** is fully headless. Check `GET /api/v1/email/status` if it 400s.
+
+Slack, GitHub, and managed Linear all finish in a **browser**. When running
+unattended, prefer Email or a scheduled agent (`runtm-automation`) and hand the
+browser step back to the user.
+
+## Verify it end to end
+
+```bash
+# What will a session from this template actually load?
+runtm-api template get "$TMPL" | jq '{skills:[.skills[].name], stale:.attachments_changed_since_build}'
+runtm-api template guardrails resolve "$TMPL"   # what it actually enforces
+runtm-api template context resolve "$TMPL"      # what it is actually told
+
+# Boot one and prove a capability works before wiring the trigger.
+SID=$(runtm-api session create --template-id "$TMPL" | jq -r .id)
+runtm-api session exec "$SID" --json -- 'ls ~/.claude/skills'
+runtm-api session destroy "$SID"
+```
+
+Booting one session and checking the skills actually landed is worth more than
+any amount of re-reading config.
+
+## More
+
+- `runtm-templates`: template lifecycle, session args, fix-sessions, secrets.
+- `runtm-integrations`: choosing MCP vs skill vs CLI vs API, and auth methods.
+- `runtm-agents`: roster fields, rubrics, budgets, scorecards, trigger config.
+- `runtm-automation`: cron-driven agents instead of event-driven ones.

--- a/packages/agent/internal/skills/files/runtm-integrations.md
+++ b/packages/agent/internal/skills/files/runtm-integrations.md
@@ -2,7 +2,7 @@
 name: runtm-integrations
 description: "Create, read, update, and delete the Runtm Cloud session-context directives from the CLI: skills (SKILL.md bundles), MCP servers (stdio or http/sse), tools (knowledge integrations / provider credentials), and custom tool providers — and attach skills/MCP servers to org templates, repos, or all repos so sessions load them. Use when the user wants to add/connect/create an integration — ALWAYS follow the 5-step process: (1) research every way to reach the service (API, SDK, CLI, MCP, GitHub repos, predefined skills), (2) investigate the auth methods (OAuth, API key, service account) with pros/cons, (3) ask the user to pick the interface + auth combination, (4) build the definition (MCP server or tool provider), (5) redirect the user to connect in the dashboard UI so secrets never pass through the agent — or to author/manage skills, wire up an MCP server, attach a skill or MCP to a template, or define a NEW custom tool provider (name, logo, mise/npm/github package, and auth fields) when no built-in provider exists. Keeps three concepts distinct: a DEFINITION (tool provider / MCP server — the wiring, no secrets), a CONNECTION (the credentials a user supplies against a definition — entered in the dashboard UI, one definition can have many), and an ATTACHMENT (which templates/repos load it)."
 metadata:
-  version: "0.4.0"
+  version: "0.5.0"
   tags: runtm,runtime,directives,skills,mcp,tools,knowledge,templates,attachments,integrations
 ---
 
@@ -377,6 +377,15 @@ runtm-api template build <template_id>
 last build, so sessions still boot with the old set until you rebuild. That
 flag is the reason to prefer `template get` over `template skills` when you are
 about to trust a template.
+
+**Attach everything, then build once.** Rebuilding after each attach costs
+minutes per round and churns the snapshot for anyone booting sessions
+meanwhile. When wiring several skills, attach them all, check `template get`
+once, then issue a single `template build`. Same for the reverse order trap:
+`template create --skip-agent` implies `--build`, so creating a template that
+way and attaching afterwards always leaves you a rebuild in debt. Assembling a
+whole agent rather than adding one integration? Use the `runtm-build-agent`
+skill, which sequences this end to end.
 
 ---
 

--- a/packages/agent/internal/skills/files/runtm-templates.md
+++ b/packages/agent/internal/skills/files/runtm-templates.md
@@ -2,7 +2,7 @@
 name: runtm-templates
 description: "Full lifecycle workflows for Runtm Cloud org templates: discover, create, build, monitor builds, verify attached skills and build staleness, manage template context and template-scoped guardrails, assign owning groups, set auto-rebuild schedules, fix broken templates via fix-session, save snapshots, manage template secrets."
 metadata:
-  version: "0.6.0"
+  version: "0.7.0"
   tags: runtm,runtime,templates,org,workflows
 ---
 
@@ -21,8 +21,17 @@ Org templates are **snapshots of fully configured sandbox environments**. Each t
 - Default agent system instructions
 - Compute tier (basic / standard / max)
 - One or more coding agents the snapshot was built for
+- **Attached skills, MCP servers, tools, and guardrails**
 
 A session created from a template boots instantly with the environment ready -- no install commands, no waiting on dependency builds.
+
+**A template is also the capability carrier for an agent.** That last bullet is
+the one people miss: a roster agent's `--template` is what decides which
+skills, MCP servers, credentials, and guardrails its sessions load. So
+templates are not only for coding agents: a support or research agent's
+template may clone nothing interesting and exist purely to carry its
+capabilities. If you are assembling an agent rather than a dev environment,
+see the `runtm-build-agent` skill for the order to create things in.
 
 ## All template commands require an org-scoped API key
 

--- a/packages/agent/skills/SKILL.md
+++ b/packages/agent/skills/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: runtm
-description: "Runtm (Runtime) Cloud CLI for AI agents. Full cloud-API surface: sessions (CRUD + search + files + upload/download + env + deploy + approvals + capability loading + lifecycle + history + events), the agent roster (identity + instructions + evaluation rubric + budget + scorecard + run grades), scheduled agents (cron automation + run-now), org templates (CRUD + build + context + guardrails + owning groups + secrets), guardrail content (allowlist rules, hooks, network rules), skills lifecycle (import, discover, resync, lock), deployments, GitHub App installations, groups, activity telemetry, secrets, instructions, LLM provider keys, external integrations (MCP, tools, Slack, GitHub, Linear, Email). Trigger on: runtm, runtime, runtm cloud, runtime cloud, runtm session, runtime session, cloud sandbox, integration, integrations, mcp, skill, provider key, scheduled agent, cron, automation, agent roster, evals, evaluation, scorecard, guardrail, approvals, deployment."
+description: "Runtm (Runtime) Cloud CLI for AI agents. Full cloud-API surface: sessions (CRUD + search + files + upload/download + env + deploy + approvals + capability loading + lifecycle + history + events), the agent roster (identity + instructions + evaluation rubric + budget + scorecard + run grades), scheduled agents (cron automation + run-now), org templates (CRUD + build + context + guardrails + owning groups + secrets), guardrail content (allowlist rules, hooks, network rules), skills lifecycle (import, discover, resync, lock), deployments, GitHub App installations, groups, activity telemetry, secrets, instructions, LLM provider keys, external integrations (MCP, tools, Slack, GitHub, Linear, Email). Trigger on: runtm, runtime, runtm cloud, runtime cloud, runtm session, runtime session, cloud sandbox, integration, integrations, mcp, skill, provider key, scheduled agent, cron, automation, agent roster, evals, evaluation, scorecard, guardrail, approvals, deployment, build an agent, create an agent, support agent."
 metadata:
-  version: "0.10.0"
+  version: "0.11.0"
   repository: https://github.com/runtm-ai/runtm
   tags: runtm,runtime,cli,sandboxes,coding-agents
 ---
@@ -54,6 +54,18 @@ Use `session connect` when a human wants a live shell; use `session exec` for sc
 **Always pass `--json` to `session exec` when you are going to parse the output.** The default is the raw PTY stream, which merges stderr into stdout and carries shell startup noise (mise/nvm banners and the like) that you would otherwise have to filter out with `grep -v`. `--json` captures the two streams separately and strips PTY carriage returns.
 
 To parameterize a template, declare **session arguments** with `--session-arg` (each becomes an env var in the session); supply values at boot with `session create --template-id <uuid> --template-args KEY=VALUE`. See the `runtm-templates` skill.
+
+## Other common path: building an agent
+
+The loop above is for **driving a sandbox yourself**. When the ask is "build me an agent that does X" (support triage, on-call, research, code review), the shape is different and the order matters. Read the **`runtm-build-agent`** skill first.
+
+The one thing to know before you start: **every capability an agent has hangs off one template.**
+
+```
+trigger -> roster agent -> template -> { skills, MCP servers, tools, guardrails, context } -> session
+```
+
+So a roster agent without `--template` can do nothing special, a skill that is never attached to that template is never loaded, and an attachment made after the last build does nothing until you rebuild. All three fail **silently**. Create the template, attach everything, verify with `template get`, then build **once**. Note that `template create --skip-agent` implies `--build`, so the fast path above will bake an empty template if you meant to attach skills to it.
 
 ## Quick Reference
 
@@ -424,7 +436,8 @@ If `authenticated: false`, ask the user to set `RUNTM_API_KEY` (or run `runtm-ap
 - `runtm-templates` -- full template lifecycle (create, build, fix, snapshot).
 - `runtm-debug` -- inspect a session's state when something is wrong.
 - `runtm-integrations` -- add/connect an **external** integration (research API/SDK/CLI/MCP/repos/skills → weigh auth methods → user picks → build definition → connect in the UI); CRUD skills, MCP servers, and tools. NB: "integration" means external tooling; LLM provider keys (Anthropic/OpenAI) live under `runtm-api providers`.
-- `runtm-agents` -- create, list, and edit Slack/GitHub integration agents (event-driven).
+- `runtm-build-agent` -- **"build me an agent that does X"**: the end-to-end assembly recipe across templates, skills/MCPs/tools, guardrails, the roster, and triggers, in the order that avoids baking an empty template.
+- `runtm-agents` -- the agent roster (identity, instructions, rubric, budget, scorecard) and its Slack/GitHub/Linear/Email triggers.
 - `runtm-automation` -- scheduled agents: cron syntax, the create-disabled → `run-now` → enable order, and debugging a schedule that didn't fire.
 
 ## Subcommand Discovery

--- a/packages/agent/skills/runtm-agents.md
+++ b/packages/agent/skills/runtm-agents.md
@@ -2,7 +2,7 @@
 name: runtm-agents
 description: "Create, list/find, and edit Runtm Cloud agents: the named agent roster (identity, instructions, evaluation rubric, budget, scorecard) and the Slack/GitHub/Linear/Email trigger integrations that launch coding sessions on events. Use when the user wants to create or configure an agent, set evaluation criteria or budgets, read the agent scorecard or a run's grade, or wire a Slack, GitHub, Linear, or email trigger from the CLI."
 metadata:
-  version: "0.2.0"
+  version: "0.3.0"
   tags: runtm,runtime,agents,roster,evals,scorecard,slack,github,linear,email,integrations,bots
 ---
 
@@ -17,6 +17,36 @@ system instructions, session defaults, an evaluation rubric, and a budget.
 bindings that launch a session when an event arrives. Triggers bind to a
 roster agent via `config.agent_id`; the roster row is the source of truth for
 defaults and editing them fans out to every linked trigger.
+
+## `--template` is where the agent's capabilities come from
+
+Before creating an agent, understand what actually gives it abilities:
+
+```
+trigger -> roster agent -> template -> { skills, MCP servers, tools, guardrails } -> session
+```
+
+The roster row carries **identity** (name, instructions, rubric, budget). The
+**template** carries **capability**: the skills, MCP servers, credentials, and
+guardrails a launched session loads. So `--template` is not a nicety:
+
+- An agent with no `--template` has instructions and nothing to act with.
+- A skill that exists in the org but is not attached to *that* template is
+  never loaded, however good it is.
+- An attachment added after the template's last build does nothing until you
+  rebuild it.
+
+All three fail silently: the agent runs, it just can't do the job. If you are
+assembling an agent from scratch rather than editing an existing one, follow
+the **`runtm-build-agent`** skill, which sequences the template, its
+capabilities, and the trigger in the order that avoids this.
+
+Check what an agent can actually do:
+
+```bash
+runtm-api agents get <id> | jq .default_template
+runtm-api template get <template_id> | jq '{skills:[.skills[].name], stale:.attachments_changed_since_build}'
+```
 
 | Verb | Roster | Trigger integration |
 |------|--------|---------------------|
@@ -67,6 +97,15 @@ scope; reads need `integrations:read`.
 Slack, GitHub, and managed Linear finish in a **browser** (you authorize the
 app), so `create` returns something to open. Email and manual Linear are
 fully headless.
+
+**Preflight, so you fail with an explanation instead of a bare 400:** Slack
+needs the org's Slack app configuration token, which is set once in the
+dashboard and has no CLI equivalent. If create 400s, that is almost always
+why, so send the user to the dashboard rather than retrying. Linear headless
+needs both `--linear-api-key` and `--service-user`. Email needs the platform
+inbox provider to be available (`GET /api/v1/email/status`). When you are
+running unattended and the user cannot click, say so and stop rather than
+re-reading the manifest endpoint.
 
 ```bash
 # Slack — returns an authorize URL to click

--- a/packages/agent/skills/runtm-build-agent.md
+++ b/packages/agent/skills/runtm-build-agent.md
@@ -1,0 +1,193 @@
+---
+name: runtm-build-agent
+description: "End-to-end recipe for assembling a working Runtm agent: plan the capabilities, create the template, attach skills/MCP servers/tools/guardrails, build once, then point a roster agent and a trigger at it. Use when the user wants to build an agent that DOES something (support triage, on-call, research, outbound, code review) rather than manage one primitive in isolation. Covers the order the pieces must be created in, and the silent failures that come from getting it wrong."
+metadata:
+  version: "0.1.0"
+  tags: runtm,runtime,agent,build,assemble,template,skills,mcp,tools,guardrails,support-agent,recipe
+---
+
+# Build an agent on Runtm
+
+Use this when the ask is **"build me an agent that does X"**: support triage,
+on-call, research, outbound, code review. It spans templates, directives, the
+roster, and triggers; the per-primitive skills (`runtm-templates`,
+`runtm-integrations`, `runtm-agents`) go deeper on each piece.
+
+## The capability chain
+
+Everything an agent can do hangs off **one template**. Read this before
+creating anything:
+
+```
+trigger          Slack / GitHub / Linear / Email / cron
+  └─ roster agent      identity, system instructions, rubric, budget
+       └─ template     <- THE capability carrier
+            ├─ skills          how to do things (SKILL.md recipes)
+            ├─ MCP servers     structured tool calls
+            ├─ tools           stored provider credentials
+            ├─ guardrails      what it may and may not run
+            └─ context         instructions baked into the environment
+                 └─ session    what actually runs when the trigger fires
+```
+
+The consequences:
+
+- **A roster agent with no template can't do anything special.** `--template`
+  is not a nicety; it is the entire answer to "what can this agent do".
+- **A skill that is created but not attached to that template does nothing.**
+  It exists in the org and is never loaded.
+- **An attachment made after the last build does nothing until you rebuild.**
+  Attaching changes config; the build bakes it into the snapshot.
+
+Templates are not only for coding agents. A support agent's template usually
+clones no repo worth speaking of and exists purely to carry its skills, MCP
+servers, credentials, and guardrails.
+
+## Order matters: build last
+
+The single most common way to waste twenty minutes is to create things in the
+order they come to mind. Plan first, attach everything, then build **once**.
+
+```bash
+export RUNTM_API_KEY=runtm_sk_live_...   # org-scoped; writes need admin/owner
+
+# 0. PLAN. Decide the capability list before creating anything (see below).
+
+# 1. Template first; everything attaches to it. Note: no --build yet.
+TMPL=$(runtm-api template create \
+  --name support-agent --display-name "Support Agent" \
+  --github-repo acme/runbooks --tier standard | jq -r .id)
+
+# 2. Capabilities. Prefer import: it attaches in the same call.
+runtm-api skills import --source github_repo --uri acme/runbooks \
+  --attach-template "$TMPL"
+
+# `skills create` has NO attach flag, so it is always two steps.
+SKILL=$(runtm-api skills create --name support-triage --md ./SKILL.md | jq -r .directive.id)
+runtm-api skills attach "$SKILL" --template "$TMPL"
+
+# Attach MERGES by default, so there is no need to read the current set first.
+# Use --replace only when you mean to discard the other attachments.
+runtm-api mcp attach "$MCP_ID" --template "$TMPL"
+
+# 3. Guardrails for this template. Note the shape differs from the org-level
+#    'guardrails rules create --kind deny --pattern ...': here it is a typed
+#    content object.
+runtm-api template guardrails create "$TMPL" \
+  --name no-force-push --type allowlist \
+  --content '{"kind":"deny","pattern":"git push --force*"}'
+
+# 4. VERIFY BEFORE BUILDING. An empty skills list here means the build bakes nothing.
+runtm-api template get "$TMPL" | jq '{
+  skills: [.skills[].name],
+  mcp: [.mcp_servers[].name],
+  stale: .attachments_changed_since_build
+}'
+
+# 5. Build ONCE, now that everything is attached.
+runtm-api template build "$TMPL" --skip-agent
+runtm-api template get "$TMPL" | jq -r .build_status   # poll to "ready"
+
+# 6. The roster agent, pointed at the template.
+AGENT=$(runtm-api agents create --name "Support" \
+  --instructions 'Triage inbound tickets. Never message a customer directly.' \
+  --template support-agent --agent claude-code | jq -r .id)
+
+# 7. A rubric, so runs get graded and the scorecard is not zeros.
+runtm-api agents update "$AGENT" --evaluator-criteria \
+  '{"objective":"Resolve or correctly escalate each ticket","checks":["cited a source","no customer contact"]}'
+
+# 8. The trigger LAST, since it is what fires all of the above.
+runtm-api agents create --type slack --name Support   # see preflight below
+```
+
+> `template create --skip-agent` implies `--build`. That fast path is right for
+> a plain dev sandbox, but it fires the build **before** anything is attached.
+> If you intend to attach skills, create without `--build` as above, or accept
+> that you must rebuild afterwards.
+
+## Step 0: plan the capability list first
+
+Do not start creating directives until you can name what the agent needs and
+which primitive carries each one. Ask the user, or infer from the job:
+
+| The agent needs to... | Primitive | Command |
+|---|---|---|
+| Follow a written procedure | Skill | `skills create` / `skills import` |
+| Call a service with structured tools | MCP server | `mcp create` |
+| Authenticate to a service | Tool (knowledge integration) | `tools create`, or the dashboard for secrets |
+| Be prevented from doing something | Guardrail | `guardrails rules` / `template guardrails` |
+| Always be told something | Template context | `template context set` |
+
+Check what already exists before authoring anything, because a good chunk of it is
+usually already in the org:
+
+```bash
+runtm-api skills list                  # skills the org already has
+runtm-api mcp list                     # MCP servers already defined
+runtm-api tools providers list         # services already wired for credentials
+runtm-api template list                # a template you can extend instead
+runtm-api skills discover --repo acme/runbooks   # read-only; what a repo offers
+```
+
+For choosing **between** an MCP server, a skill wrapping a CLI, and a raw API
+recipe, and for the auth trade-offs, use the `runtm-integrations` skill. That
+decision is the one worth slowing down for; the rest of this file is mechanics.
+
+## Failure modes
+
+These fail **silently**: no error, just an agent that cannot do its job.
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Agent runs but ignores its skills | Skills created, never attached | `skills attach <id> --template <t>`, then rebuild |
+| `template get` shows the skills, sessions still don't have them | Attached after the last build | `attachments_changed_since_build: true` -> `template build` |
+| Built template has an empty `skills` list | Built before attaching (often via `--skip-agent`) | Attach, then rebuild |
+| Agent has no special behavior at all | Roster agent has no `--template` | `agents update <id> --template <slug>` |
+| Scorecard is all zeros | No `evaluator_criteria` on the agent | `agents update <id> --evaluator-criteria '{...}'` |
+| Trigger fires, but with none of the agent's identity | Trigger not bound to the roster agent | Triggers bind via `config.agent_id`: `--agent-id` on email, `--config '{"agent_id":"<roster_id>"}'` elsewhere |
+
+Rebuilding after every single attach also wastes minutes and churns the
+snapshot. Batch the attachments, then build once.
+
+## Trigger preflight
+
+Check these **before** calling `agents create --type ...`, so you fail with an
+explanation instead of a bare 400:
+
+- **Slack** needs the org's Slack *app configuration token*, set once in the
+  dashboard. Without it, create returns 400. There is no CLI command to set it
+  so send the user to the dashboard, then retry.
+- **GitHub** cannot be a clickable link: the App-manifest flow must be POSTed,
+  so the CLI writes an auto-submitting HTML page for you to open.
+- **Linear** is headless only with `--linear-api-key` plus `--service-user`;
+  the managed OAuth path returns an install URL to open.
+- **Email** is fully headless. Check `GET /api/v1/email/status` if it 400s.
+
+Slack, GitHub, and managed Linear all finish in a **browser**. When running
+unattended, prefer Email or a scheduled agent (`runtm-automation`) and hand the
+browser step back to the user.
+
+## Verify it end to end
+
+```bash
+# What will a session from this template actually load?
+runtm-api template get "$TMPL" | jq '{skills:[.skills[].name], stale:.attachments_changed_since_build}'
+runtm-api template guardrails resolve "$TMPL"   # what it actually enforces
+runtm-api template context resolve "$TMPL"      # what it is actually told
+
+# Boot one and prove a capability works before wiring the trigger.
+SID=$(runtm-api session create --template-id "$TMPL" | jq -r .id)
+runtm-api session exec "$SID" --json -- 'ls ~/.claude/skills'
+runtm-api session destroy "$SID"
+```
+
+Booting one session and checking the skills actually landed is worth more than
+any amount of re-reading config.
+
+## More
+
+- `runtm-templates`: template lifecycle, session args, fix-sessions, secrets.
+- `runtm-integrations`: choosing MCP vs skill vs CLI vs API, and auth methods.
+- `runtm-agents`: roster fields, rubrics, budgets, scorecards, trigger config.
+- `runtm-automation`: cron-driven agents instead of event-driven ones.

--- a/packages/agent/skills/runtm-integrations.md
+++ b/packages/agent/skills/runtm-integrations.md
@@ -2,7 +2,7 @@
 name: runtm-integrations
 description: "Create, read, update, and delete the Runtm Cloud session-context directives from the CLI: skills (SKILL.md bundles), MCP servers (stdio or http/sse), tools (knowledge integrations / provider credentials), and custom tool providers — and attach skills/MCP servers to org templates, repos, or all repos so sessions load them. Use when the user wants to add/connect/create an integration — ALWAYS follow the 5-step process: (1) research every way to reach the service (API, SDK, CLI, MCP, GitHub repos, predefined skills), (2) investigate the auth methods (OAuth, API key, service account) with pros/cons, (3) ask the user to pick the interface + auth combination, (4) build the definition (MCP server or tool provider), (5) redirect the user to connect in the dashboard UI so secrets never pass through the agent — or to author/manage skills, wire up an MCP server, attach a skill or MCP to a template, or define a NEW custom tool provider (name, logo, mise/npm/github package, and auth fields) when no built-in provider exists. Keeps three concepts distinct: a DEFINITION (tool provider / MCP server — the wiring, no secrets), a CONNECTION (the credentials a user supplies against a definition — entered in the dashboard UI, one definition can have many), and an ATTACHMENT (which templates/repos load it)."
 metadata:
-  version: "0.4.0"
+  version: "0.5.0"
   tags: runtm,runtime,directives,skills,mcp,tools,knowledge,templates,attachments,integrations
 ---
 
@@ -377,6 +377,15 @@ runtm-api template build <template_id>
 last build, so sessions still boot with the old set until you rebuild. That
 flag is the reason to prefer `template get` over `template skills` when you are
 about to trust a template.
+
+**Attach everything, then build once.** Rebuilding after each attach costs
+minutes per round and churns the snapshot for anyone booting sessions
+meanwhile. When wiring several skills, attach them all, check `template get`
+once, then issue a single `template build`. Same for the reverse order trap:
+`template create --skip-agent` implies `--build`, so creating a template that
+way and attaching afterwards always leaves you a rebuild in debt. Assembling a
+whole agent rather than adding one integration? Use the `runtm-build-agent`
+skill, which sequences this end to end.
 
 ---
 

--- a/packages/agent/skills/runtm-templates.md
+++ b/packages/agent/skills/runtm-templates.md
@@ -2,7 +2,7 @@
 name: runtm-templates
 description: "Full lifecycle workflows for Runtm Cloud org templates: discover, create, build, monitor builds, verify attached skills and build staleness, manage template context and template-scoped guardrails, assign owning groups, set auto-rebuild schedules, fix broken templates via fix-session, save snapshots, manage template secrets."
 metadata:
-  version: "0.6.0"
+  version: "0.7.0"
   tags: runtm,runtime,templates,org,workflows
 ---
 
@@ -21,8 +21,17 @@ Org templates are **snapshots of fully configured sandbox environments**. Each t
 - Default agent system instructions
 - Compute tier (basic / standard / max)
 - One or more coding agents the snapshot was built for
+- **Attached skills, MCP servers, tools, and guardrails**
 
 A session created from a template boots instantly with the environment ready -- no install commands, no waiting on dependency builds.
+
+**A template is also the capability carrier for an agent.** That last bullet is
+the one people miss: a roster agent's `--template` is what decides which
+skills, MCP servers, credentials, and guardrails its sessions load. So
+templates are not only for coding agents: a support or research agent's
+template may clone nothing interesting and exist purely to carry its
+capabilities. If you are assembling an agent rather than a dev environment,
+see the `runtm-build-agent` skill for the order to create things in.
 
 ## All template commands require an org-scoped API key
 


### PR DESCRIPTION
## Summary

Prompted by a real session: a user built a customer support agent with the CLI today and their local agent took twenty minutes to get there. The Datadog trace shows exactly which piece of knowledge was missing.

What they did, in order:

| Time (UTC) | Action |
|---|---|
| 19:43–19:47 | Creates 22 directives (`nixtla-docs`, `nixtla-stripe`, `nixtla-hubspot`, `nixtla-supabase`, `nixtla-investigations`) |
| 19:48:02 | Creates the template, **after** the skills |
| 19:48:03 | Fires the build one second later, before anything is attached |
| 19:52 | Deletes 13 of the 22 directives |
| 19:54:38 | Finally creates the roster agent |
| 19:55–19:58 | Stalls on Slack, re-reading `slack/manifest` after a 400 |

The worker rebuilt the template five times in six minutes, directive count swinging 16 → 12 → 27 → 1 → 29.

**Root cause in the docs:** nothing in the package said that a roster agent's capabilities come from the template it points at. `runtm-agents` mentioned `--template` only as "Default org template for launched sessions". `runtm-templates` described templates as dev sandboxes (repos cloned, runtimes installed, services running), so someone building a support agent had no reason to think templates were for them. And the three ways this goes wrong all fail silently: no template on the agent, a skill never attached, an attachment added after the last build.

## Changes

**New `runtm-build-agent` skill** owning the end-to-end assembly, because it spans templates, directives, the roster, and triggers and no existing skill owned it. Leads with the chain:

```
trigger -> roster agent -> template -> { skills, MCP servers, tools, guardrails, context } -> session
```

Then the ordering that avoids the trap (template, attach, verify, build **once**, agent, trigger), a step-0 planning table mapping each need to its primitive, a silent-failure table, and a trigger preflight.

**Four existing skills**, each fixing something the trace implicated:

- `SKILL.md` routed "create an agent" to a line describing `runtm-agents` as "Slack/GitHub integration agents (event-driven)" — stale since the roster work, and it steers an agent away from the file it needs. Also adds a second headline path, since `template → session → exec` only fits coding agents.
- `runtm-agents.md` states that `--template` is the capability answer, and turns the Slack app-configuration-token prerequisite into a preflight that says to stop and hand off rather than retry.
- `runtm-templates.md` lists attached skills/MCP servers among what a template bakes, and says templates are not only for coding agents.
- `runtm-integrations.md` adds "attach everything, then build once", and warns that `template create --skip-agent` implies `--build`. That one matters: **our own headline recipe is what leads you into baking an empty template.**

## Test plan

- [x] Extracted every `runtm-api` invocation from the new skill and resolved each against the built binary. This caught a real error: `template guardrails create` takes `--name`/`--type`/`--content`, not the `--kind`/`--pattern` shape that org-level `guardrails rules create` uses. Fixed, and the difference is now called out inline.
- [x] `make sync-skills`; `skills/` and the `//go:embed` copy under `internal/skills/files/` verified identical
- [x] `skills install` writes all 8 files including the new one
- [x] `go build` and `go test ./...` green
- [x] No em dashes in any added line

## Note

Skills ship embedded in the binary, so this reaches users only on the next `packages/agent/v*` tag. Current release `v0.0.14` is at the tip of main.

Made with [Cursor](https://cursor.com)