### PR TITLE
feat(agent): session share create|list|revoke + session previews

### DIFF
--- a/docs/cloud-api/sessions/preview-shares-create.mdx
+++ b/docs/cloud-api/sessions/preview-shares-create.mdx
@@ -1,0 +1,134 @@
+---
+title: "Share a Preview"
+api: "POST /api/sessions/{session_id}/preview-shares"
+description: "Give someone outside your organization access to one port of a session's live preview"
+---
+
+Grants one email address access to one port of a session's live preview, and emails them the link.
+
+This is the narrowest grant in Runtm. The invitee can open that preview and nothing else — no workspace, no terminal, no prompting — and they are **not** added to your organization. They need a Runtm account to open it, but not before you invite them: the grant binds to their user id the first time they sign in and open the link.
+
+Paused sandboxes wake up automatically when a shared link is opened, so a share keeps working after the ~20 minute idle pause.
+
+Re-inviting an address that already has this port is a no-op and does not send a second email.
+
+**Required scope:** `sessions:write`
+
+<Info>
+  From the CLI: `runtm-api session share create <session_id> --email dev@acme.com --port 3000`
+</Info>
+
+## Path Parameters
+
+<ParamField path="session_id" type="string" required>
+  The session ID (e.g. `ses_abc123`).
+</ParamField>
+
+## Headers
+
+<ParamField header="Authorization" type="string" required>
+  Bearer token. Example: `Bearer runtm_xxx`
+</ParamField>
+
+<ParamField header="X-Organization-Id" type="string">
+  Scope to an organization. Must match the API key's own organization.
+</ParamField>
+
+## Body
+
+<ParamField body="email" type="string" required>
+  Address to invite. Max 320 characters.
+</ParamField>
+
+<ParamField body="port" type="integer" required>
+  The single port to share. Ports `22` and `2222` are rejected — they carry sandbox tooling rather than your app.
+</ParamField>
+
+<ParamField body="preview_url" type="string">
+  Override the link that gets emailed. Omit this and the server derives the preview URL for `port`. Pass it when you need a specific path (e.g. `.../index.html`).
+</ParamField>
+
+## Response
+
+<ResponseField name="share" type="object">
+  The grant: `id`, `port`, `invited_email`, `user_id`, `created_by`, `created_at`, `last_accessed_at`, `has_accessed`.
+</ResponseField>
+
+<ResponseField name="created" type="boolean">
+  `false` when the address already had this port.
+</ResponseField>
+
+<ResponseField name="emailed" type="boolean">
+  Whether the invite email went out. `false` when the grant already existed or email delivery is not configured — send `preview_url` yourself in that case.
+</ResponseField>
+
+<ResponseField name="preview_url" type="string">
+  The link the invitee should open.
+</ResponseField>
+
+<RequestExample>
+```bash cURL
+curl -X POST "https://app.runtm.com/api/cloud/sessions/ses_abc123/preview-shares" \
+  -H "Authorization: Bearer runtm_xxx" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "dev@acme.com", "port": 3000}'
+```
+
+```bash CLI
+runtm-api session share create ses_abc123 --email dev@acme.com --port 3000
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://app.runtm.com/api/cloud/sessions/ses_abc123/preview-shares",
+    headers={
+        "Authorization": "Bearer runtm_xxx",
+        "Content-Type": "application/json",
+    },
+    json={"email": "dev@acme.com", "port": 3000},
+)
+
+body = response.json()
+if not body["emailed"]:
+    print("Send this yourself:", body["preview_url"])
+```
+
+```javascript JavaScript
+const response = await fetch(
+  "https://app.runtm.com/api/cloud/sessions/ses_abc123/preview-shares",
+  {
+    method: "POST",
+    headers: {
+      "Authorization": "Bearer runtm_xxx",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ email: "dev@acme.com", port: 3000 }),
+  }
+);
+
+const { share, emailed, preview_url } = await response.json();
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200
+{
+  "share": {
+    "id": "9c1f0b7e-4b1a-4c2e-8f3d-2a5b6c7d8e9f",
+    "port": 3000,
+    "invited_email": "dev@acme.com",
+    "user_id": null,
+    "created_by": "user_abc",
+    "created_by_email": "you@yourcompany.com",
+    "created_at": "2026-08-19T22:10:00Z",
+    "last_accessed_at": null,
+    "has_accessed": false
+  },
+  "created": true,
+  "emailed": true,
+  "preview_url": "https://3000-iqsaph2xwcvxthiznmwro.dev.runtm.com"
+}
+```
+</ResponseExample>

--- a/docs/cloud-api/sessions/preview-shares-create.mdx
+++ b/docs/cloud-api/sessions/preview-shares-create.mdx
@@ -45,7 +45,7 @@ Re-inviting an address that already has this port is a no-op and does not send a
 </ParamField>
 
 <ParamField body="preview_url" type="string">
-  Override the link that gets emailed. Omit this and the server derives the preview URL for `port`. Pass it when you need a specific path (e.g. `.../index.html`).
+  Optional. Only the **path and query** are honored — the emailed link's host is always the server-derived preview host for this session and port, so this cannot redirect the invite elsewhere. Pass it when you need a specific path (e.g. `.../index.html`); omit it and the server derives the bare preview URL.
 </ParamField>
 
 ## Response

