### PR TITLE
security(agent): build runtm-api with Go 1.26.6

### DIFF
--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -37,9 +37,14 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          # 1.25.9+ fixes the Go-stdlib CVEs (CVE-2025-68121, CVE-2026-27143)
-          # flagged by Artifact Registry scanning on the released binaries.
-          go-version: '1.25.12'
+          # Exact pin — bump on Go security releases, then tag a new
+          # packages/agent/vX.Y.Z so the published binary picks the fix up.
+          # setup-go forces GOTOOLCHAIN=local, so a `toolchain` directive in
+          # go.mod cannot override this; this pin IS the stdlib version.
+          # 1.26.6 fixes CVE-2026-39821 (CRITICAL) + CVE-2026-33818 /
+          # 46600 / 56853 / 56859 / 56862 / 56864 / 56865 (HIGH), all flagged
+          # by Artifact Registry scanning on the released runtm-api binary.
+          go-version: '1.26.6'
           cache-dependency-path: packages/agent/go.sum
 
       - name: Compute clean version


### PR DESCRIPTION
## Why

The released `runtm-api` binary is baked into the `runtm-claude-code` sandbox image (mise `github:runtm-ai/runtm`) and is scanned directly by Artifact Registry / GCP SCC at `/opt/mise/installs/github-runtm-ai-runtm/packages-agent-v*/runtm-api`.

The latest release (v0.0.14) still ships **go1.25.12**, producing 8 open findings on `runtm-claude-code` in `runtm-prod`:

| CVE | Severity | Fixed in |
|---|---|---|
| CVE-2026-39821 | **CRITICAL** | go1.25.13 |
| CVE-2026-46600 | HIGH | go1.26.6 |
| CVE-2026-33818, -56853, -56859, -56862, -56864, -56865 | HIGH | go1.25.13 |

`CVE-2026-46600` is only fixed in the 1.26 line, so this goes to **1.26.6** rather than 1.25.13.

## Why not a `toolchain` directive in go.mod

`actions/setup-go` explicitly sets `GOTOOLCHAIN=local`, so a `toolchain go1.26.6` line in `go.mod` would fail the build rather than upgrade it. The `go-version` pin in this workflow is what determines the stdlib baked into the binary.

## After merge

Tag `packages/agent/v0.0.15` to publish the rebuilt binary, then bump the bake-time pin in runtm-cloud `backend/e2b_template/e2b_mise.toml` and rebuild `runtm-claude-code`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)