### PR TITLE
fix(worker): stop exposing deployments on the public internet

### DIFF
--- a/packages/shared/runtm_shared/__init__.py
+++ b/packages/shared/runtm_shared/__init__.py
@@ -110,7 +110,10 @@ from runtm_shared.types import (
 )
 from runtm_shared.urls import (
     construct_deployment_url,
+    deployment_label,
+    deployments_are_private,
     get_base_domain,
+    get_deployment_proxy_domain,
     get_subdomain_for_app,
 )
 
@@ -197,7 +200,10 @@ __all__ = [
     "find_project_root",
     # URLs
     "construct_deployment_url",
+    "deployment_label",
+    "deployments_are_private",
     "get_base_domain",
+    "get_deployment_proxy_domain",
     "get_subdomain_for_app",
     # Lockfiles
     "LockfileStatus",

--- a/packages/shared/runtm_shared/urls.py
+++ b/packages/shared/runtm_shared/urls.py
@@ -1,16 +1,23 @@
 """URL construction utilities for Runtm deployments.
 
-This module handles constructing deployment URLs, supporting both:
+This module handles constructing deployment URLs, supporting:
 - Default Fly.io URLs: <app>.fly.dev
 - Custom domain URLs: <app>.runtm.com (when RUNTM_BASE_DOMAIN is set)
+- Proxied URLs: <label>.apps.runtm.com (when RUNTM_DEPLOYMENT_PROXY_DOMAIN is set)
 
-When a custom base domain is configured, deployments automatically get
-a subdomain on that domain (e.g., my-app.runtm.com).
+RUNTM_DEPLOYMENT_PROXY_DOMAIN is the switch for *private* deployments. Setting
+it means an authenticating reverse proxy fronts every deployment, so the app
+itself must not be reachable any other way: the deploy path allocates no public
+IPs, publishes no public DNS record, and reports the proxied URL as the
+deployment's URL. Leaving it unset keeps the historical public behaviour, which
+is what a self-hosted Runtm without such a proxy needs.
 """
 
 from __future__ import annotations
 
 import os
+
+APP_NAME_PREFIX = "runtm-"
 
 
 def get_base_domain() -> str:
@@ -20,6 +27,38 @@ def get_base_domain() -> str:
         Base domain (e.g., "runtm.com") or empty string for default fly.dev
     """
     return os.environ.get("RUNTM_BASE_DOMAIN", "")
+
+
+def get_deployment_proxy_domain() -> str:
+    """Domain of the authenticating proxy that fronts deployments.
+
+    Returns:
+        Proxy domain (e.g., "apps.runtm.com"), or empty string when
+        deployments are served publicly.
+    """
+    return os.environ.get("RUNTM_DEPLOYMENT_PROXY_DOMAIN", "")
+
+
+def deployments_are_private() -> bool:
+    """Whether deployments are reachable only through the proxy.
+
+    True when a proxy domain is configured. Every "do not expose this app"
+    decision in the deploy path keys off this one function so the three
+    mechanisms that make an app public — a public IP, a public DNS record, and
+    a public URL handed back to the user — can never drift apart.
+    """
+    return bool(get_deployment_proxy_domain())
+
+
+def deployment_label(app_name: str) -> str:
+    """Proxy host label for a Fly app name: ``runtm-dep-abc123`` → ``dep-abc123``.
+
+    The proxy restores the prefix to rebuild the app name, so this is the exact
+    inverse of what it does (see proxy/Caddyfile in runtm-cloud).
+    """
+    if app_name.startswith(APP_NAME_PREFIX):
+        return app_name[len(APP_NAME_PREFIX) :]
+    return app_name
 
 
 def construct_deployment_url(app_name: str, base_domain: str | None = None) -> str:
@@ -38,7 +77,17 @@ def construct_deployment_url(app_name: str, base_domain: str | None = None) -> s
 
         >>> construct_deployment_url("runtm-abc123", "runtm.com")
         "https://runtm-abc123.runtm.com"  # custom domain
+
+    With RUNTM_DEPLOYMENT_PROXY_DOMAIN=apps.runtm.com the app has no public
+    address at all, so the proxied host is the only URL that resolves:
+
+        >>> construct_deployment_url("runtm-dep-abc123")
+        "https://dep-abc123.apps.runtm.com"
     """
+    proxy_domain = get_deployment_proxy_domain()
+    if proxy_domain:
+        return f"https://{deployment_label(app_name)}.{proxy_domain}"
+
     if base_domain is None:
         base_domain = get_base_domain()
 
@@ -59,8 +108,13 @@ def get_subdomain_for_app(app_name: str, base_domain: str | None = None) -> str 
         base_domain: Override base domain
 
     Returns:
-        Subdomain hostname (e.g., "runtm-abc123.runtm.com") or None
+        Subdomain hostname (e.g., "runtm-abc123.runtm.com"), or None when no
+        base domain is set or deployments are private — a private deployment
+        gets no public hostname, so there is nothing to certificate.
     """
+    if deployments_are_private():
+        return None
+
     if base_domain is None:
         base_domain = get_base_domain()
 

--- a/packages/shared/tests/test_urls.py
+++ b/packages/shared/tests/test_urls.py
@@ -1,0 +1,75 @@
+"""Deployment URL construction, public and proxied.
+
+RUNTM_DEPLOYMENT_PROXY_DOMAIN is the single switch between the two modes, so
+these tests pin what it changes: the URL a user is handed, and whether a public
+hostname exists to be certificated at all.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from runtm_shared.urls import (
+    construct_deployment_url,
+    deployment_label,
+    deployments_are_private,
+    get_subdomain_for_app,
+)
+
+APP_NAME = "runtm-dep-abc123de"
+PROXY_DOMAIN = "apps.runtm.com"
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neither variable leaks in from the developer's shell."""
+    monkeypatch.delenv("RUNTM_DEPLOYMENT_PROXY_DOMAIN", raising=False)
+    monkeypatch.delenv("RUNTM_BASE_DOMAIN", raising=False)
+
+
+class TestPublicMode:
+    def test_defaults_to_fly_dev(self) -> None:
+        assert construct_deployment_url(APP_NAME) == f"https://{APP_NAME}.fly.dev"
+
+    def test_base_domain_wins_over_fly_dev(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RUNTM_BASE_DOMAIN", "runtm.com")
+        assert construct_deployment_url(APP_NAME) == f"https://{APP_NAME}.runtm.com"
+
+    def test_subdomain_is_certificatable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RUNTM_BASE_DOMAIN", "runtm.com")
+        assert get_subdomain_for_app(APP_NAME) == f"{APP_NAME}.runtm.com"
+
+    def test_not_private(self) -> None:
+        assert deployments_are_private() is False
+
+
+class TestPrivateMode:
+    @pytest.fixture(autouse=True)
+    def proxy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RUNTM_DEPLOYMENT_PROXY_DOMAIN", PROXY_DOMAIN)
+
+    def test_is_private(self) -> None:
+        assert deployments_are_private() is True
+
+    def test_url_is_the_proxied_host(self) -> None:
+        assert construct_deployment_url(APP_NAME) == f"https://dep-abc123de.{PROXY_DOMAIN}"
+
+    def test_proxy_domain_beats_base_domain(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Both set is the production config: the public host must not win."""
+        monkeypatch.setenv("RUNTM_BASE_DOMAIN", "runtm.com")
+        url = construct_deployment_url(APP_NAME)
+        assert url == f"https://dep-abc123de.{PROXY_DOMAIN}"
+        assert "runtm-dep-abc123de.runtm.com" not in url
+
+    def test_no_public_subdomain_to_certificate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A cert would publish the hostname in CT logs and imply public access."""
+        monkeypatch.setenv("RUNTM_BASE_DOMAIN", "runtm.com")
+        assert get_subdomain_for_app(APP_NAME) is None
+
+
+class TestDeploymentLabel:
+    def test_strips_the_app_prefix(self) -> None:
+        assert deployment_label(APP_NAME) == "dep-abc123de"
+
+    def test_passes_through_an_unprefixed_name(self) -> None:
+        assert deployment_label("someapp") == "someapp"

--- a/packages/worker/runtm_worker/builder/docker.py
+++ b/packages/worker/runtm_worker/builder/docker.py
@@ -19,6 +19,20 @@ from runtm_shared.errors import BuildError
 from runtm_shared.urls import construct_deployment_url, deployments_are_private
 
 
+def no_public_ips_flags() -> list[str]:
+    """``flyctl deploy`` flags that keep a private app off the public internet.
+
+    flyctl allocates public ingress for any app whose config declares an
+    ``[http_service]`` and has no IPs yet — including an app whose IPs were
+    released by the rollout. That makes this a property of *every* deploy
+    invocation, not of the first one, so both call sites share this helper
+    rather than each remembering the flag: ``build_remote`` below, and the
+    config-only redeploy in ``jobs/deploy.py``, which reuses a previous image
+    and never reaches this module.
+    """
+    return ["--no-public-ips"] if deployments_are_private() else []
+
+
 @dataclass
 class BuildResult:
     """Result of a Docker build operation."""
@@ -285,19 +299,18 @@ destination = "{vol.path}"
             ]
 
             # The [http_service] written above makes flyctl allocate a
-            # dedicated IPv6 and a shared IPv4 on first deploy — the last thing
-            # still putting deployments on the public internet after Runtm
-            # stopped calling allocateIpAddress itself. --no-public-ips turns
-            # that off; the app is then addressable only over the Flycast
-            # address _ensure_fly_app allocated. [http_service] itself has to
-            # stay: Flycast routes through the same service definition, and it
-            # is what lets the Fly proxy auto-start a suspended machine.
+            # dedicated IPv6 and a shared IPv4 — the last thing still putting
+            # deployments on the public internet after Runtm stopped calling
+            # allocateIpAddress itself. --no-public-ips turns that off; the app
+            # is then addressable only over the Flycast address _ensure_fly_app
+            # allocated. [http_service] itself has to stay: Flycast routes
+            # through the same service definition, and it is what lets the Fly
+            # proxy auto-start a suspended machine.
             #
             # Only new allocations are suppressed — an app that already has
             # public IPs keeps them until they are released (see
             # scripts/backfill-private-deployments.sh in runtm-cloud).
-            if deployments_are_private():
-                base_cmd.append("--no-public-ips")
+            base_cmd += no_public_ips_flags()
 
             # Use BuildKit directly — Depot requires mTLS/DEPOT_TOKEN auth that is
             # unavailable inside Fly worker machines; it times out after 5 min before

--- a/packages/worker/runtm_worker/builder/docker.py
+++ b/packages/worker/runtm_worker/builder/docker.py
@@ -16,7 +16,7 @@ from docker.errors import DockerException
 
 from runtm_shared import AppDiscovery
 from runtm_shared.errors import BuildError
-from runtm_shared.urls import construct_deployment_url
+from runtm_shared.urls import construct_deployment_url, deployments_are_private
 
 
 @dataclass
@@ -283,6 +283,21 @@ destination = "{vol.path}"
                 "--wait-timeout",
                 "5m",
             ]
+
+            # The [http_service] written above makes flyctl allocate a
+            # dedicated IPv6 and a shared IPv4 on first deploy — the last thing
+            # still putting deployments on the public internet after Runtm
+            # stopped calling allocateIpAddress itself. --no-public-ips turns
+            # that off; the app is then addressable only over the Flycast
+            # address _ensure_fly_app allocated. [http_service] itself has to
+            # stay: Flycast routes through the same service definition, and it
+            # is what lets the Fly proxy auto-start a suspended machine.
+            #
+            # Only new allocations are suppressed — an app that already has
+            # public IPs keeps them until they are released (see
+            # scripts/backfill-private-deployments.sh in runtm-cloud).
+            if deployments_are_private():
+                base_cmd.append("--no-public-ips")
 
             # Use BuildKit directly — Depot requires mTLS/DEPOT_TOKEN auth that is
             # unavailable inside Fly worker machines; it times out after 5 min before

--- a/packages/worker/runtm_worker/jobs/deploy.py
+++ b/packages/worker/runtm_worker/jobs/deploy.py
@@ -26,7 +26,11 @@ from runtm_shared.types import (
     can_transition,
     get_tier_spec,
 )
-from runtm_shared.urls import construct_deployment_url, get_subdomain_for_app
+from runtm_shared.urls import (
+    construct_deployment_url,
+    deployments_are_private,
+    get_subdomain_for_app,
+)
 from runtm_worker.builder import DockerBuilder
 from runtm_worker.logs import LogCapture
 from runtm_worker.providers import FlyProvider
@@ -301,6 +305,10 @@ class DeployJob:
 
         This hides provider URLs - users only see runtm.com URLs.
 
+        Does nothing when deployments are private: a public DNS record is one
+        of the three things that make an app reachable from outside, and the
+        proxy addresses the app over Flycast, which needs no DNS of ours.
+
         Args:
             provider: Fly provider instance (for SSL cert)
             app_name: Fly app name (e.g., "runtm-abc123")
@@ -309,6 +317,10 @@ class DeployJob:
         import time
 
         from runtm_shared.urls import get_base_domain
+
+        if deployments_are_private():
+            deploy_log.write("Private deployment: skipping public DNS and certificate")
+            return
 
         base_domain = get_base_domain()
         subdomain = get_subdomain_for_app(app_name)
@@ -437,10 +449,14 @@ class DeployJob:
     ) -> bool:
         """Ensure the Fly app exists (the registry push requires it).
 
-        No IP addresses are allocated here, by design: runtm never calls
-        allocateIpAddress. `flyctl deploy` allocates what the generated
-        fly.toml's [http_service] needs, so the remote-builder path still
-        ends up publicly reachable without us provisioning anything.
+        No *public* IP is allocated here, by design. On the public path
+        `flyctl deploy` allocates what the generated fly.toml's [http_service]
+        needs. On the private path it is told not to (`--no-public-ips`) and the
+        app gets a Flycast address instead, which only the proxy can reach.
+
+        The Flycast allocation runs for existing apps too, not just newly
+        created ones: it is idempotent, and it is what backfills an app that
+        was first deployed before private deployments existed.
 
         Args:
             provider: Fly provider instance
@@ -453,15 +469,25 @@ class DeployJob:
         build_log.write(f"Ensuring Fly app exists: {app_name}")
 
         existing_app = provider._get_app(app_name)
-        if existing_app:
+        created = existing_app is None
+
+        if created:
+            provider._create_app(app_name)
+            build_log.write(f"Created Fly app: {app_name}")
+        else:
             build_log.write(f"Using existing Fly app: {app_name}")
-            return False
 
-        # Create app
-        provider._create_app(app_name)
-        build_log.write(f"Created Fly app: {app_name}")
+        if deployments_are_private():
+            address = provider.ensure_private_ipv6(app_name)
+            if address:
+                build_log.write(f"Flycast address: {address} (private, proxy-only)")
+            else:
+                build_log.write(
+                    "WARNING: could not allocate a Flycast address. The app will "
+                    "deploy but stay unreachable until one exists."
+                )
 
-        return True
+        return created
 
     def run(self, deployment_id: str) -> bool:
         """Run the deploy pipeline.