--- a/docs/cloud-api/sessions/preview-shares-list.mdx
+++ b/docs/cloud-api/sessions/preview-shares-list.mdx
@@ -1,0 +1,93 @@
+---
+title: "List Preview Shares"
+api: "GET /api/sessions/{session_id}/preview-shares"
+description: "See who has access to a session's live preview"
+---
+
+Lists the preview shares on a session, newest first. Optionally narrowed to a single port.
+
+Use `has_accessed` to tell whether an invitee ever actually opened the preview — useful for chasing a client who says they never got the link.
+
+**Required scope:** `sessions:read`
+
+<Info>
+  From the CLI: `runtm-api session share list <session_id>`
+</Info>
+
+## Path Parameters
+
+<ParamField path="session_id" type="string" required>
+  The session ID (e.g. `ses_abc123`).
+</ParamField>
+
+## Query Parameters
+
+<ParamField query="port" type="integer">
+  Only return shares for this port. Omit for all ports.
+</ParamField>
+
+## Headers
+
+<ParamField header="Authorization" type="string" required>
+  Bearer token. Example: `Bearer runtm_xxx`
+</ParamField>
+
+<ParamField header="X-Organization-Id" type="string">
+  Scope to an organization.
+</ParamField>
+
+## Response
+
+<ResponseField name="shares" type="array">
+  Each share: `id`, `port`, `invited_email`, `user_id`, `created_by`, `created_by_email`, `created_at`, `last_accessed_at`, `has_accessed`.
+</ResponseField>
+
+<ResponseField name="count" type="integer">
+  Number of shares returned.
+</ResponseField>
+
+<RequestExample>
+```bash cURL
+curl "https://app.runtm.com/api/cloud/sessions/ses_abc123/preview-shares?port=3000" \
+  -H "Authorization: Bearer runtm_xxx"
+```
+
+```bash CLI
+runtm-api session share list ses_abc123 --port 3000
+```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://app.runtm.com/api/cloud/sessions/ses_abc123/preview-shares",
+    headers={"Authorization": "Bearer runtm_xxx"},
+    params={"port": 3000},
+)
+
+for share in response.json()["shares"]:
+    seen = "opened" if share["has_accessed"] else "not opened yet"
+    print(share["invited_email"], seen)
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200
+{
+  "shares": [
+    {
+      "id": "9c1f0b7e-4b1a-4c2e-8f3d-2a5b6c7d8e9f",
+      "port": 3000,
+      "invited_email": "dev@acme.com",
+      "user_id": "user_xyz",
+      "created_by": "user_abc",
+      "created_by_email": "you@yourcompany.com",
+      "created_at": "2026-08-19T22:10:00Z",
+      "last_accessed_at": "2026-08-19T22:41:12Z",
+      "has_accessed": true
+    }
+  ],
+  "count": 1
+}
+```
+</ResponseExample>

--- a/docs/cloud-api/sessions/preview-shares-revoke.mdx
+++ b/docs/cloud-api/sessions/preview-shares-revoke.mdx
@@ -1,0 +1,73 @@
+---
+title: "Revoke a Preview Share"
+api: "DELETE /api/sessions/{session_id}/preview-shares/{share_id}"
+description: "Withdraw someone's access to a shared preview"
+---
+
+Deletes a preview share.
+
+Revocation takes effect once the holder's current preview cookie expires — a few minutes — rather than instantly. To cut access off immediately, pause or destroy the session as well.
+
+Get `share_id` from [List Preview Shares](/cloud-api/sessions/preview-shares-list).
+
+**Required scope:** `sessions:write`
+
+<Info>
+  From the CLI: `runtm-api session share revoke <session_id> <share_id>`
+</Info>
+
+## Path Parameters
+
+<ParamField path="session_id" type="string" required>
+  The session ID (e.g. `ses_abc123`).
+</ParamField>
+
+<ParamField path="share_id" type="string" required>
+  The share ID. Scoped by session, so an id alone is not enough to revoke.
+</ParamField>
+
+## Headers
+
+<ParamField header="Authorization" type="string" required>
+  Bearer token. Example: `Bearer runtm_xxx`
+</ParamField>
+
+<ParamField header="X-Organization-Id" type="string">
+  Scope to an organization.
+</ParamField>
+
+## Response
+
+<ResponseField name="revoked" type="boolean">
+  `true` when the share was deleted. Returns `404` when no such share exists on this session.
+</ResponseField>
+
+<RequestExample>
+```bash cURL
+curl -X DELETE \
+  "https://app.runtm.com/api/cloud/sessions/ses_abc123/preview-shares/9c1f0b7e-4b1a-4c2e-8f3d-2a5b6c7d8e9f" \
+  -H "Authorization: Bearer runtm_xxx"
+```
+
+```bash CLI
+runtm-api session share revoke ses_abc123 9c1f0b7e-4b1a-4c2e-8f3d-2a5b6c7d8e9f
+```
+
+```python Python
+import requests
+
+requests.delete(
+    "https://app.runtm.com/api/cloud/sessions/ses_abc123"
+    "/preview-shares/9c1f0b7e-4b1a-4c2e-8f3d-2a5b6c7d8e9f",
+    headers={"Authorization": "Bearer runtm_xxx"},
+)
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200
+{
+  "revoked": true
+}
+```
+</ResponseExample>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -114,6 +114,14 @@
         "cloud-api/sessions/rename",
         "cloud-api/sessions/visibility",
         {
+          "group": "Sharing",
+          "pages": [
+            "cloud-api/sessions/preview-shares-create",
+            "cloud-api/sessions/preview-shares-list",
+            "cloud-api/sessions/preview-shares-revoke"
+          ]
+        },
+        {
           "group": "Lifecycle",
           "pages": [
             "cloud-api/sessions/pause",

--- a/packages/agent/internal/cmd/root.go
+++ b/packages/agent/internal/cmd/root.go
@@ -47,6 +47,7 @@ Docs: https://docs.runtm.com`,
 	AddSessionDeploy(sessionCmd, rt)
 	AddSessionTerminal(sessionCmd, rt)
 	AddSessionOps(sessionCmd, rt)
