### PR TITLE
fix(worker): never allocate Fly IP addresses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,25 @@ jobs:
           RUNTM_API_SECRET: test-secret-for-ci-at-least-32-chars
           ARTIFACT_STORAGE_PATH: /tmp/artifacts
 
+  test-worker:
+    name: Test Worker Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          pip install -e packages/shared[dev]
+          pip install -e packages/worker[dev]
+
+      - name: Run tests
+        run: pytest packages/worker/tests -v
+
   test-cli:
     name: Test CLI Package
     runs-on: ubuntu-latest

--- a/packages/worker/runtm_worker/jobs/deploy.py
+++ b/packages/worker/runtm_worker/jobs/deploy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import concurrent.futures
 import contextlib
 import logging
 import os
@@ -430,15 +429,18 @@ class DeployJob:
                     f"App is accessible at https://{app_name}.fly.dev in the meantime."
                 )
 
-    def _ensure_fly_app_with_ips(
+    def _ensure_fly_app(
         self,
         provider: FlyProvider,
         app_name: str,
         build_log,
     ) -> bool:
-        """Ensure Fly app exists and has IP addresses allocated.
+        """Ensure the Fly app exists (the registry push requires it).
 
-        Uses concurrent execution for IP allocation to save time.
+        No IP addresses are allocated here, by design: runtm never calls
+        allocateIpAddress. `flyctl deploy` allocates what the generated
+        fly.toml's [http_service] needs, so the remote-builder path still
+        ends up publicly reachable without us provisioning anything.
 
         Args:
             provider: Fly provider instance
@@ -458,19 +460,6 @@ class DeployJob:
         # Create app
         provider._create_app(app_name)
         build_log.write(f"Created Fly app: {app_name}")
-
-        # Allocate IP addresses concurrently
-        build_log.write("Allocating IP addresses...")
-
-        # Use ThreadPoolExecutor for concurrent IP allocation
-        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-            future = executor.submit(provider._allocate_ip_addresses, app_name)
-            allocated_ips = future.result(timeout=30)
-
-        if allocated_ips:
-            build_log.write(f"Allocated IPs: {', '.join(allocated_ips)}")
-        else:
-            build_log.write("Warning: Could not allocate IP addresses")
 
         return True
 
@@ -675,7 +664,7 @@ class DeployJob:
                 # For redeployments, the app already exists so this is a no-op
                 provider = FlyProvider(api_token=self.fly_api_token)
                 try:
-                    self._ensure_fly_app_with_ips(provider, app_name, build_log)
+                    self._ensure_fly_app(provider, app_name, build_log)
                 except Exception as e:
                     raise BuildError(f"Failed to create Fly app: {e}") from e
 

--- a/packages/worker/runtm_worker/providers/fly.py
+++ b/packages/worker/runtm_worker/providers/fly.py
@@ -130,94 +130,6 @@ class FlyProvider(DeployProvider):
         )
         return response.json()
 
-    def _allocate_ip_addresses(self, app_name: str) -> list[str]:
-        """Allocate IP addresses for the app using GraphQL API.
-
-        This is required for the app to be accessible on the .fly.dev domain.
-        Allocates both a shared IPv4 and an IPv6 address.
-
-        Args:
-            app_name: App name
-
-        Returns:
-            List of allocated IP addresses
-        """
-        allocated_ips = []
-
-        # Allocate shared IPv4 (free tier)
-        ipv4_mutation = """
-        mutation($input: AllocateIPAddressInput!) {
-            allocateIpAddress(input: $input) {
-                ipAddress {
-                    id
-                    address
-                    type
-                }
-            }
-        }
-        """
-
-        try:
-            response = httpx.post(
-                self.FLY_GRAPHQL_URL,
-                headers={
-                    "Authorization": f"Bearer {self.api_token}",
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "query": ipv4_mutation,
-                    "variables": {
-                        "input": {
-                            "appId": app_name,
-                            "type": "shared_v4",
-                        }
-                    },
-                },
-                timeout=30.0,
-            )
-
-            if response.status_code == 200:
-                data = response.json()
-                if "data" in data and data["data"].get("allocateIpAddress"):
-                    ip_data = data["data"]["allocateIpAddress"]["ipAddress"]
-                    if ip_data:
-                        allocated_ips.append(ip_data.get("address", "shared_v4"))
-        except Exception:
-            # Continue even if IPv4 allocation fails
-            pass
-
-        # Allocate IPv6 (always free)
-        try:
-            response = httpx.post(
-                self.FLY_GRAPHQL_URL,
-                headers={
-                    "Authorization": f"Bearer {self.api_token}",
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "query": ipv4_mutation,
-                    "variables": {
-                        "input": {
-                            "appId": app_name,
-                            "type": "v6",
-                        }
-                    },
-                },
-                timeout=30.0,
-            )
-
-            if response.status_code == 200:
-                data = response.json()
-                if "data" in data and data["data"].get("allocateIpAddress"):
-                    ip_data = data["data"]["allocateIpAddress"]["ipAddress"]
-                    if ip_data:
-                        allocated_ips.append(ip_data.get("address", "v6"))
-        except Exception:
-            # Continue even if IPv6 allocation fails
-            pass
-
-        return allocated_ips
-
     def _get_app(self, app_name: str) -> dict[str, Any] | None:
         """Get app details.
 
@@ -557,14 +469,6 @@ class FlyProvider(DeployProvider):
             if not existing_app:
                 self._create_app(app_name)
                 logs_buffer.append(f"Created app: {app_name}")
-
-                # Allocate IP addresses for public access
-                logs_buffer.append("Allocating IP addresses...")
-                allocated_ips = self._allocate_ip_addresses(app_name)
-                if allocated_ips:
-                    logs_buffer.append(f"Allocated IPs: {', '.join(allocated_ips)}")
-                else:
-                    logs_buffer.append("Warning: Could not allocate IP addresses")
             else:
                 logs_buffer.append(f"Using existing app: {app_name}")
 
@@ -953,51 +857,11 @@ class FlyProvider(DeployProvider):
         """
         app_name = resource.app_name
 