--- a/packages/worker/runtm_worker/jobs/deploy.py
+++ b/packages/worker/runtm_worker/jobs/deploy.py
@@ -32,6 +32,7 @@ from runtm_shared.urls import (
     get_subdomain_for_app,
 )
 from runtm_worker.builder import DockerBuilder
+from runtm_worker.builder.docker import no_public_ips_flags
 from runtm_worker.logs import LogCapture
 from runtm_worker.providers import FlyProvider
 
@@ -564,6 +565,14 @@ class DeployJob:
                     app_name = previous_resource.app_name
                     image_ref = f"registry.fly.io/{app_name}:{previous_image_label}"
 
+                    # The app already exists on this path, so this is only here
+                    # for its second job: ensuring the Flycast address. A
+                    # config-only redeploy is a full deploy as far as the app's
+                    # reachability goes, and it is the one path that can reach a
+                    # private app that has never had one.
+                    provider = FlyProvider(api_token=self.fly_api_token)
+                    self._ensure_fly_app(provider, app_name, deploy_log)
+
                     # Stage secrets BEFORE deploy - they'll be picked up by flyctl deploy
                     # This avoids a second release/restart after deploy completes
                     if self.secrets:
@@ -574,6 +583,10 @@ class DeployJob:
 
                     deploy_log.write(f"Deploying image: {image_ref}")
 