+	AddSessionShare(sessionCmd, rt)
 
 	root.AddCommand(
 		NewAuthCommand(rt),

--- a/packages/agent/internal/cmd/session_share_cmd.go
+++ b/packages/agent/internal/cmd/session_share_cmd.go
@@ -1,0 +1,242 @@
+// Package cmd: preview sharing and preview-URL discovery.
+//
+// A preview share grants ONE email address access to ONE port of a session's
+// live preview. It is deliberately the narrowest grant in the product: the
+// invitee gets the preview and nothing else — no workspace, no terminal, no
+// prompting — and they are not added to the organization. They do need a
+// Runtm account, but not before being invited; the grant binds to their user
+// id the first time they sign in and open the link.
+//
+// This exists because the share API is dual-mode (Bearer API key or the web
+// app's HMAC), but until now only the web app could reach it. Anyone driving
+// Runtm from the CLI had to open the dashboard to hand a prototype to someone
+// outside their org.
+//
+// Wired into `runtm session` from root.go via `AddSessionShare(sessionCmd, rt)`.
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+// AddSessionShare attaches the preview-share tree and the `previews` listing
+// to the existing `runtm session` command.
+func AddSessionShare(sessionCmd *cobra.Command, rt *Runtime) {
+	share := &cobra.Command{
+		Use:   "share",
+		Short: "Share a session's live preview with someone outside the org",
+		Long: `Grant one email address access to one port of a session's live preview.
+
+The invitee can open that preview and nothing else — no workspace, no
+terminal, no prompting — and they are not added to your organization. They
+need a Runtm account to open it, but not before you invite them.
+
+Paused sandboxes wake up automatically when a shared link is opened, so a
+share keeps working after the ~20-minute idle pause.
+
+  runtm-api session share create <session_id> --email dev@acme.com --port 3000
+  runtm-api session share list   <session_id>
+  runtm-api session share revoke <session_id> <share_id>`,
+	}
+	share.AddCommand(
+		newSessionShareCreate(rt),
+		newSessionShareList(rt),
+		newSessionShareRevoke(rt),
+	)
+	sessionCmd.AddCommand(share, newSessionPreviews(rt))
+}
+
+func newSessionShareCreate(rt *Runtime) *cobra.Command {
+	var (
+		email      string
+		port       int
+		previewURL string
+	)
+	cmd := &cobra.Command{
+		Use:   "create <session_id>",
+		Short: "Invite an email to one port of a preview (POST /api/sessions/{id}/preview-shares)",
+		Long: `Grants <email> access to <port> of this session's preview and emails them
+the link. Re-inviting an address that already has the port is a no-op, and no
+second email is sent.
+
+The response includes "preview_url" — the link to send if "emailed" is false
+(which happens when email delivery is not configured).
+
+Required scope: sessions:write`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _, err := rt.Client()
+			if err != nil {
+				return err
+			}
+			if email == "" {
+				return fmt.Errorf("--email is required")
+			}
+			body := map[string]any{"email": email, "port": port}
+			// Only sent when the caller already knows the live URL (the web
+			// app does, including any path). The server derives one otherwise.
+			if previewURL != "" {
+				body["preview_url"] = previewURL
+			}
+			resp, err := c.PostJSON("/sessions/"+url.PathEscape(args[0])+"/preview-shares", body)
+			return runJSON(rt, resp, err)
+		},
+	}
+	cmd.Flags().StringVar(&email, "email", "", "Email address to invite (required)")
+	cmd.Flags().IntVar(&port, "port", 3000, "Preview port to share")
+	cmd.Flags().StringVar(&previewURL, "preview-url", "", "Override the emailed link (defaults to the session's preview URL for this port)")
+	return cmd
+}
+
+func newSessionShareList(rt *Runtime) *cobra.Command {
+	var port int
+	cmd := &cobra.Command{
+		Use:   "list <session_id>",
+		Short: "List preview shares (GET /api/sessions/{id}/preview-shares)",
+		Long: `Lists who has access to this session's preview. "has_accessed" tells you
+whether the invitee ever actually opened it.
+
+Required scope: sessions:read`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _, err := rt.Client()
+			if err != nil {
+				return err
+			}
+			q := url.Values{}
+			if port > 0 {
+				q.Set("port", strconv.Itoa(port))
+			}
+			resp, err := c.Get("/sessions/"+url.PathEscape(args[0])+"/preview-shares", q)
+			return runJSON(rt, resp, err)
+		},
+	}
+	cmd.Flags().IntVar(&port, "port", 0, "Only shares for this port (default: all ports)")
+	return cmd
+}
+
+func newSessionShareRevoke(rt *Runtime) *cobra.Command {
+	return &cobra.Command{
+		Use:   "revoke <session_id> <share_id>",
+		Short: "Revoke a preview share (DELETE /api/sessions/{id}/preview-shares/{share_id})",
+		Long: `Revokes access. Takes effect once the holder's current preview cookie
+expires (a few minutes), not instantly.
+
+Get <share_id> from 'runtm-api session share list <session_id>'.
+
+Required scope: sessions:write`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _, err := rt.Client()
+			if err != nil {
+				return err
+			}
+			resp, err := c.Delete(
+				"/sessions/" + url.PathEscape(args[0]) + "/preview-shares/" + url.PathEscape(args[1]),
+			)
+			return runJSON(rt, resp, err)
+		},
+	}
+}
+
+// --- previews (projection over /api/sessions/) ----------------------------
+
+// sessionPreviewRow is the trimmed shape `previews` emits. `session list`
+// returns the full session objects, which bury the preview URL in a wall of
+// fields; agents asked for "my preview URLs" should get exactly that.
+type sessionPreviewRow struct {
+	ID         string `json:"id"`
+	Name       string `json:"name,omitempty"`
+	State      string `json:"state"`
+	PreviewURL string `json:"preview_url"`
+}
+
+func newSessionPreviews(rt *Runtime) *cobra.Command {
+	var (
+		limit    int
+		teamMode bool
+		all      bool
+	)
+	cmd := &cobra.Command{
+		Use:   "previews",
+		Short: "List preview URLs for your own sessions",
+		Long: `Lists the preview URLs of sessions YOU created, newest first.
+
+Scoped to your API key's user by default. This is the command to reach for
+when you want "my preview URLs" — 'session list --team-mode' in a busy org
+returns every teammate's sessions too, which is rarely what was meant.
+
+Sessions with no preview URL yet are omitted unless --all is passed. A paused
+session still lists its URL: opening it wakes the sandbox automatically.
+
+Required scope: sessions:read`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _, err := rt.Client()
+			if err != nil {
+				return err
+			}
+
+			q := url.Values{}
+			q.Set("limit", strconv.Itoa(limit))
+			if teamMode {
+				q.Set("team_mode", "true")
+			}
+			resp, err := c.Get("/sessions/", q)
+			if err != nil {
+				return err
+			}
+
+			var payload struct {
+				Sessions []struct {
+					ID         string `json:"id"`
+					Name       string `json:"name"`
+					State      string `json:"state"`
+					PreviewURL string `json:"preview_url"`
+				} `json:"sessions"`
+				Total int `json:"total"`
+			}
+			if err := json.Unmarshal(resp, &payload); err != nil {
+				// Shape changed underneath us — hand back the raw body rather
+				// than swallowing the data the caller asked for.
+				rt.WriteJSON(resp)
+				return nil
+			}
+
+			rows := make([]sessionPreviewRow, 0, len(payload.Sessions))
+			for _, s := range payload.Sessions {
+				if s.PreviewURL == "" && !all {
+					continue
+				}
+				rows = append(rows, sessionPreviewRow{
+					ID:         s.ID,
+					Name:       s.Name,
+					State:      s.State,
+					PreviewURL: s.PreviewURL,
+				})
+			}
+
+			rt.WriteObject(map[string]any{
+				"previews": rows,
+				"count":    len(rows),
+				"scope":    previewScope(teamMode),
+			})
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 50, "Number of sessions to scan (1-100)")
+	cmd.Flags().BoolVar(&teamMode, "team-mode", false, "Include teammates' team-visible sessions instead of only your own")
+	cmd.Flags().BoolVar(&all, "all", false, "Include sessions that have no preview URL yet")
+	return cmd
+}
+
+func previewScope(teamMode bool) string {
+	if teamMode {
+		return "team"
+	}
+	return "mine"
+}