-        # First, get the app's IP addresses for DNS records
+        # Report the app's existing IP addresses as DNS records. Runtm never
+        # allocates IPs, so an app with none yields no A/AAAA records here and
+        # the caller must point DNS at the app another way (e.g. a CNAME to
+        # {app}.fly.dev).
         ips = self._get_app_ips(app_name)
-
-        # Check if we have IPv4 - if not, try to allocate it
-        has_ipv4 = any(ip.get("type", "").lower() in ("v4", "shared_v4") for ip in ips)
-
-        if not has_ipv4:
-            # Try to allocate shared IPv4 (FREE) if missing (required for many DNS providers like Squarespace)
-            # Note: shared_v4 is free, dedicated v4 costs $2/month
-            try:
-                ipv4_mutation = """
-                mutation($input: AllocateIPAddressInput!) {
-                    allocateIpAddress(input: $input) {
-                        ipAddress {
-                            id
-                            address
-                            type
-                        }
-                    }
-                }
-                """
-                result = self._graphql_request(
-                    ipv4_mutation,
-                    {
-                        "input": {
-                            "appId": app_name,
-                            "type": "shared_v4",  # FREE shared IPv4, not dedicated ($2/mo)
-                        }
-                    },
-                )
-                # Check if allocation succeeded
-                ip_data = result.get("allocateIpAddress", {}).get("ipAddress")
-                if ip_data:
-                    # Brief wait for IP to propagate, then refresh
-                    import time
-
-                    time.sleep(1)
-                    ips = self._get_app_ips(app_name)
-            except FlyError:
-                # If allocation fails, continue with what we have
-                # User will see a warning about IPv6-only with manual allocation instructions
-                pass
-            except Exception:
-                # Other errors - continue with what we have
-                pass
 
         dns_records = []
         record_name = "@" if hostname.count(".") == 1 else hostname.split(".")[0]
@@ -1258,50 +1122,9 @@ class FlyProvider(DeployProvider):
             app_data = data.get("app", {})
             cert = app_data.get("certificate")
 
-            # Use _get_app_ips to get complete IP list (including shared IPv4)
+            # Report whatever IPs the app already has. Runtm never allocates
+            # them, so this list is empty for an app that was never given one.
             ips = self._get_app_ips(app_name)
-
-            # Check if we have IPv4 - if not, try to allocate it
-            has_ipv4 = any(ip.get("type", "").lower() in ("v4", "shared_v4") for ip in ips)
-
-            if not has_ipv4:
-                # Try to allocate shared IPv4 (FREE) if missing (required for many DNS providers)
-                # Note: shared_v4 is free, dedicated v4 costs $2/month
-                try:
-                    ipv4_mutation = """
-                    mutation($input: AllocateIPAddressInput!) {
-                        allocateIpAddress(input: $input) {
-                            ipAddress {
-                                id
-                                address
-                                type
-                            }
-                        }
-                    }
-                    """
-                    result = self._graphql_request(
-                        ipv4_mutation,
-                        {
-                            "input": {
-                                "appId": app_name,
-                                "type": "shared_v4",  # FREE shared IPv4, not dedicated ($2/mo)
-                            }
-                        },
-                    )
-                    # Check if allocation succeeded
-                    ip_data = result.get("allocateIpAddress", {}).get("ipAddress")
-                    if ip_data:
-                        # Brief wait for IP to propagate, then refresh
-                        import time
-
-                        time.sleep(1)
-                        ips = self._get_app_ips(app_name)
-                except FlyError:
-                    # If allocation fails, continue with what we have
-                    pass
-                except Exception:
-                    # Other errors - continue with what we have
-                    pass
 
             # Build DNS records (prioritize IPv4)
             dns_records = []