+                    # Same flag as the build path, for the same reason: flyctl
+                    # allocates public ingress for an [http_service] app with no
+                    # IPs, so without this a config-only redeploy would hand
+                    # back the public IPs the rollout released.
                     cmd = [
                         "flyctl",
                         "deploy",
@@ -584,7 +597,7 @@ class DeployJob:
                         "--yes",
                         "--wait-timeout",
                         "5m",
-                    ]
+                    ] + no_public_ips_flags()
 
                     result = subprocess.run(
                         cmd,
@@ -609,6 +622,17 @@ class DeployJob:
 
                     # Secrets were staged before deploy, no need to inject again
 
+                    # The previous deployment's URL is inherited, except when it
+                    # predates private mode: that URL names a public host this
+                    # app no longer answers on, so carrying it forward would
+                    # publish a dead link. Rebuilt from the app name instead,
+                    # which is what every other path already does.
+                    deploy_url = (
+                        construct_deployment_url(app_name)
+                        if deployments_are_private()
+                        else previous_resource.url
+                    )
+
                     # Save provider resource (reuse previous but update deployment link)
                     from runtm_shared.types import ProviderResource
 
@@ -617,17 +641,17 @@ class DeployJob:
                         machine_id=previous_resource.machine_id,
                         region=previous_resource.region,
                         image_ref=image_ref,
-                        url=previous_resource.url,
+                        url=deploy_url,
                     )
                     self._save_provider_resource(deployment, resource, previous_image_label)
 