--- a/packages/agent/internal/cmd/session_share_cmd.go
+++ b/packages/agent/internal/cmd/session_share_cmd.go
@@ -78,8 +78,8 @@ Required scope: sessions:write`,
 				return fmt.Errorf("--email is required")
 			}
 			body := map[string]any{"email": email, "port": port}
-			// Only sent when the caller already knows the live URL (the web
-			// app does, including any path). The server derives one otherwise.
+			// The server pins the emailed link's host to the session's own
+			// preview host; passing a URL only contributes its path/query.
 			if previewURL != "" {
 				body["preview_url"] = previewURL
 			}
@@ -89,7 +89,7 @@ Required scope: sessions:write`,
 	}
 	cmd.Flags().StringVar(&email, "email", "", "Email address to invite (required)")
 	cmd.Flags().IntVar(&port, "port", 3000, "Preview port to share")
-	cmd.Flags().StringVar(&previewURL, "preview-url", "", "Override the emailed link (defaults to the session's preview URL for this port)")
+	cmd.Flags().StringVar(&previewURL, "preview-url", "", "Add a path/query to the emailed link (host is always the session's own preview host)")
 	return cmd
 }
 

--- a/packages/agent/internal/cmd/session_share_cmd_test.go
+++ b/packages/agent/internal/cmd/session_share_cmd_test.go
@@ -1,0 +1,307 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// shareRuntime wires a Runtime at a mock API so the share commands can be
+// executed end to end (flags -> request -> printed JSON) rather than only
+// checked for registration.
+func shareRuntime(t *testing.T, handler http.HandlerFunc) (*Runtime, *bytes.Buffer) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	t.Setenv("RUNTM_API_KEY", "runtm_sk_test")
+	t.Setenv("RUNTM_ORG_ID", "")
+	stdout := &bytes.Buffer{}
+	return &Runtime{
+		Flags:  &GlobalFlags{APIURL: srv.URL},
+		Stdout: stdout,
+		Stderr: &bytes.Buffer{},
+	}, stdout
+}
+
+func TestSessionShareSubcommandsRegistered(t *testing.T) {
+	root := NewRootCommand()
+	session := findSub(t, root, "session")
+
+	if !hasSub(session, "share") {
+		t.Fatal("session is missing \"share\"")
+	}
+	share := findSub(t, session, "share")
+	for _, name := range []string{"create", "list", "revoke"} {
+		if !hasSub(share, name) {
+			t.Errorf("session share is missing %q", name)
+		}
+	}
+	// The preview listing is a sibling of share, not a child.
+	if !hasSub(session, "previews") {
+		t.Error("session is missing \"previews\"")
+	}
+}
+
+func TestShareCreateSendsEmailAndPort(t *testing.T) {
+	var gotPath, gotMethod string
+	var gotBody map[string]any
+
+	rt, stdout := shareRuntime(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"created":true,"emailed":true,"preview_url":"https://3000-x.dev.runtm.com"}`))
+	})
+
+	cmd := newSessionShareCreate(rt)
+	cmd.SetArgs([]string{"ses-1", "--email", "dev@acme.com", "--port", "5173"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if !strings.HasSuffix(gotPath, "/sessions/ses-1/preview-shares") {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotBody["email"] != "dev@acme.com" {
+		t.Errorf("email = %v", gotBody["email"])
+	}
+	if gotBody["port"].(float64) != 5173 {
+		t.Errorf("port = %v, want 5173", gotBody["port"])
+	}
+	// preview_url is omitted unless explicitly overridden — the server derives
+	// it, which is the whole point for a CLI caller.
+	if _, ok := gotBody["preview_url"]; ok {
+		t.Error("preview_url should be omitted when not passed")
+	}
+	// The printed body must carry the link, since that's what the user sends
+	// when email delivery isn't configured.
+	if !strings.Contains(stdout.String(), "3000-x.dev.runtm.com") {
+		t.Errorf("stdout missing preview_url: %s", stdout.String())
+	}
+}
+
+func TestShareCreateDefaultsToPort3000(t *testing.T) {
+	var gotBody map[string]any
+	rt, _ := shareRuntime(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	cmd := newSessionShareCreate(rt)
+	cmd.SetArgs([]string{"ses-1", "--email", "dev@acme.com"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotBody["port"].(float64) != 3000 {
+		t.Errorf("default port = %v, want 3000", gotBody["port"])
+	}
+}
+
+func TestShareCreateRequiresEmail(t *testing.T) {
+	called := false
+	rt, _ := shareRuntime(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	cmd := newSessionShareCreate(rt)
+	cmd.SetArgs([]string{"ses-1"})
+	cmd.SilenceUsage, cmd.SilenceErrors = true, true
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected an error when --email is missing")
+	}
+	if called {
+		t.Error("must not call the API without an email")
+	}
+}
+
+func TestShareListPassesPortFilter(t *testing.T) {
+	var gotQuery string
+	rt, _ := shareRuntime(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"shares":[],"count":0}`))
+	})
+
+	cmd := newSessionShareList(rt)
+	cmd.SetArgs([]string{"ses-1", "--port", "8080"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotQuery != "port=8080" {
+		t.Errorf("query = %q, want port=8080", gotQuery)
+	}
+}
+
+func TestShareListOmitsPortWhenUnset(t *testing.T) {
+	var gotQuery string
+	rt, _ := shareRuntime(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"shares":[],"count":0}`))
+	})
+
+	cmd := newSessionShareList(rt)
+	cmd.SetArgs([]string{"ses-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotQuery != "" {
+		t.Errorf("query = %q, want empty (all ports)", gotQuery)
+	}
+}
+
+func TestShareRevokeDeletesTheShare(t *testing.T) {
+	var gotPath, gotMethod string
+	rt, _ := shareRuntime(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		_, _ = w.Write([]byte(`{"revoked":true}`))
+	})
+
+	cmd := newSessionShareRevoke(rt)
+	cmd.SetArgs([]string{"ses-1", "share-9"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method = %q, want DELETE", gotMethod)
+	}
+	if !strings.HasSuffix(gotPath, "/sessions/ses-1/preview-shares/share-9") {
+		t.Errorf("path = %q", gotPath)
+	}
+}
+
+// --- previews -------------------------------------------------------------
+
+const previewsPayload = `{
+  "sessions": [
+    {"id":"s1","name":"Bippy deck","state":"paused","preview_url":"https://3000-a.dev.runtm.com"},
+    {"id":"s2","name":"No server yet","state":"running","preview_url":""},
+    {"id":"s3","name":"Tour","state":"running","preview_url":"https://3000-c.dev.runtm.com"}
+  ],
+  "total": 3
+}`
+
+func TestPreviewsIsScopedToTheCallerByDefault(t *testing.T) {
+	var gotQuery string
+	rt, stdout := shareRuntime(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(previewsPayload))
+	})
+
+	cmd := newSessionPreviews(rt)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	// The bug this command exists to fix: asking for "my preview URLs" and
+	// getting the whole org back because team_mode leaked in.
+	if strings.Contains(gotQuery, "team_mode") {
+		t.Errorf("must not request team mode by default, query = %q", gotQuery)
+	}
+
+	var out struct {
+		Count int    `json:"count"`
+		Scope string `json:"scope"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal stdout: %v (%s)", err, stdout.String())
+	}
+	if out.Scope != "mine" {
+		t.Errorf("scope = %q, want mine", out.Scope)
+	}
+}
+
+func TestPreviewsDropsSessionsWithoutAUrl(t *testing.T) {
+	rt, stdout := shareRuntime(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(previewsPayload))
+	})
+
+	cmd := newSessionPreviews(rt)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var out struct {
+		Previews []sessionPreviewRow `json:"previews"`
+		Count    int                 `json:"count"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Count != 2 {
+		t.Fatalf("count = %d, want 2 (s2 has no preview URL)", out.Count)
+	}
+	for _, p := range out.Previews {
+		if p.ID == "s2" {
+			t.Error("s2 has no preview URL and should be omitted")
+		}
+	}
+	// A paused session still lists — opening the link wakes it.
+	if out.Previews[0].State != "paused" || out.Previews[0].PreviewURL == "" {
+		t.Errorf("paused session should still be listed: %+v", out.Previews[0])
+	}
+}
+
+func TestPreviewsAllIncludesSessionsWithoutAUrl(t *testing.T) {
+	rt, stdout := shareRuntime(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(previewsPayload))
+	})
+
+	cmd := newSessionPreviews(rt)
+	cmd.SetArgs([]string{"--all"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var out struct {
+		Count int `json:"count"`
+	}
+	_ = json.Unmarshal(stdout.Bytes(), &out)
+	if out.Count != 3 {
+		t.Errorf("count = %d, want 3 with --all", out.Count)
+	}
+}
+
+func TestPreviewsTeamModeIsOptIn(t *testing.T) {
+	var gotQuery string
+	rt, stdout := shareRuntime(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(previewsPayload))
+	})
+
+	cmd := newSessionPreviews(rt)
+	cmd.SetArgs([]string{"--team-mode"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(gotQuery, "team_mode=true") {
+		t.Errorf("query = %q, want team_mode=true", gotQuery)
+	}
+	// Scope is reported so an agent can tell the user whose sessions these are.
+	if !strings.Contains(stdout.String(), `"scope": "team"`) {
+		t.Errorf("stdout should report team scope: %s", stdout.String())
+	}
+}
+
+func TestPreviewsFallsBackToRawBodyOnUnknownShape(t *testing.T) {
+	rt, stdout := shareRuntime(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`["unexpected"]`))
+	})
+
+	cmd := newSessionPreviews(rt)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	// Better to hand back data we can't project than to silently print zero.
+	if !strings.Contains(stdout.String(), "unexpected") {
+		t.Errorf("expected raw passthrough, got %s", stdout.String())
+	}
+}

--- a/packages/agent/internal/skills/files/SKILL.md
+++ b/packages/agent/internal/skills/files/SKILL.md
@@ -79,7 +79,11 @@ To parameterize a template, declare **session arguments** with `--session-arg` (
 | Inspect workspace state | `runtm-api session workspace-state <id>` |
 | Pause / resume / rename | `runtm-api session pause\|resume\|rename <id> [...]` |
 | Bump idle timer | `runtm-api session heartbeat <id>` |
-| Change visibility | `runtm-api session visibility <id> private\|team` |
+| Change visibility (inside the org) | `runtm-api session visibility <id> private\|team` |
+| **Share a preview outside the org** | `runtm-api session share create <id> --email <addr> [--port N]` |
+| List who a preview is shared with | `runtm-api session share list <id> [--port N]` |
+| Revoke a preview share | `runtm-api session share revoke <id> <share_id>` |
+| **List my own preview URLs** | `runtm-api session previews` |
 | Per-session instructions | `runtm-api session instructions get\|set <id> ...` |
 | Collaborators | `runtm-api session collaborators <id>` |
 | Start dev server | `runtm-api session run-server <id> [--port N]` |
@@ -360,8 +364,10 @@ If `authenticated: false`, ask the user to set `RUNTM_API_KEY` (or run `runtm-ap
 
 | Operation | Required scope(s) |
 |-----------|------------------|
-| `session list\|get\|status\|history\|workspace-state\|collaborators` | `sessions:read` |
+| `session list\|get\|status\|history\|workspace-state\|collaborators\|previews` | `sessions:read` |
+| `session share list` | `sessions:read` |
 | `session create\|destroy\|rename\|pause\|resume\|git\|visibility\|heartbeat\|run-server` | `sessions:write` (`sessions:delete` for destroy) |
+| `session share create\|revoke` | `sessions:write` |
 | `session launch` | `sessions:write` + `sessions:prompt` |
 | `session connect\|exec` | `sessions:terminal` |
 | `session prompt\|prompt-cancel\|events` | `sessions:prompt` |

--- a/packages/agent/internal/skills/files/runtm-sessions.md
+++ b/packages/agent/internal/skills/files/runtm-sessions.md
@@ -31,6 +31,9 @@ Workflow recipes for the `runtm-api session` subcommands. For endpoint details s
 | Hold a sandbox without spending | `session pause` then `session resume` later |
 | Edit files programmatically | `session file write` |
 | Inject configuration | `session env set <id> KEY=VAL ...` |
+| **Show a preview to someone outside the org** | `session share create <id> --email <addr> --port N` |
+| **Get the preview URLs of my own sessions** | `session previews` (NOT `session list --team-mode`) |
+| Let teammates in the same org open a session | `session visibility <id> team` |
 
 ## Recipe: boot a session from a template, then run commands
 
@@ -170,6 +173,69 @@ runtm-api session search --source schedule --created-after 2026-07-01
 
 `session list` only pages; `search` filters by agent, model, template, source,
 creator, and time windows, and matches name/prompt text with `-q`.
+
+## Recipe: find my own preview URLs
+
+When the user asks "what are my preview URLs" / "give me the link to my
+prototype", use `session previews`. It is scoped to the API key's own user and
+returns just `id`, `name`, `state`, `preview_url`.
+
+```bash
+runtm-api session previews              # my sessions that have a preview URL
+runtm-api session previews --all        # include ones with no URL yet
+runtm-api session previews --team-mode  # opt in to teammates' shared sessions
+```
+
+Do **not** reach for `session list --team-mode` here. In a busy org that
+returns every teammate's sessions, so the user gets back a wall of URLs that
+are mostly not theirs. `session previews` defaults to `scope: "mine"` and says
+so in its output.
+
+A `paused` session still lists its URL. Opening a shared preview wakes the
+sandbox automatically, so a paused state is not a reason to withhold the link.
+
+## Recipe: share a live preview with someone outside the org
+
+Two different things, often confused:
+
+| You want | Use |
+|----------|-----|
+| A teammate **in the org** to open the whole session | `session visibility <id> team` |
+| Someone **outside the org** to view only the running app | `session share create ...` |
+
+A preview share grants exactly one `(session, port)` pair. The invitee gets the
+app and nothing else -- no workspace, no terminal, no prompting -- and is not
+added to the organization. They need a Runtm account to open it, but not before
+being invited: the grant binds to their account the first time they sign in.
+
+```bash
+# 1. Make sure something is actually serving on the port
+runtm-api session run-server <id> --port 3000
+
+# 2. Grant access and email the link
+runtm-api session share create <id> --email client@acme.com --port 3000
+# -> {"created": true, "emailed": true, "preview_url": "https://3000-....dev.runtm.com"}
+
+# 3. See who has access and whether they opened it
+runtm-api session share list <id>
+# -> shares[].has_accessed
+
+# 4. Withdraw access
+runtm-api session share revoke <id> <share_id>
+```
+
+If `emailed` is `false`, delivery is not configured -- send `preview_url` to the
+invitee yourself. Re-inviting an address that already has the port is a no-op
+and sends no second email.
+
+Sessions auto-pause after ~20 minutes idle. A shared link keeps working
+regardless: opening it wakes the sandbox and lands the visitor on the preview
+after a few seconds. Do not pre-emptively `session resume` just to keep a share
+alive.
+
+Revocation applies once the holder's current preview cookie expires (a few
+minutes), not instantly. To cut access immediately, also pause or destroy the
+session.
 
 ## Recipe: ship a deployment and track it afterwards
 