--- a/packages/worker/tests/test_no_ip_allocation.py
+++ b/packages/worker/tests/test_no_ip_allocation.py
@@ -1,0 +1,210 @@
+"""Runtm must never allocate Fly IP addresses.
+
+Deployed apps get their public IPs from `flyctl deploy`, which allocates
+whatever the generated fly.toml's [http_service] needs. Runtm itself issues no
+`allocateIpAddress` mutation on any path.
+
+These assertions are made at the HTTP boundary rather than by mocking an
+internal helper: the removed code lived in four different places, two of which
+inlined the mutation instead of calling a shared function, so a test that
+patched one helper would not notice the mutation coming back somewhere else.
+Anything reaching Fly's GraphQL endpoint is recorded and inspected here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from runtm_shared.types import MachineConfig, MachineTier, ProviderResource
+from runtm_worker.builder.docker import DockerBuilder
+from runtm_worker.jobs.deploy import DeployJob
+from runtm_worker.providers.fly import FlyProvider
+
+APP_NAME = "runtm-dep-abc123de"
+HOSTNAME = "app.example.com"
+IPV6 = "2a09:8280:1::1:2345"
+
+
+class RecordingGraphQL:
+    """Stands in for `httpx.post`, recording every GraphQL body sent."""
+
+    def __init__(self) -> None:
+        self.bodies: list[dict[str, Any]] = []
+
+    def __call__(self, url: str, **kwargs: Any) -> MagicMock:
+        body = kwargs.get("json") or {}
+        self.bodies.append(body)
+        query = body.get("query", "")
+
+        # Dispatch on the query so the provider sees a plausible response and
+        # runs to completion instead of bailing early down an error path.
+        if "ipAddresses" in query:
+            # IPv6-only app: the exact case the removed code used to "fix" by
+            # allocating a free shared IPv4 on the fly.
+            data = {
+                "app": {
+                    "ipAddresses": {"nodes": [{"address": IPV6, "type": "v6"}]},
+                    "sharedIpAddress": None,
+                }
+            }
+        elif "certificate" in query:
+            data = {
+                "app": {
+                    "certificate": {
+                        "id": "cert_1",
+                        "hostname": HOSTNAME,
+                        "configured": True,
+                        "clientStatus": "Ready",
+                        "issued": {"nodes": [{"type": "rsa", "expiresAt": "2027-01-01"}]},
+                        "dnsValidationHostname": None,
+                        "dnsValidationTarget": None,
+                    }
+                }
+            }
+        else:
+            data = {}
+
+        return MagicMock(status_code=200, json=lambda: {"data": data}, text="")
+
+    @property
+    def queries(self) -> list[str]:
+        return [b.get("query", "") for b in self.bodies]
+
+    def assert_no_allocation(self) -> None:
+        offenders = [q for q in self.queries if "allocateipaddress" in q.lower()]
+        assert not offenders, f"allocateIpAddress mutation was sent: {offenders}"
+
+
+@pytest.fixture
+def provider() -> FlyProvider:
+    return FlyProvider(api_token="test-token", org="test-org")
+
+
+@pytest.fixture
+def graphql() -> RecordingGraphQL:
+    recorder = RecordingGraphQL()
+    with patch("runtm_worker.providers.fly.httpx.post", recorder):
+        yield recorder
+
+
+class TestAllocationHelperIsGone:
+    def test_provider_has_no_allocate_helper(self) -> None:
+        """The helper itself must not come back under its old name."""
+        assert not hasattr(FlyProvider, "_allocate_ip_addresses")
+
+    def test_deploy_job_helper_is_renamed(self) -> None:
+        """`_ensure_fly_app_with_ips` promised IPs it no longer provisions."""
+        assert not hasattr(DeployJob, "_ensure_fly_app_with_ips")
+        assert hasattr(DeployJob, "_ensure_fly_app")
+
+
+class TestEnsureFlyApp:
+    def _job(self) -> DeployJob:
+        return DeployJob(db=MagicMock(), storage=MagicMock(), fly_api_token="test-token")
+
+    def test_creates_app_without_allocating(self) -> None:
+        job = self._job()
+        fake_provider = MagicMock(spec=FlyProvider)
+        fake_provider._get_app.return_value = None
+
+        created = job._ensure_fly_app(fake_provider, APP_NAME, MagicMock())
+
+        assert created is True
+        fake_provider._create_app.assert_called_once_with(APP_NAME)
+        # spec=FlyProvider means touching a removed attribute raises, so this
+        # fails loudly if the call is ever restored.
+        assert not hasattr(fake_provider, "_allocate_ip_addresses")
+
+    def test_existing_app_is_left_alone(self) -> None:
+        job = self._job()
+        fake_provider = MagicMock(spec=FlyProvider)
+        fake_provider._get_app.return_value = {"name": APP_NAME}
+
+        created = job._ensure_fly_app(fake_provider, APP_NAME, MagicMock())
+
+        assert created is False
+        fake_provider._create_app.assert_not_called()
+
+
+class TestDeployPath:
+    def test_deploy_issues_no_allocation(
+        self, provider: FlyProvider, graphql: RecordingGraphQL
+    ) -> None:
+        """The direct Machines-API path creates the app and nothing else."""
+        config = MachineConfig.from_tier(tier=MachineTier.STARTER, image="registry.fly.io/x:v1")
+
+        with (
+            patch.object(provider, "_get_app", return_value=None),
+            patch.object(provider, "_create_app") as create_app,
+            patch.object(provider, "_create_machine", return_value={"id": "m1", "region": "iad"}),
+            patch.object(provider, "_wait_for_machine", return_value=True),
+        ):
+            result = provider.deploy("dep_abc123de", config)
+
+        assert result.success
+        create_app.assert_called_once()
+        graphql.assert_no_allocation()
+
+
+class TestCustomDomain:
+    def _resource(self) -> ProviderResource:
+        return ProviderResource(
+            app_name=APP_NAME,
+            machine_id="m1",
+            region="iad",
+            image_ref="registry.fly.io/x:v1",
+            url=f"https://{APP_NAME}.fly.dev",
+        )
+
+    def test_add_custom_domain_on_ipv6_only_app_issues_no_allocation(
+        self, provider: FlyProvider, graphql: RecordingGraphQL
+    ) -> None:
+        info = provider.add_custom_domain(self._resource(), HOSTNAME)
+
+        graphql.assert_no_allocation()
+        # An IPv6-only app now yields an AAAA record and no A record, instead
+        # of an IPv4 being provisioned on demand to produce one.
+        types = [r.record_type for r in info.dns_records]
+        assert "AAAA" in types
+        assert "A" not in types
+
+    def test_domain_status_on_ipv6_only_app_issues_no_allocation(
+        self, provider: FlyProvider, graphql: RecordingGraphQL
+    ) -> None:
+        info = provider.get_custom_domain_status(self._resource(), HOSTNAME)
+
+        graphql.assert_no_allocation()
+        assert "A" not in [r.record_type for r in info.dns_records]
+
+
+class TestFlyTomlKeepsHttpService:
+    """The invariant the whole removal rests on.
+
+    `flyctl deploy` allocates IPs for an app whose config declares an
+    [http_service]. Drop that section and deployed apps would silently stop
+    being reachable, with nothing else in the codebase to catch it.
+    """
+
+    def test_generated_fly_toml_declares_http_service(self, tmp_path: Path) -> None:
+        context = tmp_path / "context"
+        context.mkdir()
+        (context / "Dockerfile").write_text("FROM alpine")
+
+        builder = DockerBuilder(use_remote_builder=True)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="Deployed", stderr="")
+            builder.build_remote(
+                context_path=context,
+                app_name=APP_NAME,
+                deployment_id="dep_abc123de",
+                fly_api_token="test-token",
+                internal_port=8080,
+            )
+
+        fly_toml = (context / "fly.toml").read_text()
+        assert "[http_service]" in fly_toml
+        assert "internal_port = 8080" in fly_toml

--- a/packages/worker/tests/test_remote_deploy.py
+++ b/packages/worker/tests/test_remote_deploy.py
@@ -44,7 +44,10 @@ def test_remote_builder_deploys_http_service_successfully(tmp_path: Path) -> Non
         stdout="Deployment complete",
         stderr="",
     )
-    with patch("subprocess.run", return_value=completed) as run:
+    with (
+        patch.dict("os.environ", {"RUNTM_BASE_DOMAIN": "runtm.com"}),
+        patch("subprocess.run", return_value=completed) as run,
+    ):
         result = builder.build_remote(
             context_path=context,
             app_name="test-app",

--- a/packages/worker/tests/test_remote_deploy.py
+++ b/packages/worker/tests/test_remote_deploy.py
@@ -1,0 +1,63 @@
+"""Regression tests for the default Fly remote-deployment path."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+from runtm_worker.builder.docker import DockerBuilder
+from runtm_worker.jobs.deploy import DeployJob
+
+
+def test_ensure_fly_app_only_creates_the_app() -> None:
+    """The pre-deploy step must not provision networking resources."""
+    provider = MagicMock()
+    provider._get_app.return_value = None
+    build_log = MagicMock()
+
+    created = DeployJob._ensure_fly_app(
+        MagicMock(),
+        provider=provider,
+        app_name="test-app",
+        build_log=build_log,
+    )
+
+    assert created is True
+    provider._create_app.assert_called_once_with("test-app")
+    assert provider.method_calls == [
+        call._get_app("test-app"),
+        call._create_app("test-app"),
+    ]
+
+
+def test_remote_builder_deploys_http_service_successfully(tmp_path: Path) -> None:
+    """The default path delegates public-service setup to ``flyctl deploy``."""
+    context = tmp_path / "context"
+    context.mkdir()
+    (context / "Dockerfile").write_text("FROM scratch\n")
+    builder = DockerBuilder(use_remote_builder=True)
+
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="Deployment complete",
+        stderr="",
+    )
+    with patch("subprocess.run", return_value=completed) as run:
+        result = builder.build_remote(
+            context_path=context,
+            app_name="test-app",
+            deployment_id="dep_abc123test",
+            fly_api_token="test-token",
+        )
+
+    assert result.success is True
+    assert result.deployed is True
+    assert result.url == "https://test-app.runtm.com"
+
+    fly_toml = (context / "fly.toml").read_text()
+    assert "[http_service]" in fly_toml
+    assert "internal_port = 3000" in fly_toml
+    assert run.call_args.args[0][:4] == ["flyctl", "deploy", "--app", "test-app"]
+    assert "--buildkit" in run.call_args.args[0]