-                    deploy_log.write(f"URL: {previous_resource.url}")
+                    deploy_log.write(f"URL: {deploy_url}")
 
                 # === SUCCESS (config-only) ===
                 self._transition_state(
                     deployment,
                     DeploymentState.READY,
-                    url=previous_resource.url,
+                    url=deploy_url,
                 )
                 return True
 

--- a/packages/worker/runtm_worker/providers/fly.py
+++ b/packages/worker/runtm_worker/providers/fly.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import time
 from typing import Any
@@ -10,9 +11,11 @@ import httpx
 
 from runtm_shared.errors import FlyError, ProviderNotConfiguredError
 from runtm_shared.types import CustomDomainInfo, DnsRecord, MachineConfig, ProviderResource
-from runtm_shared.urls import construct_deployment_url
+from runtm_shared.urls import construct_deployment_url, deployments_are_private
 
 from .base import DeployProvider, DeployResult, ProviderStatus
+
+logger = logging.getLogger(__name__)
 
 
 class FlyProvider(DeployProvider):
@@ -472,6 +475,13 @@ class FlyProvider(DeployProvider):
             else:
                 logs_buffer.append(f"Using existing app: {app_name}")
 
+            # This path drives the Machines API directly, with no flyctl to
+            # allocate anything, so an app deployed here has never had a public
+            # IP. Give it the Flycast address the proxy needs.
+            if deployments_are_private():
+                address = self.ensure_private_ipv6(app_name)
+                logs_buffer.append(f"Flycast address: {address or 'unavailable'}")
+
             # Create machine
             logs_buffer.append(f"Creating machine with image: {config.image}")
             machine = self._create_machine(app_name, config)
@@ -837,6 +847,59 @@ class FlyProvider(DeployProvider):
             return nodes
         except FlyError:
             return []