--- a/packages/agent/skills/SKILL.md
+++ b/packages/agent/skills/SKILL.md
@@ -79,7 +79,11 @@ To parameterize a template, declare **session arguments** with `--session-arg` (
 | Inspect workspace state | `runtm-api session workspace-state <id>` |
 | Pause / resume / rename | `runtm-api session pause\|resume\|rename <id> [...]` |
 | Bump idle timer | `runtm-api session heartbeat <id>` |
-| Change visibility | `runtm-api session visibility <id> private\|team` |
+| Change visibility (inside the org) | `runtm-api session visibility <id> private\|team` |
+| **Share a preview outside the org** | `runtm-api session share create <id> --email <addr> [--port N]` |
+| List who a preview is shared with | `runtm-api session share list <id> [--port N]` |
+| Revoke a preview share | `runtm-api session share revoke <id> <share_id>` |
+| **List my own preview URLs** | `runtm-api session previews` |
 | Per-session instructions | `runtm-api session instructions get\|set <id> ...` |
 | Collaborators | `runtm-api session collaborators <id>` |
 | Start dev server | `runtm-api session run-server <id> [--port N]` |
@@ -360,8 +364,10 @@ If `authenticated: false`, ask the user to set `RUNTM_API_KEY` (or run `runtm-ap
 
 | Operation | Required scope(s) |
 |-----------|------------------|
-| `session list\|get\|status\|history\|workspace-state\|collaborators` | `sessions:read` |
+| `session list\|get\|status\|history\|workspace-state\|collaborators\|previews` | `sessions:read` |
+| `session share list` | `sessions:read` |
 | `session create\|destroy\|rename\|pause\|resume\|git\|visibility\|heartbeat\|run-server` | `sessions:write` (`sessions:delete` for destroy) |
+| `session share create\|revoke` | `sessions:write` |
 | `session launch` | `sessions:write` + `sessions:prompt` |
 | `session connect\|exec` | `sessions:terminal` |
 | `session prompt\|prompt-cancel\|events` | `sessions:prompt` |

--- a/packages/agent/skills/runtm-sessions.md
+++ b/packages/agent/skills/runtm-sessions.md
@@ -31,6 +31,9 @@ Workflow recipes for the `runtm-api session` subcommands. For endpoint details s
 | Hold a sandbox without spending | `session pause` then `session resume` later |
 | Edit files programmatically | `session file write` |
 | Inject configuration | `session env set <id> KEY=VAL ...` |
+| **Show a preview to someone outside the org** | `session share create <id> --email <addr> --port N` |
+| **Get the preview URLs of my own sessions** | `session previews` (NOT `session list --team-mode`) |
+| Let teammates in the same org open a session | `session visibility <id> team` |
 
 ## Recipe: boot a session from a template, then run commands
 
@@ -170,6 +173,69 @@ runtm-api session search --source schedule --created-after 2026-07-01
 
 `session list` only pages; `search` filters by agent, model, template, source,
 creator, and time windows, and matches name/prompt text with `-q`.
+
+## Recipe: find my own preview URLs
+
+When the user asks "what are my preview URLs" / "give me the link to my
+prototype", use `session previews`. It is scoped to the API key's own user and
+returns just `id`, `name`, `state`, `preview_url`.
+
+```bash
+runtm-api session previews              # my sessions that have a preview URL
+runtm-api session previews --all        # include ones with no URL yet
+runtm-api session previews --team-mode  # opt in to teammates' shared sessions
+```
+
+Do **not** reach for `session list --team-mode` here. In a busy org that
+returns every teammate's sessions, so the user gets back a wall of URLs that
+are mostly not theirs. `session previews` defaults to `scope: "mine"` and says
+so in its output.
+
+A `paused` session still lists its URL. Opening a shared preview wakes the
+sandbox automatically, so a paused state is not a reason to withhold the link.
+
+## Recipe: share a live preview with someone outside the org
+
+Two different things, often confused:
+
+| You want | Use |
+|----------|-----|
+| A teammate **in the org** to open the whole session | `session visibility <id> team` |
+| Someone **outside the org** to view only the running app | `session share create ...` |
+
+A preview share grants exactly one `(session, port)` pair. The invitee gets the
+app and nothing else -- no workspace, no terminal, no prompting -- and is not
+added to the organization. They need a Runtm account to open it, but not before
+being invited: the grant binds to their account the first time they sign in.
+
+```bash
+# 1. Make sure something is actually serving on the port
+runtm-api session run-server <id> --port 3000
+
+# 2. Grant access and email the link
+runtm-api session share create <id> --email client@acme.com --port 3000
+# -> {"created": true, "emailed": true, "preview_url": "https://3000-....dev.runtm.com"}
+
+# 3. See who has access and whether they opened it
+runtm-api session share list <id>
+# -> shares[].has_accessed
+
+# 4. Withdraw access
+runtm-api session share revoke <id> <share_id>
+```
+
+If `emailed` is `false`, delivery is not configured -- send `preview_url` to the
+invitee yourself. Re-inviting an address that already has the port is a no-op
+and sends no second email.
+
+Sessions auto-pause after ~20 minutes idle. A shared link keeps working
+regardless: opening it wakes the sandbox and lands the visitor on the preview
+after a few seconds. Do not pre-emptively `session resume` just to keep a share
+alive.
+
+Revocation applies once the holder's current preview cookie expires (a few
+minutes), not instantly. To cut access immediately, also pause or destroy the
+session.
 
 ## Recipe: ship a deployment and track it afterwards
 


### PR DESCRIPTION
## Summary

CLI-first users (e.g. anyone driving Runtm through `runtm-api`) had no way to share a live preview with someone outside their org — the share API shipped dual-mode in runtm-cloud#374, but only the dashboard could reach it. This adds the CLI surface plus the "which preview URLs are mine" query that agents kept getting wrong.

- **`session share create <id> --email <addr> [--port N]`** — invite one email to one port. The backend derives the preview URL and sends the invite; the CLI prints `preview_url` + `emailed` so the caller forwards the link themselves when email delivery isn't configured.
- **`session share list|revoke`** — full lifecycle; `has_accessed` shows whether the invitee ever opened it.
- **`session previews`** — preview URLs scoped to the API key's own user (`scope: "mine"`), replacing the `session list --team-mode` misuse that returned every teammate's URLs in busy orgs.
- **Docs**: three Mintlify pages under `cloud-api/sessions/` + a Sharing nav group in `mint.json`.
- **Skills**: command/scope tables in `SKILL.md`, two new `runtm-sessions` recipes (find my preview URLs / share outside the org), synced into the embedded copies via `make sync-skills`.

Pairs with the runtm-cloud PR that adds wake-on-request for shared previews and moves the invite email into the backend (linked after it opens). The CLI works against prod as-is — endpoints already exist; without the paired PR the only degradation is `emailed: false` on create.

cc @cvolante54 — this builds directly on your preview-shares work in runtm-cloud#374.
@runtm-ai-guardian please review; watch for regressions in command registration (`root.go`) and the skills sync.

## Test plan

- [x] `go build ./...` + `go vet` clean (Go 1.25 toolchain)
- [x] 12 new tests in `session_share_cmd_test.go` (httptest-backed: flag→request mapping, port filter, scoping defaults, raw-body fallback) — `go test ./internal/cmd/` all green, full `go test ./...` green
- [x] Real-binary e2e against a real local backend (Postgres + migrations + seeded keys/sessions): `auth status`, `previews` (scope=mine, excludes other users + URL-less sessions), `share create` (created/emailed/preview_url), case-insensitive re-invite dedup, `list`, `revoke`, port 22 → 400, foreign session → 404, `sessions:read`-only key → 403 on create but list works
- [ ] `runtm-api skills install` refresh on a machine with `~/.claude/skills/runtm/` after merge

Made with [Cursor](https://cursor.com)