### PR DESCRIPTION
Removes every call to Fly's `allocateIpAddress` GraphQL mutation. Runtm no longer provisions IPs for deployed apps.

## What changed

All four allocation sites are gone:

| Site | Was | Now |
|---|---|---|
| `FlyProvider._allocate_ip_addresses` | Two GraphQL mutations (`shared_v4`, then `v6`), each swallowing exceptions | Deleted |
| `DeployJob._ensure_fly_app_with_ips` | Created the app, then ran the allocation on a `ThreadPoolExecutor` with a 30s timeout | Renamed `_ensure_fly_app`; just ensures the app exists (the registry push requires it). `concurrent.futures` import dropped as unused |
| `FlyProvider.deploy()` | Allocated right after `_create_app` on the direct Machines-API path | Branch just creates the app |
| `add_custom_domain` / `get_custom_domain_status` | Checked `has_ipv4` and inline-allocated a free `shared_v4` if missing | Read existing IPs via `_get_app_ips` and build A/AAAA from whatever is there |

## Why the production path still works

The remote-builder path is the default (`use_remote_builder=True`) and doesn't depend on any of this. The `fly.toml` the worker generates declares an `[http_service]`, and `flyctl deploy` allocates whatever that needs — so deployed apps still come up reachable on `{app}.fly.dev` and `{app}.runtm.com`. Fly does it; we don't.

Worth noting the removed code was already close to a no-op in practice: every allocation was wrapped in a bare `except Exception: pass` and a failure only produced a `"Warning: Could not allocate IP addresses"` log line, with the deploy proceeding either way.

## Behavior changes to be aware of

- **Local-build path** (`ALLOW_LOCAL_BUILDS=true` + `USE_REMOTE_BUILDER=false`) drives the Machines REST API directly with no flyctl involved, so an app first created that way now has no IPs and won't serve public traffic. Dev-only; left as-is deliberately, since the ask was unconditional.
- **Custom domains**: an app with no IPv4 no longer gets one provisioned on demand, so `add_custom_domain` returns no A record. DNS providers that can't do AAAA or CNAME flattening would need an IP allocated out of band.

## Test plan

- [x] `ruff check packages/worker/` — clean
- [x] `ruff format --check` on both files — already formatted
- [x] `pytest packages/worker/tests` — 11 passed (no existing test covered this code)
- [ ] Deploy an app end-to-end through the remote builder and confirm it's reachable on its `.runtm.com` host

Branched off current `main`; both files were byte-identical between the pinned submodule commit and `main`, so no rebase conflicts. Landing this needs a follow-up submodule-pointer bump in `runtm-cloud`.