+
+    def ensure_private_ipv6(self, app_name: str) -> str | None:
+        """Allocate the app's Flycast address, unless it already has one.
+
+        Flycast is a private IPv6 on the org's WireGuard mesh, reachable only
+        from other apps in the same org. It is what makes an app with no public
+        IP addressable at all — ``{app}.flycast`` resolves to it, and requests
+        to it go through Fly's proxy, so ``auto_start_machines`` still wakes a
+        suspended machine (verified against a live suspended deployment: 200 in
+        1.3s from a cold stop).
+
+        This is the one ``allocateIpAddress`` call Runtm makes. It is
+        deliberately narrow — ``private_v6`` only, never a public type — and
+        idempotent, so a redeploy of an app created before private deployments
+        existed backfills its Flycast address on the way through.
+
+        Args:
+            app_name: Fly app name
+
+        Returns:
+            The Flycast address, or None if allocation failed. Failure is not
+            fatal to the caller: the deploy still produces a running app, it is
+            simply unreachable until an address exists.
+        """
+        for ip in self._get_app_ips(app_name):
+            if ip.get("type", "").lower() == "private_v6":
+                logger.info("Flycast address already allocated for %s", app_name)
+                return ip.get("address")
+
+        mutation = """
+        mutation($input: AllocateIPAddressInput!) {
+            allocateIpAddress(input: $input) {
+                ipAddress {
+                    address
+                    type
+                }
+            }
+        }
+        """
+
+        try:
+            data = self._graphql_request(
+                mutation,
+                {"input": {"appId": app_name, "type": "private_v6"}},
+            )
+            address = ((data.get("allocateIpAddress") or {}).get("ipAddress", {}) or {}).get(
+                "address"
+            )
+            logger.info("Allocated Flycast address %s for %s", address, app_name)
+            return address
+        except FlyError as e:
+            logger.error("Flycast allocation failed for %s: %s", app_name, e)
+            return None
 
     def add_custom_domain(
         self,

--- a/packages/worker/tests/test_config_only_deploy.py
+++ b/packages/worker/tests/test_config_only_deploy.py
@@ -1,0 +1,145 @@
+"""The config-only redeploy path must honour the private-deployment rules.
+
+This path exists to apply an env-var or tier change without rebuilding, so it
+reuses a previous image and returns before the build phase — and therefore
+before every private-mode guard the build path picked up. It still runs a real
+``flyctl deploy``, which allocates public ingress for an ``[http_service]`` app
+that has no IPs, so on its own it is enough to hand back the public addresses
+the rollout released.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from runtm_shared.types import DeploymentState, ProviderResource
+from runtm_worker.jobs.deploy import DeployJob
+
+APP_NAME = "runtm-dep-abc123de"
+DEPLOYMENT_ID = "dep_abc123de4567"
+PREVIOUS_ID = "dep_previous1234"
+IMAGE_LABEL = "dep-previous1234"
+PROXY_DOMAIN = "apps.example.com"
+PUBLIC_URL = f"https://{APP_NAME}.example.com"
+
+MANIFEST = {
+    "name": "hello",
+    "template": "docker",
+    "port": 8080,
+    "tier": "starter",
+}
+
+
+class _Result:
+    """What the caller keeps from a config-only run."""
+
+    def __init__(self) -> None:
+        self.argv: list[str] = []
+        self.ready_url: str | None = None
+        self.provider: MagicMock | None = None
+        self.ok: bool = False
+
+
+def _run_config_only() -> _Result:
+    """Drive ``DeployJob.run`` down the config-only branch."""
+    out = _Result()
+
+    job = DeployJob(
+        db=MagicMock(),
+        storage=MagicMock(),
+        fly_api_token="test-token",
+        redeploy_from=PREVIOUS_ID,
+        config_only=True,
+    )
+
+    deployment = MagicMock()
+    deployment.id = "row-1"
+    deployment.manifest_json = MANIFEST
+    deployment.state = DeploymentState.QUEUED
+
+    previous = ProviderResource(
+        app_name=APP_NAME,
+        machine_id="m1",
+        region="iad",
+        image_ref=f"registry.fly.io/{APP_NAME}:{IMAGE_LABEL}",
+        # Written before deployments went private: a host the app has since
+        # stopped answering on.
+        url=PUBLIC_URL,
+    )
+
+    @contextmanager
+    def fake_log_capture(*args: Any, **kwargs: Any):
+        yield MagicMock()
+
+    def record_state(_deployment: Any, state: Any, **kwargs: Any) -> None:
+        if state == DeploymentState.READY:
+            out.ready_url = kwargs.get("url")
+
+    def record_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess:
+        out.argv = cmd
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
+
+    provider = MagicMock()
+    provider._get_app.return_value = {"name": APP_NAME}
+    out.provider = provider
+
+    with (
+        patch.object(job, "_get_deployment", return_value=deployment),
+        patch.object(job, "_get_previous_provider_resource", return_value=(previous, IMAGE_LABEL)),
+        patch.object(job, "_transition_state", side_effect=record_state),
+        patch.object(job, "_save_provider_resource"),
+        patch("runtm_worker.jobs.deploy.LogCapture", fake_log_capture),
+        patch("runtm_worker.jobs.deploy.FlyProvider", return_value=provider),
+        patch("subprocess.run", side_effect=record_run),
+    ):
+        out.ok = job.run(DEPLOYMENT_ID)
+
+    return out
+
+
+@pytest.fixture
+def private(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNTM_DEPLOYMENT_PROXY_DOMAIN", PROXY_DOMAIN)
+
+
+@pytest.fixture
+def public(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("RUNTM_DEPLOYMENT_PROXY_DOMAIN", raising=False)
+
+
+class TestPrivateMode:
+    def test_deploy_cannot_reallocate_public_ips(self, private: None) -> None:
+        out = _run_config_only()
+
+        assert out.ok is True
+        assert "--no-public-ips" in out.argv
+
+    def test_flycast_is_ensured(self, private: None) -> None:
+        """The only path that can reach a private app with no Flycast address."""
+        out = _run_config_only()
+
+        assert out.provider is not None
+        out.provider.ensure_private_ipv6.assert_called_once_with(APP_NAME)
+
+    def test_inherited_public_url_is_replaced(self, private: None) -> None:
+        """Carrying the previous URL forward would publish a dead link."""
+        out = _run_config_only()
+
+        assert out.ready_url == f"https://dep-abc123de.{PROXY_DOMAIN}"
+        assert out.ready_url != PUBLIC_URL
+
+
+class TestPublicMode:
+    def test_nothing_changes(self, public: None) -> None:
+        out = _run_config_only()
+
+        assert out.ok is True
+        assert "--no-public-ips" not in out.argv
+        assert out.ready_url == PUBLIC_URL
+        assert out.provider is not None
+        out.provider.ensure_private_ipv6.assert_not_called()

--- a/packages/worker/tests/test_no_ip_allocation.py
+++ b/packages/worker/tests/test_no_ip_allocation.py
@@ -1,8 +1,13 @@
-"""Runtm must never allocate Fly IP addresses.
+"""Runtm must never allocate a *public* Fly IP address.
 
-Deployed apps get their public IPs from `flyctl deploy`, which allocates
-whatever the generated fly.toml's [http_service] needs. Runtm itself issues no
-`allocateIpAddress` mutation on any path.
+On the public path, deployed apps get their IPs from `flyctl deploy`, which
+allocates whatever the generated fly.toml's [http_service] needs. Runtm issues
+no `allocateIpAddress` mutation of a public type on any path.
+
+The one allocation Runtm does make is `private_v6` — the Flycast address that
+makes an app with no public IP reachable from the proxy. It is asserted
+separately below, and the guard here is typed rather than blanket so that
+"allocate an address" cannot quietly come back as a public one.
 
 These assertions are made at the HTTP boundary rather than by mocking an
 internal helper: the removed code lived in four different places, two of which
@@ -27,6 +32,12 @@ from runtm_worker.providers.fly import FlyProvider
 APP_NAME = "runtm-dep-abc123de"
 HOSTNAME = "app.example.com"
 IPV6 = "2a09:8280:1::1:2345"
+FLYCAST = "fdaa:3b:fa0:0:1::295"
+PROXY_DOMAIN = "apps.example.com"
+
+# Every public address type Fly can hand out. A private_v6 allocation is
+# expected; anything in this set is the regression.
+PUBLIC_IP_TYPES = ("shared_v4", "v4", "v6")
 
 
 class RecordingGraphQL:
@@ -42,7 +53,13 @@ class RecordingGraphQL:
 
         # Dispatch on the query so the provider sees a plausible response and
         # runs to completion instead of bailing early down an error path.
-        if "ipAddresses" in query:
+        if "allocateIpAddress" in query:
+            data = {
+                "allocateIpAddress": {
+                    "ipAddress": {"address": FLYCAST, "type": "private_v6"},
+                }
+            }
+        elif "ipAddresses" in query:
             # IPv6-only app: the exact case the removed code used to "fix" by
             # allocating a free shared IPv4 on the fly.
             data = {
@@ -74,9 +91,22 @@ class RecordingGraphQL:
     def queries(self) -> list[str]:
         return [b.get("query", "") for b in self.bodies]
 
+    @property
+    def allocations(self) -> list[dict[str, Any]]:
+        """The `input` of every allocateIpAddress mutation sent."""
+        return [
+            b.get("variables", {}).get("input", {})
+            for b in self.bodies
+            if "allocateipaddress" in b.get("query", "").lower()
+        ]
+
     def assert_no_allocation(self) -> None:
         offenders = [q for q in self.queries if "allocateipaddress" in q.lower()]
         assert not offenders, f"allocateIpAddress mutation was sent: {offenders}"
+
+    def assert_no_public_allocation(self) -> None:
+        offenders = [a for a in self.allocations if a.get("type") in PUBLIC_IP_TYPES]
+        assert not offenders, f"public IP was allocated: {offenders}"
 
 
 @pytest.fixture
@@ -89,6 +119,18 @@ def graphql() -> RecordingGraphQL:
     recorder = RecordingGraphQL()
     with patch("runtm_worker.providers.fly.httpx.post", recorder):
         yield recorder
+
+
+@pytest.fixture
+def private(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deployments served only through the proxy."""
+    monkeypatch.setenv("RUNTM_DEPLOYMENT_PROXY_DOMAIN", PROXY_DOMAIN)
+
+
+@pytest.fixture
+def public(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The historical behaviour: deployments on the public internet."""
+    monkeypatch.delenv("RUNTM_DEPLOYMENT_PROXY_DOMAIN", raising=False)
 
 
 class TestAllocationHelperIsGone:
@@ -208,3 +250,153 @@ class TestFlyTomlKeepsHttpService:
         fly_toml = (context / "fly.toml").read_text()
         assert "[http_service]" in fly_toml
         assert "internal_port = 8080" in fly_toml
+
+
+def _run_remote_build(tmp_path: Path) -> list[str]:
+    """Drive build_remote and return the flyctl argv it invoked."""
+    context = tmp_path / "context"
+    context.mkdir()
+    (context / "Dockerfile").write_text("FROM alpine")
+
+    builder = DockerBuilder(use_remote_builder=True)
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="Deployed", stderr="")
+        builder.build_remote(
+            context_path=context,
+            app_name=APP_NAME,
+            deployment_id="dep_abc123de",
+            fly_api_token="test-token",
+            internal_port=8080,
+        )
+    return mock_run.call_args[0][0]
+
+
+class TestPrivateDeployments:
+    """With a proxy domain set, nothing about the app may be public.
+
+    Three separate mechanisms used to expose a deployment, and removing any two
+    of them still leaves it reachable, so each gets its own assertion.
+    """
+
+    def _job(self) -> DeployJob:
+        return DeployJob(db=MagicMock(), storage=MagicMock(), fly_api_token="test-token")
+
+    def test_deploy_passes_no_public_ips(self, private: None, tmp_path: Path) -> None:
+        """Mechanism 1: flyctl's own allocation for [http_service]."""
+        assert "--no-public-ips" in _run_remote_build(tmp_path)
+
+    def test_public_deploy_keeps_allocating(self, public: None, tmp_path: Path) -> None:
+        """Unset means unchanged — a self-hosted Runtm has no proxy to hide behind."""
+        assert "--no-public-ips" not in _run_remote_build(tmp_path)
+
+    def test_public_dns_is_skipped(self, private: None, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Mechanism 2: the {app}.{base_domain} CNAME and its certificate."""
+        monkeypatch.setenv("RUNTM_BASE_DOMAIN", "example.com")
+        job = self._job()
+        provider = MagicMock(spec=FlyProvider)
+
+        job._provision_custom_subdomain(provider, APP_NAME, MagicMock())
+
+        provider.add_custom_domain.assert_not_called()
+
+    def test_public_dns_still_provisioned_when_public(
+        self, public: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("RUNTM_BASE_DOMAIN", "example.com")
+        job = self._job()
+        provider = MagicMock(spec=FlyProvider)
+        provider.add_custom_domain.return_value = MagicMock(
+            dns_records=[], certificate_status="ready"
+        )
+
+        # Stop at the certificate step; the DNS half needs a configured
+        # Settings object and is not what this test is about.
+        with patch.object(job, "_get_dns_provider", return_value=None):
+            job._provision_custom_subdomain(provider, APP_NAME, MagicMock())
+
+        provider.add_custom_domain.assert_called_once()
+
+    def test_ensure_fly_app_allocates_flycast(self, private: None) -> None:
+        job = self._job()
+        provider = MagicMock(spec=FlyProvider)
+        provider._get_app.return_value = None
+        provider.ensure_private_ipv6.return_value = FLYCAST
+
+        job._ensure_fly_app(provider, APP_NAME, MagicMock())
+
+        provider.ensure_private_ipv6.assert_called_once_with(APP_NAME)
+
+    def test_existing_app_gets_flycast_backfilled(self, private: None) -> None:
+        """An app first deployed before this change has no Flycast address."""
+        job = self._job()
+        provider = MagicMock(spec=FlyProvider)
+        provider._get_app.return_value = {"name": APP_NAME}
+        provider.ensure_private_ipv6.return_value = FLYCAST
+
+        created = job._ensure_fly_app(provider, APP_NAME, MagicMock())
+
+        assert created is False
+        provider._create_app.assert_not_called()
+        provider.ensure_private_ipv6.assert_called_once_with(APP_NAME)
+
+    def test_no_flycast_when_public(self, public: None) -> None:
+        job = self._job()
+        provider = MagicMock(spec=FlyProvider)
+        provider._get_app.return_value = None
+
+        job._ensure_fly_app(provider, APP_NAME, MagicMock())
+
+        provider.ensure_private_ipv6.assert_not_called()
+
+    def test_deploy_survives_a_failed_allocation(self, private: None) -> None:
+        """Unreachable beats undeployed: a failed allocation must not raise."""
+        job = self._job()
+        provider = MagicMock(spec=FlyProvider)
+        provider._get_app.return_value = None
+        provider.ensure_private_ipv6.return_value = None
+
+        assert job._ensure_fly_app(provider, APP_NAME, MagicMock()) is True
+
+
+class TestFlycastAllocation:
+    """Mechanism 3 in reverse: the only address Runtm hands out is private."""
+
+    def test_allocation_is_private_typed(
+        self, provider: FlyProvider, graphql: RecordingGraphQL
+    ) -> None:
+        address = provider.ensure_private_ipv6(APP_NAME)
+
+        assert address == FLYCAST
+        graphql.assert_no_public_allocation()
+        assert [a.get("type") for a in graphql.allocations] == ["private_v6"]
+
+    def test_allocation_is_idempotent(self, provider: FlyProvider) -> None:
+        """A redeploy must not stack up a second Flycast address."""
+        with patch.object(
+            provider,
+            "_get_app_ips",
+            return_value=[{"address": FLYCAST, "type": "private_v6"}],
+        ):
+            recorder = RecordingGraphQL()
+            with patch("runtm_worker.providers.fly.httpx.post", recorder):
+                address = provider.ensure_private_ipv6(APP_NAME)
+
+        assert address == FLYCAST
+        assert recorder.allocations == []
+
+    def test_a_public_only_app_still_gets_flycast(
+        self, provider: FlyProvider, graphql: RecordingGraphQL
+    ) -> None:
+        """The recorded app has a public v6 and no private one — allocate."""
+        assert provider.ensure_private_ipv6(APP_NAME) == FLYCAST
+        assert len(graphql.allocations) == 1
+
+    def test_allocation_failure_is_not_fatal(self, provider: FlyProvider) -> None:
+        def explode(url: str, **kwargs: Any) -> MagicMock:
+            return MagicMock(status_code=500, json=lambda: {}, text="boom")
+
+        with (
+            patch.object(provider, "_get_app_ips", return_value=[]),
+            patch("runtm_worker.providers.fly.httpx.post", explode),
+        ):
+            assert provider.ensure_private_ipv6(APP_NAME) is None


### PR DESCRIPTION
## What

#58 removed the four `allocateIpAddress` call sites, but deployed apps stayed publicly reachable. Its own commit message says so:

> The remote-builder path (the production default) is unaffected: the fly.toml the worker generates declares an `[http_service]`, and `flyctl deploy` allocates whatever that needs, so deployed apps still come up reachable on {app}.fly.dev and {app}.runtm.com.

Runtm stopped *asking* Fly for IPs; flyctl kept allocating them. Confirmed on an app deployed an hour after that shipped:

```
$ fly ips list -a runtm-dep-48894c81
v6  2a09:8280:1::183:d808:0   public ingress (dedicated)   ← allocated by that deploy
v4  66.241.124.197            public ingress (shared)

$ curl -o /dev/null -w '%{http_code}' https://runtm-dep-48894c81.fly.dev/     → 200, no auth
$ curl -o /dev/null -w '%{http_code}' https://runtm-dep-48894c81.runtm.com/   → 200, no auth
```

## How

Three mechanisms make a deployment public, and removing any two still leaves it reachable. All three now key off one switch, `RUNTM_DEPLOYMENT_PROXY_DOMAIN`:

| Mechanism | Change |
|---|---|
| flyctl's allocation for `[http_service]` | `flyctl deploy --no-public-ips` |
| the `{app}.{base_domain}` CNAME + certificate | `_provision_custom_subdomain` returns early; `get_subdomain_for_app` yields None |
| the URL handed back to the user | `construct_deployment_url` returns the proxied host — the only one that resolves |

Reachability comes from **Flycast** instead: `ensure_private_ipv6` gives the app a private IPv6 on the org's WireGuard mesh, dialable only from apps in the same org. That is the one `allocateIpAddress` call Runtm makes — typed `private_v6`, never public, and idempotent, so a redeploy backfills an app created before this existed.

Unset, behaviour is identical to today. A self-hosted Runtm with no authenticating proxy in front of it still needs public deployments, so private-by-default would be the wrong default there.

## Verified on live infrastructure

Before writing any config, against a real deployment in prod:

- `{app}.flycast` resolves from another app in the org, and requests traverse Fly's proxy — so `auto_start_machines` still wakes a suspended machine: **200 in 1.3s from a cold stop**. (Deployments run `min_machines_running = 0`, so a path that can't wake them would 502 on every first request.)
- TLS over Flycast works **only** with the app's `fly.dev` name in SNI (`…flycast` SNI fails the handshake outright — curl reports 000). The consuming proxy change in runtm-cloud sends Host/SNI accordingly.
- `[http_service]` must stay: Flycast routes through the same service definition.
- After releasing the public IPs on that app, both public hosts stopped answering (000) while the Flycast path still returned 200.

## Tests

The #58 guards asserted *no* `allocateIpAddress` mutation at the HTTP boundary, which this change would have to weaken. They now assert no **public-typed** allocation instead, so `private_v6` cannot smuggle a public type back in. New coverage: `--no-public-ips` present when private and absent when public, DNS/cert skipped when private and still provisioned when public, Flycast allocated for new *and* existing apps, allocation idempotent, a failed allocation not failing the deploy, and URL construction in both modes (including both env vars set, where the public host must not win).

`pytest packages/worker/tests packages/shared/tests` → 43 passed.

## Rollout

`--no-public-ips` only suppresses *new* allocations; the ~161 existing apps keep the IPs they have. `scripts/backfill-private-deployments.sh` in the paired runtm-cloud PR releases them (Flycast first, then public IPs, then DNS — that order matters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)